### PR TITLE
Parameters for events triggered by keyboard plugin are now optional

### DIFF
--- a/mpf/plugins/keyboard.py
+++ b/mpf/plugins/keyboard.py
@@ -295,8 +295,9 @@ class Keyboard(object):
                     elif type(self.key_map[key_press]) == dict:
                         # we have an event
                         event_dict = self.key_map[key_press]
+                        event_params = event_dict['params'] or {}
                         self.machine.events.post(str(event_dict['event']),
-                                                 **event_dict['params'])
+                                                 **event_params)
 
     def process_key_release(self, symbol, modifiers):
         """Processes a key release (key up) event by setting the switch and/or


### PR DESCRIPTION
In the keyboard plugin, an event can be fired for a keypress with ```event``` but this requires parameters to be set with ```params```. Attempting to add an ```action_shutdown``` event fails because the handler doesn't accept ``kwargs``. This pull request makes the ```params``` values optional. 
