### PR TITLE
refactor DelayManager. remove all static variables

### DIFF
--- a/mpf/devices/ball_device.py
+++ b/mpf/devices/ball_device.py
@@ -31,7 +31,7 @@ class BallDevice(Device):
         super(BallDevice, self).__init__(machine, name, config, collection,
                                          validate=validate)
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(machine.delayRegistry)
 
         if self.config['ball_capacity'] is None:
             self.config['ball_capacity'] = len(self.config['ball_switches'])

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -23,7 +23,7 @@ class BallSave(Device):
         super(BallSave, self).__init__(machine, name, config, collection,
                                        validate=validate)
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(machine.delayRegistry)
         self.enabled = False
         self.saves_remaining = 0
 

--- a/mpf/devices/diverter.py
+++ b/mpf/devices/diverter.py
@@ -27,7 +27,7 @@ class Diverter(Device):
         super(Diverter, self).__init__(machine, name, config, collection,
                                        validate=validate)
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(machine.delayRegistry)
 
         # Attributes
         self.active = False

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -23,7 +23,7 @@ class Multiball(Device):
         super(Multiball, self).__init__(machine, name, config, collection,
                                         validate=validate)
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(machine.delayRegistry)
         self.balls_ejected = 0
 
         # let ball devices initialise first

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -44,7 +44,7 @@ class Playfield(BallDevice):
         self.tags = self.config['tags']
         self.label = self.config['label']
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
 
         self.machine.ball_devices[name] = self
 

--- a/mpf/devices/score_reel.py
+++ b/mpf/devices/score_reel.py
@@ -896,7 +896,7 @@ class ScoreReel(Device):
     def __init__(self, machine, name, config, collection=None, validate=True):
         super(ScoreReel, self).__init__(machine, name, config, collection,
                                         validate=validate)
-        self.delay = DelayManager()
+        self.delay = DelayManager(machine.delayRegistry)
 
         self.rollover_reel_advanced = False
         # True when a rollover pulse has been ordered

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -41,7 +41,7 @@ class Shot(Device):
         super(Shot, self).__init__(machine, name, config, collection,
                                    validate=validate)
 
-        self.delay = mpf.system.tasks.DelayManager()
+        self.delay = mpf.system.tasks.DelayManager(self.machine.delayRegistry)
 
         self.running_light_show = None
         self.active_sequences = list()

--- a/mpf/media_controller/core/display.py
+++ b/mpf/media_controller/core/display.py
@@ -43,7 +43,7 @@ class DisplayController(object):
         self.log = logging.getLogger("DisplayController")
         self.log.debug("Loading the DisplayController")
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
 
         self.hw_module = None
         self.fonts = None

--- a/mpf/media_controller/core/media_controller.py
+++ b/mpf/media_controller/core/media_controller.py
@@ -21,7 +21,7 @@ from mpf.media_controller.core.bcp_server import BCPServer
 from mpf.system.config import Config, CaseInsensitiveDict
 from mpf.system.events import EventManager
 from mpf.system.timing import Timing
-from mpf.system.tasks import Task, DelayManager
+from mpf.system.tasks import Task, DelayManager, DelayManagerRegistry
 from mpf.system.player import Player
 from mpf.system.assets import AssetManager
 from mpf.system.utility_functions import Util
@@ -82,7 +82,8 @@ class MediaController(object):
         self.machine_vars = CaseInsensitiveDict()
         self.machine_var_monitor = False
         self.tick_num = 0
-        self.delay = DelayManager()
+        self.delayRegistry = DelayManagerRegistry()
+        self.delay = DelayManager(self.delayRegistry)
 
         self._pc_assets_to_load = 0
         self._pc_total_assets = 0
@@ -383,7 +384,7 @@ class MediaController(object):
         self.events.post('timer_tick')  # sends the timer_tick system event
         self.tick_num += 1
         Task.timer_tick()  # notifies tasks
-        DelayManager.timer_tick(self)
+        self.delayRegistry.timer_tick(self)
         self.events._process_event_queue()
 
     def run(self):

--- a/mpf/platform/smart_virtual.py
+++ b/mpf/platform/smart_virtual.py
@@ -26,7 +26,7 @@ class HardwarePlatform(VirtualPlatform):
         self.log = logging.getLogger("Smart Virtual Platform")
         self.log.debug("Configuring smart_virtual hardware interface.")
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
 
     def __repr__(self):
         return '<Platform.SmartVirtual>'
@@ -89,8 +89,7 @@ class HardwarePlatform(VirtualPlatform):
 
     def tick(self):
         # ticks every hw loop (typically hundreds of times per sec)
-
-        self.delay._process_delays(self.machine)
+        pass
 
     def confirm_eject_via_switch(self, switch):
         self.machine.switch_controller.process_switch(switch.name, 1)

--- a/mpf/platform/snux.py
+++ b/mpf/platform/snux.py
@@ -21,7 +21,7 @@ class Snux(object):
 
     def __init__(self, machine, platform):
         self.log = logging.getLogger('Platform.Snux')
-        self.delay = DelayManager()
+        self.delay = DelayManager(machine.delayRegistry)
 
         self.machine = machine
         self.platform = platform

--- a/mpf/plugins/switch_player.py
+++ b/mpf/plugins/switch_player.py
@@ -26,7 +26,7 @@ class SwitchPlayer(object):
             return
 
         self.machine = machine
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
         self.current_step = 0
 
         config_spec = '''

--- a/mpf/system/ball_controller.py
+++ b/mpf/system/ball_controller.py
@@ -26,7 +26,7 @@ class BallController(object):
         self.machine = machine
         self.log = logging.getLogger("BallController")
         self.log.debug("Loading the BallController")
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
 
         self.game = None
 

--- a/mpf/system/logic_blocks.py
+++ b/mpf/system/logic_blocks.py
@@ -269,7 +269,7 @@ class Counter(LogicBlock):
 
         super(Counter, self).__init__(machine, name, player, config)
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
 
         self.ignore_hits = False
         self.hit_value = -1

--- a/mpf/system/machine.py
+++ b/mpf/system/machine.py
@@ -14,7 +14,7 @@ import Queue
 
 from mpf.system import *
 from mpf.system.config import Config, CaseInsensitiveDict
-from mpf.system.tasks import Task, DelayManager
+from mpf.system.tasks import Task, DelayManager, DelayManagerRegistry
 from mpf.system.data_manager import DataManager
 from mpf.system.timing import Timing
 from mpf.system.assets import AssetManager
@@ -71,7 +71,8 @@ class MachineController(object):
         self.flag_bcp_reset_complete = False
         self.asset_loader_complete = False
 
-        self.delay = DelayManager()
+        self.delayRegistry = DelayManagerRegistry()
+        self.delay = DelayManager(self.delayRegistry)
 
         self.crash_queue = Queue.Queue()
         Task.create(self._check_crash_queue)
@@ -438,7 +439,7 @@ class MachineController(object):
         self.timing.timer_tick()  # notifies the timing module
         self.events.post('timer_tick')  # sends the timer_tick system event
         tasks.Task.timer_tick()  # notifies tasks
-        tasks.DelayManager.timer_tick(self)
+        self.delayRegistry.timer_tick(self)
         self.events._process_event_queue()
 
     def _platform_stop(self):

--- a/mpf/system/mode.py
+++ b/mpf/system/mode.py
@@ -29,7 +29,7 @@ class Mode(object):
 
         self.log = logging.getLogger('Mode.' + name)
 
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
 
         self.priority = 0
         self._active = False
@@ -526,7 +526,7 @@ class ModeTimer(object):
         self.timer = None
         self.bcp = False
         self.event_keys = set()
-        self.delay = DelayManager()
+        self.delay = DelayManager(self.machine.delayRegistry)
         self.log = None
         self.debug = False
 

--- a/mpf/system/switch_controller.py
+++ b/mpf/system/switch_controller.py
@@ -217,7 +217,7 @@ class SwitchController(object):
         last changed state.
         """
 
-        return (time.time() - self.switches[switch_name]['time']) * 1000.0
+        return round((time.time() - self.switches[switch_name]['time']) * 1000.0, 0)
 
     def secs_since_change(self, switch_name):
         """Returns the number of ms that have elapsed since this switch

--- a/mpf/system/switch_controller.py
+++ b/mpf/system/switch_controller.py
@@ -581,6 +581,11 @@ class SwitchController(object):
                     self.machine.switches[switch_name].deactivation_events):
                 self.machine.events.post(event)
 
+    def get_next_timed_switch_event(self):
+        if not self.active_timed_switches:
+            return False
+        return min(self.active_timed_switches.keys())
+
     def _tick(self):
         """Called once per machine tick.
 

--- a/mpf/system/tasks.py
+++ b/mpf/system/tasks.py
@@ -84,27 +84,31 @@ class Task(object):
             Task.Tasks.add(task)
         Task.NewTasks = set()
 
+class DelayManagerRegistry(object):
+    def __init__(self):
+        self.delay_managers = set()
+
+    def get_next_event(self):
+        next_event_time = False
+        for delay_manager in self.delay_managers:
+            next_event_time_single = delay_manager._get_next_event()
+            if not next_event_time or (next_event_time > next_event_time_single and next_event_time_single):
+                next_event_time = next_event_time_single
+
+        return next_event_time
+
+    def timer_tick(self, machine):
+        for i in self.delay_managers:
+            i._process_delays(machine)
 
 class DelayManager(object):
-    """Parent class for a delay manager which can manage multiple delays."""
+    """Handles delays for one object"""
 
-    delay_managers = set()
-    dead_delay_managers = set()
-
-    # todo it might not make sense to keep each DelayManager as a separate
-    # class instance. It makes iterating complex and doesn't really add any
-    # value? (Well, apart from it's easy to wipe all the delays that a single
-    # module created.) But it might be faster to just have a single delay
-    # manager for the whole system. Then again, we're only iterating at a
-    # relatively slow loop rate.
-
-    def __init__(self):
+    def __init__(self, registry):
         self.log = logging.getLogger("DelayManager")
         self.delays = {}
-        DelayManager.delay_managers.add(self)
-
-    def __del__(self):
-        DelayManager.dead_delay_managers.add(self)  # todo I don't like this
+        self.registry = registry
+        self.registry.delay_managers.add(self)
 
     def add(self, ms, callback, name=None, **kwargs):
         """Adds a delay.
@@ -179,15 +183,6 @@ class DelayManager(object):
         """Removes (clears) all the delays associated with this DelayManager."""
         self.delays = {}
 
-    def get_next_event(self):
-        next_event_time = False
-        for delay_manager in DelayManager.delay_managers:
-            next_event_time_single = delay_manager._get_next_event()
-            if not next_event_time or (next_event_time > next_event_time_single and next_event_time_single):
-                next_event_time = next_event_time_single
-
-        return next_event_time
-
     def _get_next_event(self):
         next_event_time = False
         for delay in self.delays.keys():
@@ -217,17 +212,6 @@ class DelayManager(object):
             # Process event queue after delay
             machine.events._process_event_queue()
 
-    @staticmethod
-    def timer_tick(machine):
-        # This is kind of complex because we have to account for a delay
-        # manager being deleted while we're iterating.
-        live_delay_managers = set()
-        while DelayManager.delay_managers:
-            i = DelayManager.delay_managers.pop()
-            if i not in DelayManager.dead_delay_managers:
-                i._process_delays(machine)
-                live_delay_managers.add(i)
-        DelayManager.delay_managers = live_delay_managers
 
 # The MIT License (MIT)
 

--- a/tests/MpfTestCase.py
+++ b/tests/MpfTestCase.py
@@ -42,7 +42,7 @@ class MpfTestCase(unittest.TestCase):
         end_time = time.time() + delta
         self.machine_run()
         while True:
-            next_event = self.machine.delay.get_next_event()
+            next_event = self.machine.delayRegistry.get_next_event()
             next_timer = self.machine.timing.get_next_timer()
 
             wait_until = next_event

--- a/tests/MpfTestCase.py
+++ b/tests/MpfTestCase.py
@@ -40,16 +40,21 @@ class MpfTestCase(unittest.TestCase):
 
     def advance_time_and_run(self, delta):
         end_time = time.time() + delta
+        self.machine.log.debug("Advance until %s", end_time)
         self.machine_run()
         while True:
             next_event = self.machine.delayRegistry.get_next_event()
             next_timer = self.machine.timing.get_next_timer()
+            next_switch = self.machine.switch_controller.get_next_timed_switch_event()
 
             wait_until = next_event
-            if wait_until and next_timer and wait_until > next_timer:
+            if not wait_until or (next_timer and wait_until > next_timer):
                 wait_until = next_timer
 
-            if wait_until and wait_until <= end_time:
+            if not wait_until or (next_switch and wait_until > next_switch):
+                wait_until = next_switch
+
+            if wait_until and wait_until < end_time:
                 self.set_time(wait_until)
                 self.machine_run()
             else:
@@ -59,6 +64,7 @@ class MpfTestCase(unittest.TestCase):
         self.machine_run()
 
     def machine_run(self):
+        self.machine.log.debug("Next run %s", time.time())
         self.machine.default_platform.tick()
         self.machine.timer_tick()
 

--- a/tests/machine_files/switch_controller/config/config.yaml
+++ b/tests/machine_files/switch_controller/config/config.yaml
@@ -1,0 +1,5 @@
+#config_version=3
+
+switches:
+    s_test:
+        number:

--- a/tests/test_SwitchController.py
+++ b/tests/test_SwitchController.py
@@ -1,0 +1,31 @@
+import unittest
+
+from mpf.system.machine import MachineController
+from MpfTestCase import MpfTestCase
+from mock import MagicMock
+import time
+
+class TestSwitchController(MpfTestCase):
+
+    def getConfigFile(self):
+        return 'config.yaml'
+
+    def getMachinePath(self):
+        return '../tests/machine_files/switch_controller/'
+
+
+    def _callback(self):
+         self.isActive = self.machine.switch_controller.is_active("s_test", ms=300)
+
+    def testIsActiveTimeing(self):
+        self.isActive = None
+
+        self.machine.switch_controller.add_switch_handler(
+                switch_name="s_test",
+                callback=self._callback,
+                state=1, ms=300)
+        self.machine.switch_controller.process_switch("s_test", 1, True)
+
+        self.advance_time_and_run(3)
+
+        self.assertEquals(True, self.isActive)


### PR DESCRIPTION
Remove the static variables in DelayManager and created DelayRegistry. Removed the __del__ magic because all DelayManagers are always referenced in delay_manager and cannot be collected by GC during runtime (and in fact they are not)