### PR TITLE
Change playfield check to be more pythonic

### DIFF
--- a/mpf/devices/ball_device.py
+++ b/mpf/devices/ball_device.py
@@ -126,6 +126,7 @@ class BallDevice(Device):
 
         self.valid = False
         self.need_first_time_count = True
+        self._playfield = False
 
         # Now configure the device
         self.configure()
@@ -867,7 +868,7 @@ class BallDevice(Device):
             self.flag_confirm_eject_via_count = True
 
         elif (self.config['confirm_eject_type'] == 'playfield' and
-                target.__class__.__name__ == 'Playfield'):
+                target.is_playfield()):
 
             if target.ok_to_confirm_ball_via_playfield_switch():
                 self.log.debug("Will confirm eject when a %s switch is "
@@ -1014,6 +1015,13 @@ class BallDevice(Device):
         self.machine.events.post('balldevice_' + self.name +
                                  '_ok_to_receive',
                                  balls=self.get_additional_ball_capacity())
+
+    def is_playfield(self):
+        """Returns True if this ball device is a Playfield-type device, False if
+        it's a regular ball device.
+
+        """
+        return self._playfield
 
 
 # The MIT License (MIT)

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -35,6 +35,7 @@ class Playfield(BallDevice):
         self.num_balls_requested = 0
         self.player_controlled_eject_in_progress = None
         self.queued_balls = list()
+        self._playfield = True
 
         # Set up event handlers
 

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-__version_info__ = ('0', '19', '0a24')
+__version_info__ = ('0', '19', '0a26')
 __version__ = '.'.join(__version_info__)
 
 __bcp_version_info__ = ('1', '0')


### PR DESCRIPTION
Added is_playfield() method to BallDevice class. Set _playfield
attribute to True if you subclass and create a playfield-type device.

MPF rev to 0.19.0a26