### PR TITLE
allow multiple playfields. generalise events and reduce usage of playfield via registry

### DIFF
--- a/mpf/devices/ball_device.py
+++ b/mpf/devices/ball_device.py
@@ -51,6 +51,8 @@ class BallDevice(Device):
             self.config['eject_coil_hold_times'] = list()
         if 'confirm_eject_type' not in self.config:
             self.config['confirm_eject_type'] = 'count'  # todo make optional?
+        if 'captures_from' not in self.config:
+            self.config['captures_from'] = 'playfield'
         if 'eject_targets' not in self.config:
             self.config['eject_targets'] = ['playfield']
         else:
@@ -449,7 +451,7 @@ class BallDevice(Device):
             # came from the playfield. Post this event so the playfield can keep
             # track of how many balls are out.
             if not self.num_balls_requested:
-                self.machine.events.post('balldevice_captured_from_playfield',
+                self.machine.events.post('balldevice_captured_from_' + self.config['captures_from'],
                                          balls=balls)
 
             # Post the relay event as other handlers might be looking for to act
@@ -864,13 +866,13 @@ class BallDevice(Device):
             self.log.debug("Will confirm eject via recount of ball switches.")
             self.flag_confirm_eject_via_count = True
 
-        elif (self.config['confirm_eject_type'] == 'playfield' or
-                target == self.machine.balldevices['playfield']):
+        elif (self.config['confirm_eject_type'] == 'playfield' and
+                target.__class__.__name__ == 'Playfield'):
 
-            if self.machine.playfield.ok_to_confirm_ball_via_playfield_switch():
-                self.log.debug("Will confirm eject when a playfield switch is "
-                               "hit")
-                self.machine.events.add_handler('sw_playfield_active',
+            if target.ok_to_confirm_ball_via_playfield_switch():
+                self.log.debug("Will confirm eject when a %s switch is "
+                               "hit", target.name)
+                self.machine.events.add_handler('sw_' + target.name + '_active',
                                                 self._eject_success)
             else:
                 self.log.debug("Will confirm eject via recount of ball "

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -53,11 +53,11 @@ class Playfield(BallDevice):
                 break
 
         # Watch for balls removed from the playfield
-        self.machine.events.add_handler('balldevice_captured_from_playfield',
+        self.machine.events.add_handler('balldevice_captured_from_' + self.name,
                                         self._ball_removed_handler)
 
         # Watch for any switch hit which indicates a ball on the playfield
-        self.machine.events.add_handler('sw_playfield_active',
+        self.machine.events.add_handler('sw_' + self.name + '_active',
                                         self.playfield_switch_hit)
 
     @property
@@ -94,7 +94,7 @@ class Playfield(BallDevice):
                                            '_ball_enter', balls=ball_change)
 
         if ball_change:
-            self.machine.events.post('playfield_ball_count_change',
+            self.machine.events.post(self.name + '_ball_count_change',
                                      balls=balls, change=ball_change)
 
     def count_balls(self, **kwargs):
@@ -294,7 +294,7 @@ class Playfield(BallDevice):
                 self.log.debug("PF switch hit with no balls expected. Setting "
                                "pf balls to 1.")
                 self.balls = 1
-                self.machine.events.post('unexpected_ball_on_playfield')
+                self.machine.events.post('unexpected_ball_on_' + self.name)
 
     def _ball_added_handler(self, balls):
         self.log.debug("%s ball(s) added to the playfield", balls)

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -9,17 +9,17 @@
 # Configuration for the MPF framework itself
 
 mpf:
-    system_modules:  # order is important here
-        timing.Timing
-        events.EventManager
-        switch_controller.SwitchController
-        ball_controller.BallController
-        modes.ModeController
-        light_controller.LightController
-        bcp.BCP
-        shots.ShotController
-        logic_blocks.LogicBlocks
-        scoring.ScoreController
+    system_modules: !!omap  # order is important here
+        - timing: mpf.system.timing.Timing
+        - events: mpf.system.events.EventManager
+        - switch_controller: mpf.system.switch_controller.SwitchController
+        - ball_controller: mpf.system.ball_controller.BallController
+        - modes: mpf.system.modes.ModeController
+        - light_controller: mpf.system.light_controller.LightController
+        - bcp: mpf.system.bcp.BCP
+        - shots: mpf.system.shots.ShotController
+        - logic_blocks: mpf.system.logic_blocks.LogicBlocks
+        - scoring: mpf.system.scoring.ScoreController
 
     device_modules:
         driver.Driver

--- a/mpf/system/machine.py
+++ b/mpf/system/machine.py
@@ -224,17 +224,10 @@ class MachineController(object):
                                           )
 
     def _load_system_modules(self):
-        self.config['mpf']['system_modules'] = (
-            self.config['mpf']['system_modules'].split(' '))
         for module in self.config['mpf']['system_modules']:
-            self.log.info("Loading '%s' system module", module)
-            module_parts = module.split('.')
-            exec('self.' + module_parts[0] + '=' + module + '(self)')
-
-            # todo there's probably a more pythonic way to do this, and I know
-            # exec() is supposedly unsafe, but meh, if you have access to put
-            # malicious files in the system folder then you have access to this
-            # code too.
+            self.log.info("Loading '%s' system module", module[1])
+            m = self.string_to_class(module[1])(self)
+            setattr(self, module[0], m);
 
     def _load_plugins(self):
         for plugin in Config.string_to_list(


### PR DESCRIPTION
additionally, fixed one potential bug in Playfield:

This should be "and" not "or" in my opinion:
```
elif (self.config['confirm_eject_type'] == 'playfield' or
-                target == self.machine.balldevices['playfield']):
```