### PR TITLE
Implemented Mike Mcgann's keyboard fix for events without params

### DIFF
--- a/mpf/media_controller/core/keyboard.py
+++ b/mpf/media_controller/core/keyboard.py
@@ -277,8 +277,9 @@ class Keyboard(object):
                     elif type(self.key_map[key_press]) == dict:
                         # we have an event
                         event_dict = self.key_map[key_press]
+                        event_params = event_dict['params'] or {}
                         self.mc.events.post(str(event_dict['event']),
-                                                 **event_dict['params'])
+                                            **event_params)
 
     def process_key_release(self, symbol, modifiers):
         """Processes a key release (key up) event by setting the switch and/or


### PR DESCRIPTION
His original pull request was for the keyboard plugin in mpf/plugins. I also implemented it in the new keyboard location in the media controller.