### PR TITLE
Playfield count refactoring

### DIFF
--- a/mpf/core/ball_controller.py
+++ b/mpf/core/ball_controller.py
@@ -163,6 +163,9 @@ class BallController(object):
                            self.machine.ball_controller.num_balls_known)
             return False
 
+    def get_free_balls(self):
+        return self.num_balls_known - self._count_balls()
+
     def collect_balls(self, target='home, trough'):
         """Used to ensure that all balls are in contained in ball devices with
         the tag or list of tags you pass.

--- a/mpf/core/ball_controller.py
+++ b/mpf/core/ball_controller.py
@@ -48,9 +48,88 @@ class BallController(object):
                 self.machine.switch_controller.add_switch_handler(switch.name,
                                                                   self._update_num_balls_known,
                                                                   ms=device.config['entrance_count_delay'])
+                self.machine.switch_controller.add_switch_handler(switch.name,
+                                                                  self._correct_playfield_count,
+                                                                  ms=device.config['entrance_count_delay'],
+                                                                  state=1)
+                self.machine.switch_controller.add_switch_handler(switch.name,
+                                                                  self._correct_playfield_count,
+                                                                  ms=device.config['exit_count_delay'],
+                                                                  state=0)
+
+        for playfield in self.machine.playfields:
+            self.machine.events.add_handler('{}_ball_count_change'.format(playfield.name),
+                                            self._correct_playfield_count)
 
         # run initial count
         self._update_num_balls_known()
+
+    def _get_loose_balls(self):
+        return self.num_balls_known - self._count_stable_balls()
+
+    def _count_stable_balls(self):
+        self.log.debug("Counting Balls")
+        balls = 0
+
+        for device in self.machine.ball_devices:
+            if device.is_playfield():
+                continue
+
+            if not device.is_ball_count_stable():
+                raise ValueError("devices not stable")
+
+            # generally we do not count ball devices without switches
+            if 'ball_switches' not in device.config:
+                continue
+            # special handling for troughs (needed for gottlieb)
+            elif not device.config['ball_switches'] and 'trough' in device.tags:
+                balls += device.balls
+            else:
+                for switch in device.config['ball_switches']:
+                    if self.machine.switch_controller.is_active(
+                            switch.name, ms=device.config['entrance_count_delay']):
+                        balls += 1
+                    elif self.machine.switch_controller.is_inactive(
+                            switch.name, ms=device.config['exit_count_delay']):
+                        continue
+                    else:
+                        raise ValueError("switches not stable")
+
+        return balls
+
+    def _correct_playfield_count(self, **kwargs):
+        del kwargs
+        self.delay.reset(ms=1, callback=self._correct_playfield_count2, name="correct_playfield")
+
+    def _correct_playfield_count2(self):
+        try:
+            loose_balls = self._get_loose_balls()
+        except ValueError:
+            self.delay.reset(ms=10000, callback=self._correct_playfield_count2, name="correct_playfield")
+            return
+
+        balls_on_pfs = 0
+
+        for playfield in self.machine.playfields:
+            balls_on_pfs += playfield.balls
+
+        # fix too much balls
+        while balls_on_pfs > loose_balls:
+            for playfield in self.machine.playfields:
+                self.log.warning("Corecting balls on pf from %s to %s",
+                                 playfield.balls, playfield.balls - 1)
+                if playfield.balls > 0:
+                    if playfield.unexpected_balls > 0:
+                        playfield.unexpected_balls -= 1
+                    playfield.balls -= 1
+                    balls_on_pfs -= 1
+                    break
+
+        for playfield in self.machine.playfields:
+            if playfield.balls != playfield.available_balls:
+                self.log.warning("Corecting available_balls %s to %s",
+                                 playfield.available_balls, playfield.balls)
+                playfield.available_balls = playfield.balls
 
     def _update_num_balls_known(self):
         balls = self._count_balls()
@@ -174,9 +253,6 @@ class BallController(object):
                            "Total balls known: %s", count,
                            self.machine.ball_controller.num_balls_known)
             return False
-
-    def get_free_balls(self):
-        return self.num_balls_known - self._count_balls()
 
     def collect_balls(self, target='home, trough'):
         """Used to ensure that all balls are in contained in ball devices with

--- a/mpf/core/ball_controller.py
+++ b/mpf/core/ball_controller.py
@@ -45,10 +45,18 @@ class BallController(object):
             if 'ball_switches' not in device.config:
                 continue
             for switch in device.config['ball_switches']:
-                self.machine.switch_controller.add_switch_handler(switch.name, self._count_balls, ms=100)
+                self.machine.switch_controller.add_switch_handler(switch.name,
+                                                                  self._update_num_balls_known,
+                                                                  ms=device.config['entrance_count_delay'])
 
         # run initial count
-        self._count_balls()
+        self._update_num_balls_known()
+
+    def _update_num_balls_known(self):
+        balls = self._count_balls()
+        if balls > self.num_balls_known:
+            self.log.debug("Setting known balls to %s", balls)
+            self.num_balls_known = balls
 
     def _count_balls(self):
         self.log.debug("Counting Balls")
@@ -63,13 +71,9 @@ class BallController(object):
                 balls += device.balls
             else:
                 for switch in device.config['ball_switches']:
-                    if self.machine.switch_controller.is_active(switch.name, ms=100):
+                    if self.machine.switch_controller.is_active(
+                            switch.name, ms=device.config['entrance_count_delay']):
                         balls += 1
-
-        self.log.debug("Setting known balls to %s", balls)
-        if balls > self.num_balls_known:
-            self.log.debug("Setting known balls to %s", balls)
-            self.num_balls_known = balls
 
         return balls
 

--- a/mpf/core/ball_controller.py
+++ b/mpf/core/ball_controller.py
@@ -55,8 +55,16 @@ class BallController(object):
     def _update_num_balls_known(self):
         balls = self._count_balls()
         if balls > self.num_balls_known:
-            self.log.debug("Setting known balls to %s", balls)
+            self.log.debug("Found new balls. Setting known balls to %s", balls)
+            self.delay.add(1, self._handle_new_balls, new_balls=balls - self.num_balls_known)
             self.num_balls_known = balls
+
+    def _handle_new_balls(self, new_balls):
+        for dummy_i in range(new_balls):
+            for playfield in self.machine.playfields:
+                if playfield.unexpected_balls > 0:
+                    playfield.unexpected_balls -= 1
+                    break
 
     def _count_balls(self):
         self.log.debug("Counting Balls")

--- a/mpf/core/ball_search.py
+++ b/mpf/core/ball_search.py
@@ -139,6 +139,7 @@ class BallSearch(object):
         lost_balls = self.playfield.balls
         self.machine.ball_controller.num_balls_known -= lost_balls
         self.playfield.balls = 0
+        self.playfield.available_balls = 0
 
         if self.playfield.config['ball_search_failed_action'] == "new_ball":
             if self.machine.ball_controller.num_balls_known > 0:

--- a/mpf/devices/ball_device.py
+++ b/mpf/devices/ball_device.py
@@ -1094,6 +1094,9 @@ class BallDevice(SystemWideDevice):
             self.balls += 1
             self._handle_new_balls(1)
 
+    def is_ball_count_stable(self):
+        return self._state == "idle" and self._idle_counted
+
     def is_ready_to_receive(self):
         return ((self._state == "idle" and self._idle_counted) or
                 (self._state == "waiting_for_ball") and

--- a/mpf/devices/ball_device.py
+++ b/mpf/devices/ball_device.py
@@ -1618,8 +1618,9 @@ class BallDevice(SystemWideDevice):
             # remove eject from queue if we have one
             if len(self.eject_queue):
                 self.eject_queue.popleft()
-            # because the path was not set up. just add the ball
-            self.eject_in_progress_target.available_balls += 1
+            else:
+                # because the path was not set up. just add the ball
+                self.eject_in_progress_target.available_balls += 1
             self._incoming_balls.popleft()
         elif self._state != "ball_left" and self._state != "failed_confirm":
             raise AssertionError(

--- a/mpf/devices/ball_device.py
+++ b/mpf/devices/ball_device.py
@@ -1618,6 +1618,8 @@ class BallDevice(SystemWideDevice):
             # remove eject from queue if we have one
             if len(self.eject_queue):
                 self.eject_queue.popleft()
+            # because the path was not set up. just add the ball
+            self.eject_in_progress_target.available_balls += 1
             self._incoming_balls.popleft()
         elif self._state != "ball_left" and self._state != "failed_confirm":
             raise AssertionError(

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -249,9 +249,6 @@ class Playfield(SystemWideDevice):
             self.mark_playfield_active()
 
             if not self.num_balls_requested:
-                if self.machine.game:
-                    self.unexpected_balls += 1
-
                 if self.machine.config['machine']['glass_off_mode']:
                     self.log.debug("Playfield_active switch hit with no balls "
                                    "expected. glass_off_mode is enabled, so "
@@ -262,6 +259,7 @@ class Playfield(SystemWideDevice):
                                    "setting playfield ball count to 1")
 
                     self.balls = 1
+                    self.unexpected_balls += 1
                     self.machine.events.post('unexpected_ball_on_' + self.name)
 
     def _ball_removed_handler(self, balls, **kwargs):

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -114,7 +114,7 @@ class Playfield(SystemWideDevice):
             self.log.warning("Playfield balls went to %s. Resetting to 0, but "
                              "FYI that something's weird", balls)
             self._balls = 0
-            self.unexpected_balls = 0
+            self.unexpected_balls += -balls
 
         self.log.debug("New Ball Count: %s. (Prior count: %s)",
                        self._balls, prior_balls)
@@ -250,7 +250,7 @@ class Playfield(SystemWideDevice):
 
             if not self.num_balls_requested:
                 if self.machine.game:
-                    self.unexpected_balls = 1
+                    self.unexpected_balls += 1
 
                 if self.machine.config['machine']['glass_off_mode']:
                     self.log.debug("Playfield_active switch hit with no balls "

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -262,20 +262,21 @@ class Playfield(SystemWideDevice):
                                    "setting playfield ball count to 1")
 
                     self.balls = 1
+                    self.available_balls += 1
                     self.unexpected_balls += 1
                     self.machine.events.post('unexpected_ball_on_' + self.name)
 
     def _ball_removed_handler(self, balls, **kwargs):
         del kwargs
-        self.available_balls -= balls
-        if self.available_balls < 0:
-            self.available_balls = 0
         # somebody got a ball from us so we obviously had one
         self.machine.events.post('sw_' + self.name + "_active", callback=self._ball_removed_handler2, balls=balls)
 
     def _ball_removed_handler2(self, balls):
         self.log.debug("%s ball(s) removed from the playfield", balls)
         self.balls -= balls
+        self.available_balls -= balls
+        if self.available_balls < 0:
+            self.available_balls = 0
 
     def _source_device_ball_lost(self, target, **kwargs):
         del kwargs

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -57,6 +57,9 @@ class Playfield(SystemWideDevice):
                         '_ball_eject_success',
                         handler=self._source_device_eject_success)
                     self.machine.events.add_handler(
+                        event='balldevice_{}_ball_lost'.format(device.name),
+                        handler=self._source_device_ball_lost)
+                    self.machine.events.add_handler(
                         event='balldevice_' + device.name +
                         '_ball_eject_failed',
                         handler=self._source_device_eject_failed)
@@ -273,6 +276,11 @@ class Playfield(SystemWideDevice):
     def _ball_removed_handler2(self, balls):
         self.log.debug("%s ball(s) removed from the playfield", balls)
         self.balls -= balls
+
+    def _source_device_ball_lost(self, target, **kwargs):
+        del kwargs
+        if target == self:
+            self.available_balls -= 1
 
     def _source_device_eject_attempt(self, balls, target, **kwargs):
         # A source device is attempting to eject a ball. We need to know if it's

--- a/mpf/modes/tilt/code/tilt.py
+++ b/mpf/modes/tilt/code/tilt.py
@@ -146,9 +146,10 @@ class Tilt(Mode):
         for autofire in self.machine.autofires:
             autofire.disable()
 
-    def _tilted_ball_drain(self, new_balls, unclaimed_balls, device):
+    def _tilted_ball_drain(self, new_balls, unclaimed_balls, device, **kwargs):
         del new_balls
         del device
+        del kwargs
 
         self._balls_to_collect -= unclaimed_balls
 

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -205,7 +205,6 @@ class MpfTestCase(unittest.TestCase):
             while not self.machine.test_init_complete:
                 self.advance_time_and_run(0.01)
 
-            self.machine.ball_controller.num_balls_known = 99
             self.advance_time_and_run(300)
 
         except Exception as e:

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -79,6 +79,11 @@ class MpfTestCase(unittest.TestCase):
         self.machine.events.post(event_name)
         self.machine_run()
 
+    def set_num_balls_known(self, balls):
+        # in case the test does not have any ball devices
+        self.machine.ball_controller.num_balls_known = balls
+        self.machine.ball_controller.last_balls = 0
+
     def get_platform(self):
         return 'virtual'
 

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -82,7 +82,6 @@ class MpfTestCase(unittest.TestCase):
     def set_num_balls_known(self, balls):
         # in case the test does not have any ball devices
         self.machine.ball_controller.num_balls_known = balls
-        self.machine.ball_controller.last_balls = 0
 
     def get_platform(self):
         return 'virtual'

--- a/mpf/tests/test_BallController.py
+++ b/mpf/tests/test_BallController.py
@@ -147,3 +147,24 @@ class TestBallController(MpfTestCase):
         self.advance_time_and_run(1)
 
         self.assertEqual(1, self._events['collecting_balls_complete'])
+
+    def test_free_balls(self):
+        self.mock_event("collecting_balls_complete")
+        self.machine.switch_controller.process_switch("s_ball_switch1", 1)
+        self.machine.switch_controller.process_switch("s_ball_switch2", 1)
+        self.machine.switch_controller.process_switch("s_ball_switch3", 1)
+        self.machine.switch_controller.process_switch("s_ball_switch4", 1)
+        self.advance_time_and_run(1)
+        self.assertEqual(4, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(0, self.machine.ball_controller.get_free_balls())
+
+        self.machine.switch_controller.process_switch("s_ball_switch3", 0)
+        self.machine.switch_controller.process_switch("s_ball_switch4", 0)
+        self.advance_time_and_run(1)
+        self.assertEqual(4, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(2, self.machine.ball_controller.get_free_balls())
+
+        self.machine.switch_controller.process_switch("s_ball_switch4", 1)
+        self.advance_time_and_run(1)
+        self.assertEqual(4, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(1, self.machine.ball_controller.get_free_balls())

--- a/mpf/tests/test_BallController.py
+++ b/mpf/tests/test_BallController.py
@@ -75,7 +75,7 @@ class TestBallController(MpfTestCase):
 
         self.machine.switch_controller.process_switch("s_ball_switch_launcher",
                                                       1)
-        self.advance_time_and_run(.5)
+        self.advance_time_and_run(1)
         self.assertEqual(4, self.machine.ball_controller.num_balls_known)
 
         self.assertEqual("idle", self.machine.ball_devices.test_trough._state)

--- a/mpf/tests/test_BallController.py
+++ b/mpf/tests/test_BallController.py
@@ -148,7 +148,32 @@ class TestBallController(MpfTestCase):
 
         self.assertEqual(1, self._events['collecting_balls_complete'])
 
-    def test_free_balls(self):
+    def test_unknown_ball_on_playfield(self):
+        self.mock_event("collecting_balls_complete")
+        self.machine.switch_controller.process_switch("s_ball_switch1", 1)
+        self.machine.switch_controller.process_switch("s_ball_switch2", 1)
+        self.machine.switch_controller.process_switch("s_ball_switch3", 1)
+        self.machine.switch_controller.process_switch("s_ball_switch4", 0)
+        self.advance_time_and_run(1)
+        self.assertEqual(3, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
+        self.assertEqual(0, self.machine.ball_controller._get_loose_balls())
+
+        self.hit_and_release_switch("s_playfield")
+        self.advance_time_and_run(1)
+        self.assertEqual(3, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(0, self.machine.ball_controller._get_loose_balls())
+        self.assertEqual(0, self.machine.playfield.available_balls)
+        self.assertEqual(0, self.machine.playfield.balls)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
+
+        self.machine.switch_controller.process_switch("s_ball_switch4", 1)
+        self.advance_time_and_run(1)
+        self.assertEqual(4, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(0, self.machine.ball_controller._get_loose_balls())
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
+
+    def test_loose_balls(self):
         self.mock_event("collecting_balls_complete")
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
         self.machine.switch_controller.process_switch("s_ball_switch2", 1)
@@ -156,15 +181,15 @@ class TestBallController(MpfTestCase):
         self.machine.switch_controller.process_switch("s_ball_switch4", 1)
         self.advance_time_and_run(1)
         self.assertEqual(4, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(0, self.machine.ball_controller.get_free_balls())
+        self.assertEqual(0, self.machine.ball_controller._get_loose_balls())
 
         self.machine.switch_controller.process_switch("s_ball_switch3", 0)
         self.machine.switch_controller.process_switch("s_ball_switch4", 0)
         self.advance_time_and_run(1)
         self.assertEqual(4, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(2, self.machine.ball_controller.get_free_balls())
+        self.assertEqual(2, self.machine.ball_controller._get_loose_balls())
 
         self.machine.switch_controller.process_switch("s_ball_switch4", 1)
         self.advance_time_and_run(1)
         self.assertEqual(4, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(1, self.machine.ball_controller.get_free_balls())
+        self.assertEqual(1, self.machine.ball_controller._get_loose_balls())

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -1634,7 +1634,6 @@ class TestBallDevice(MpfTestCase):
         self.advance_time_and_run(1)
         self.assertEqual(0, launcher.balls)
         self.assertEqual(2, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(1, self.machine.ball_controller.get_free_balls())
         self.assertEqual(1, playfield.available_balls)
         self.assertEqual(0, playfield.balls)
 

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -845,6 +845,7 @@ class TestBallDevice(MpfTestCase):
 
         # assume there are already two balls on the playfield
         playfield.balls = 2
+        playfield.available_balls = 2
 
         # request an ball to pf
         playfield.add_ball()
@@ -1659,8 +1660,9 @@ class TestBallDevice(MpfTestCase):
         self.assertEqual(2, self.machine.ball_controller.num_balls_known)
 
         # no more balls on pf
-        self.assertEqual(0, playfield.available_balls)
         self.assertEqual(0, playfield.balls)
+        # eject is not failed yet
+        self.assertEqual(1, playfield.available_balls)
 
         self.advance_time_and_run(30)
 

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -814,6 +814,7 @@ class TestBallDevice(MpfTestCase):
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
         self.machine.switch_controller.process_switch("s_ball_switch2", 1)
         self.advance_time_and_run(1)
+        self.assertEqual(0, playfield.unexpected_balls)
         self.assertEqual(2, self._captured)
         self._captured = 0
 

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -817,6 +817,9 @@ class TestBallDevice(MpfTestCase):
         self.assertEqual(2, self._captured)
         self._captured = 0
 
+        # assume there are more balls in the machine
+        self.machine.ball_controller.num_balls_known = 4
+
         self.assertEqual(0, playfield.balls)
 
         # it should keep the ball

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -29,11 +29,18 @@ class TestBallDevice(MpfTestCase):
                                         self._missing_ball)
 
         self._missing = 0
+        self.assertEqual(0, self.machine.playfield.balls)
+        self.assertEqual(0, self.machine.playfield.available_balls)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
 
         self.machine.switch_controller.process_switch("s_ball_switch_launcher",
                                                       1)
         self.advance_time_and_run(1)
         self.assertEqual(1, device2.balls)
+        self.assertEqual(1, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(0, self.machine.playfield.balls)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
+        self.assertEqual(1, self.machine.playfield.available_balls)
 
         coil2.pulse.assert_called_once_with()
 
@@ -44,6 +51,9 @@ class TestBallDevice(MpfTestCase):
         self.assertEqual(0, self._missing)
         self.advance_time_and_run(300)
         self.assertEqual(1, self._missing)
+        self.assertEqual(1, self.machine.playfield.balls)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
+        self.assertEqual(1, self.machine.playfield.available_balls)
 
     def _requesting_ball(self, balls, **kwargs):
         del kwargs
@@ -765,6 +775,7 @@ class TestBallDevice(MpfTestCase):
         self.assertEqual(1, self._missing)
         self.assertEqual(0, self._captured)
         self.assertEqual(1, playfield.balls)
+        self.assertEqual(1, playfield.available_balls)
 
         # count should be on less and one ball missing
         self.assertEqual(1, device1.balls)

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -1632,6 +1632,10 @@ class TestBallDevice(MpfTestCase):
                                                       0)
         self.advance_time_and_run(1)
         self.assertEqual(0, launcher.balls)
+        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(1, self.machine.ball_controller.get_free_balls())
+        self.assertEqual(1, playfield.available_balls)
+        self.assertEqual(0, playfield.balls)
 
         # the ball should go to target1. however, it jumps to the pf and drains
         # without hitting a switch on the pf

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -1576,7 +1576,6 @@ class TestBallDevice(MpfTestCase):
         self._captured = 0
         self._missing = 0
         self._collecting_balls_complete = 0
-        self.machine.ball_controller.num_balls_known = 2
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
@@ -1675,7 +1674,6 @@ class TestBallDevice(MpfTestCase):
         self._captured = 0
         self._missing = 0
         self._collecting_balls_complete = 0
-        self.machine.ball_controller.num_balls_known = 2
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
@@ -1823,7 +1821,6 @@ class TestBallDevice(MpfTestCase):
         self._captured = 0
         self._missing = 0
         self._collecting_balls_complete = 0
-        self.machine.ball_controller.num_balls_known = 2
 
         # add initial balls to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -1654,6 +1654,7 @@ class TestBallDevice(MpfTestCase):
         self.advance_time_and_run(30)
 
         self.assertEqual(2, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(0, playfield.balls)
         self.assertEqual(0, playfield.available_balls)
 
     def test_ball_missing_to_pf_and_drain_with_pf_switch(self):

--- a/mpf/tests/test_BallDeviceHoldCoil.py
+++ b/mpf/tests/test_BallDeviceHoldCoil.py
@@ -1,9 +1,6 @@
-import unittest
-
-from mpf.core.machine import MachineController
 from mpf.tests.MpfTestCase import MpfTestCase
 from mock import MagicMock
-import time
+
 
 class TestBallDevicesHoldCoil(MpfTestCase):
 
@@ -12,6 +9,10 @@ class TestBallDevicesHoldCoil(MpfTestCase):
 
   def getMachinePath(self):
       return 'tests/machine_files/ball_device/'
+
+  def setUp(self):
+      super().setUp()
+      self.machine.ball_controller.num_balls_known = 99
 
   def test_holdcoil_with_direct_release(self):
       self.machine.coils['hold_coil'].enable = MagicMock()

--- a/mpf/tests/test_BallDeviceJamSwitch.py
+++ b/mpf/tests/test_BallDeviceJamSwitch.py
@@ -362,6 +362,8 @@ class TestBallDeviceJamSwitch(MpfTestCase):
         self.assertEqual(3, self.machine.ball_devices.trough.balls)
         self.assertEqual(0, self.machine.ball_devices.plunger.balls)
         self.assertEqual(1, self.machine.ball_devices.playfield.balls)
+        self.assertEqual(1, self.machine.playfield.balls)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
         self.assertEqual("idle", self.machine.ball_devices.trough._state)
         self.assertEqual("idle", self.machine.ball_devices.plunger._state)
 
@@ -402,6 +404,8 @@ class TestBallDeviceJamSwitch(MpfTestCase):
         self.assertEqual(4, self.machine.ball_controller.num_balls_known)
         self.assertEqual(1, self.machine.ball_devices.plunger.balls)
         self.assertEqual(3, self.machine.ball_devices.trough.balls)
+        self.assertEqual(0, self.machine.playfield.balls)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
         self.assertEqual(1, self._captured)
 
     def test_eject_while_second_ball_enter(self):

--- a/mpf/tests/test_BallDeviceJamSwitch.py
+++ b/mpf/tests/test_BallDeviceJamSwitch.py
@@ -1,4 +1,3 @@
-
 from mpf.tests.MpfTestCase import MpfTestCase
 from mock import MagicMock
 
@@ -12,6 +11,7 @@ class TestBallDeviceJamSwitch(MpfTestCase):
         return 'tests/machine_files/ball_device/'
 
     def _captured_from_pf(self, balls, **kwargs):
+        del kwargs
         self._captured += balls
 
     def put_four_balls_in_trough(self):
@@ -24,6 +24,7 @@ class TestBallDeviceJamSwitch(MpfTestCase):
         self.advance_time_and_run(1)
         self.assertEqual(4, self.machine.ball_devices.trough.balls)
         self.assertEqual(4, self._captured)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
         self._captured = 0
 
         self.trough_coil = self.machine.coils.trough_eject
@@ -176,7 +177,6 @@ class TestBallDeviceJamSwitch(MpfTestCase):
         self.machine.switch_controller.process_switch('s_plunger', 1)
         self.advance_time_and_run(1)
 
-
         self.advance_time_and_run(100)
         self.assertEqual("idle", self.machine.ball_devices.trough._state)
         self.assertEqual("ejecting", self.machine.ball_devices.plunger._state)
@@ -304,7 +304,6 @@ class TestBallDeviceJamSwitch(MpfTestCase):
         self.machine.switch_controller.process_switch('s_plunger', 1)
         self.advance_time_and_run(1)
 
-
         self.advance_time_and_run(100)
         self.assertEqual("idle", self.machine.ball_devices.trough._state)
         self.assertEqual("ejecting", self.machine.ball_devices.plunger._state)
@@ -339,6 +338,7 @@ class TestBallDeviceJamSwitch(MpfTestCase):
         # ball goes into plunger
         self.machine.switch_controller.process_switch('s_plunger', 1)
         self.advance_time_and_run(1)
+        self.assertEqual(0, self.machine.playfield.unexpected_balls)
 
         self.assertEqual(self.machine.ball_devices.trough.balls, 3)
         self.assertEqual(self.machine.ball_devices.plunger.balls, 1)
@@ -397,7 +397,6 @@ class TestBallDeviceJamSwitch(MpfTestCase):
 
         self.machine.switch_controller.process_switch('s_plunger', 1)
         self.advance_time_and_run(1)
-
 
         self.assertEqual("idle", self.machine.ball_devices.trough._state)
         self.assertEqual("ejecting", self.machine.ball_devices.plunger._state)

--- a/mpf/tests/test_BallDeviceJamSwitch.py
+++ b/mpf/tests/test_BallDeviceJamSwitch.py
@@ -17,7 +17,6 @@ class TestBallDeviceJamSwitch(MpfTestCase):
     def put_four_balls_in_trough(self):
         self._captured = 0
         self.machine.events.add_handler('balldevice_captured_from_playfield', self._captured_from_pf)
-        self.machine.ball_controller.num_balls_known = 4
         self.machine.switch_controller.process_switch('s_trough_1', 1)
         self.machine.switch_controller.process_switch('s_trough_2', 1)
         self.machine.switch_controller.process_switch('s_trough_3', 1)

--- a/mpf/tests/test_BallDeviceManualWithTarget.py
+++ b/mpf/tests/test_BallDeviceManualWithTarget.py
@@ -21,12 +21,16 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         self._missing += 1
 
     def _requesting_ball(self, balls, **kwargs):
+        del kwargs
         self._requesting += balls
 
     def _ball_enter(self, new_balls, unclaimed_balls, **kwargs):
+        del kwargs
+        del unclaimed_balls
         self._enter += new_balls
 
     def _captured_from_pf(self, balls, **kwargs):
+        del kwargs
         self._captured += balls
 
     def test_manual_successful_eject_to_pf(self):
@@ -1032,6 +1036,7 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         playfield = self.machine.ball_devices['playfield']
 
         # add ball to pf
+        self.machine.ball_controller.num_balls_known = 1
         playfield.balls = 1
         self.assertEqual(1, playfield.balls)
         coil4.pulse = MagicMock()
@@ -1074,6 +1079,7 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         playfield = self.machine.ball_devices['playfield']
 
         # add ball to pf
+        self.machine.ball_controller.num_balls_known = 1
         playfield.balls = 1
         coil5.pulse = MagicMock()
         coil2.pulse = MagicMock()
@@ -1119,7 +1125,6 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         self.assertEqual(0, playfield.balls)
         self.assertEqual(1, launcher.balls)
         self.assertEqual(0, vuk.balls)
-
 
         # it should stay there and wait for manual eject
         self.assertEqual(0, playfield.balls)

--- a/mpf/tests/test_BallDeviceManualWithTarget.py
+++ b/mpf/tests/test_BallDeviceManualWithTarget.py
@@ -198,7 +198,6 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         self._enter = 0
         self._captured = 0
         self._missing = 0
-        self.machine.ball_controller.num_balls_known = 1
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
@@ -630,7 +629,6 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         self._enter = 0
         self._captured = 0
         self._missing = 0
-        self.machine.ball_controller.num_balls_known = 2
 
         # add two initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)

--- a/mpf/tests/test_BallDeviceManualWithTarget.py
+++ b/mpf/tests/test_BallDeviceManualWithTarget.py
@@ -934,12 +934,16 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         self.machine.switch_controller.process_switch("s_playfield", 0)
         self.advance_time_and_run(1)
 
+        self.assertEqual(1, playfield.balls)
+        self.assertEqual(1, playfield.available_balls)
+
         # no launcher eject
         coil1.pulse.assert_called_once_with()
         assert not coil2.pulse.called
         self.advance_time_and_run(100)
 
         self.assertEqual(1, playfield.balls)
+        self.assertEqual(1, playfield.available_balls)
         self.assertEqual(0, self._captured)
         self.assertEqual(0, self._missing)
         self.assertEqual("idle", device2._state)
@@ -966,6 +970,7 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
         self.assertEqual(2, self._captured)
         self._captured = 0
         self.assertEqual(0, playfield.balls)
+        self.assertEqual(0, playfield.available_balls)
 
         # it should keep the ball
         coil1.pulse = MagicMock()
@@ -1022,6 +1027,7 @@ class TestBallDeviceManualWithTarget(MpfTestCase):
 
         self.advance_time_and_run(100)
         self.assertEqual(1, playfield.balls)
+        self.assertEqual(1, playfield.available_balls)
         self.assertEqual(0, self._captured)
         self.assertEqual(0, self._missing)
 

--- a/mpf/tests/test_BallDeviceSwitchConfirmation.py
+++ b/mpf/tests/test_BallDeviceSwitchConfirmation.py
@@ -11,6 +11,10 @@ class TestBallDeviceSwitchConfirmation(MpfTestCase):
         self._requesting = 0
         self._queue = False
 
+    def setUp(self):
+        super().setUp()
+        self.machine.ball_controller.num_balls_known = 99
+
     def getConfigFile(self):
         return 'test_ball_device_switch_confirmation.yaml'
 

--- a/mpf/tests/test_BallDeviceSwitchConfirmation.py
+++ b/mpf/tests/test_BallDeviceSwitchConfirmation.py
@@ -11,10 +11,6 @@ class TestBallDeviceSwitchConfirmation(MpfTestCase):
         self._requesting = 0
         self._queue = False
 
-    def setUp(self):
-        super().setUp()
-        self.machine.ball_controller.num_balls_known = 99
-
     def getConfigFile(self):
         return 'test_ball_device_switch_confirmation.yaml'
 
@@ -158,7 +154,11 @@ class TestBallDeviceSwitchConfirmation(MpfTestCase):
         self.assertEqual(1, self._captured)
         self._captured = 0
 
+        # assume we have more than one ball to prevent BallController from "fixing" pf
+        self.machine.ball_controller.num_balls_known = 5
+
         self.assertEqual(0, playfield.balls)
+        self.assertEqual(0, playfield.unexpected_balls)
 
         # it should keep the ball
         coil1.pulse = MagicMock()
@@ -206,6 +206,7 @@ class TestBallDeviceSwitchConfirmation(MpfTestCase):
             "s_ball_switch_target2_1", 1)
         self.advance_time_and_run(1)
         self.assertEqual(1, device4.balls)
+        self.assertEqual(1, playfield.unexpected_balls)
 
         # eject will fail since the eject_confirm switch was not hit
         self.advance_time_and_run(30)
@@ -219,7 +220,8 @@ class TestBallDeviceSwitchConfirmation(MpfTestCase):
         self.assertEqual(0, self._enter)
         self.assertEqual(1, self._captured)
 
-        self.assertEqual(1, playfield.balls)
+        # no ball on pf because the pf saw an unexpected ball
+        self.assertEqual(0, playfield.balls)
         self.assertEqual(1, self._missing)
 
     def test_eject_successful_but_ball_never_arrives(self):
@@ -336,8 +338,6 @@ class TestBallDeviceSwitchConfirmation(MpfTestCase):
                                         self._missing_ball)
         self._captured = 0
         self._missing = 0
-
-        self.machine.ball_controller.num_balls_known = 1
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
@@ -462,8 +462,6 @@ class TestBallDeviceSwitchConfirmation(MpfTestCase):
                                         self._missing_ball)
         self._captured = 0
         self._missing = 0
-
-        self.machine.ball_controller.num_balls_known = 1
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)

--- a/mpf/tests/test_BallLock.py
+++ b/mpf/tests/test_BallLock.py
@@ -47,7 +47,6 @@ class TestBallLock(MpfTestCase):
         self._captured = 0
         self._missing = 0
         self._collecting_balls_complete = 0
-        self.machine.ball_controller.num_balls_known = 2
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
@@ -217,7 +216,6 @@ class TestBallLock(MpfTestCase):
         self._captured = 0
         self._missing = 0
         self._collecting_balls_complete = 0
-        self.machine.ball_controller.num_balls_known = 2
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
@@ -312,7 +310,6 @@ class TestBallLock(MpfTestCase):
         self._captured = 0
         self._missing = 0
         self._collecting_balls_complete = 0
-        self.machine.ball_controller.num_balls_known = 2
 
         # add an initial ball to trough
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)

--- a/mpf/tests/test_BallSave.py
+++ b/mpf/tests/test_BallSave.py
@@ -214,9 +214,10 @@ class TestBallSave(MpfTestCase):
     def testBallDoubleDrain(self):
         # prepare game
         self.machine.switch_controller.process_switch('s_ball_switch1', 1)
+        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
         self.advance_time_and_run(10)
-        self.assertEqual(1, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(1, self.machine.ball_devices.bd_trough.balls)
+        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
+        self.assertEqual(2, self.machine.ball_devices.bd_trough.balls)
 
         self.assertFalse(self.machine.ball_saves.default.enabled)
 
@@ -226,13 +227,16 @@ class TestBallSave(MpfTestCase):
         self.machine_run()
         self.post_event("enable1")
 
+        self.machine.playfield.add_ball()
+        self.advance_time_and_run(4)
+
         # ball save should be enabled now
         self.assertTrue(self.machine.ball_saves.default.enabled)
 
         # takes roughly 4s to get ball confirmed
         self.advance_time_and_run(4)
         self.assertNotEqual(None, self.machine.game)
-        self.assertEqual(1, self.machine.playfield.balls)
+        self.assertEqual(2, self.machine.playfield.balls)
         self.assertTrue(self.machine.ball_saves.default.enabled)
 
         # double drain

--- a/mpf/tests/test_BallSave.py
+++ b/mpf/tests/test_BallSave.py
@@ -213,7 +213,6 @@ class TestBallSave(MpfTestCase):
 
     def testBallDoubleDrain(self):
         # prepare game
-        self.machine.ball_controller.num_balls_known = 0
         self.machine.switch_controller.process_switch('s_ball_switch1', 1)
         self.advance_time_and_run(10)
         self.assertEqual(1, self.machine.ball_controller.num_balls_known)

--- a/mpf/tests/test_BallSearch.py
+++ b/mpf/tests/test_BallSearch.py
@@ -58,7 +58,7 @@ class TestBallSearch(MpfTestCase):
 
         self.machine.switch_controller.process_switch("s_start", 1)
         self.machine.switch_controller.process_switch("s_start", 0)
-        self.advance_time_and_run(1)
+        self.advance_time_and_run(2)
         self.assertNotEqual(None, self.machine.game)
         self.assertEqual(False, self.machine.ball_devices['playfield'].ball_search.enabled)
 
@@ -101,7 +101,7 @@ class TestBallSearch(MpfTestCase):
 
         self.machine.switch_controller.process_switch("s_start", 1)
         self.machine.switch_controller.process_switch("s_start", 0)
-        self.advance_time_and_run(1)
+        self.advance_time_and_run(2)
         self.assertNotEqual(None, self.machine.game)
         self.assertEqual(False, self.machine.ball_devices['playfield'].ball_search.enabled)
 

--- a/mpf/tests/test_GottliebTrough.py
+++ b/mpf/tests/test_GottliebTrough.py
@@ -41,7 +41,6 @@ class TestGottliebTrough(MpfTestCase):
         self.assertEqual('idle', self.machine.ball_devices.plunger._state)
 
     def test_boot_with_balls_in_drain_and_trough(self):
-        self.machine.ball_controller.num_balls_known = 0
         self.machine.coils.outhole.pulse = MagicMock()
         self.machine.coils.trough.pulse = MagicMock()
 

--- a/mpf/tests/test_Head2Head.py
+++ b/mpf/tests/test_Head2Head.py
@@ -56,6 +56,7 @@ class TestHead2Head(MpfTestCase):
     def testUnexpectedBallWithTransfer(self):
         # devices captures from one pf and ejects to another
         # tests target_on_unexpected_ball
+        self.machine.ball_controller.num_balls_known = 4
         self.machine.playfields.playfield_front.balls = 2
         self.machine.playfields.playfield_back.balls = 2
 
@@ -66,6 +67,7 @@ class TestHead2Head(MpfTestCase):
 
     def testUnexpectedBallWithRouting(self):
         # device captures and ejects to same pf but ball has to routed through trough
+        self.machine.ball_controller.num_balls_known = 4
         self.machine.playfields.playfield_front.balls = 2
         self.machine.playfields.playfield_back.balls = 2
 

--- a/mpf/tests/test_Head2Head.py
+++ b/mpf/tests/test_Head2Head.py
@@ -56,7 +56,7 @@ class TestHead2Head(MpfTestCase):
     def testUnexpectedBallWithTransfer(self):
         # devices captures from one pf and ejects to another
         # tests target_on_unexpected_ball
-        self.machine.ball_controller.num_balls_known = 4
+        self.set_num_balls_known(4)
         self.machine.playfields.playfield_front.balls = 2
         self.machine.playfields.playfield_back.balls = 2
 
@@ -67,9 +67,11 @@ class TestHead2Head(MpfTestCase):
 
     def testUnexpectedBallWithRouting(self):
         # device captures and ejects to same pf but ball has to routed through trough
-        self.machine.ball_controller.num_balls_known = 4
+        self.set_num_balls_known(4)
         self.machine.playfields.playfield_front.balls = 2
+        self.machine.playfields.playfield_front.available_balls = 2
         self.machine.playfields.playfield_back.balls = 2
+        self.machine.playfields.playfield_back.available_balls = 2
 
         self.hit_switch_and_run("s_launcher_lane_front", 1)
 

--- a/mpf/tests/test_Head2Head.py
+++ b/mpf/tests/test_Head2Head.py
@@ -58,12 +58,16 @@ class TestHead2Head(MpfTestCase):
         # tests target_on_unexpected_ball
         self.set_num_balls_known(4)
         self.machine.playfields.playfield_front.balls = 2
+        self.machine.playfields.playfield_front.available_balls = 2
         self.machine.playfields.playfield_back.balls = 2
+        self.machine.playfields.playfield_back.available_balls = 2
 
         self.hit_switch_and_run("s_middle_back1", 15)
 
         self.assertEqual(1, self.machine.playfields.playfield_front.balls)
+        self.assertEqual(1, self.machine.playfields.playfield_front.available_balls)
         self.assertEqual(3, self.machine.playfields.playfield_back.balls)
+        self.assertEqual(3, self.machine.playfields.playfield_back.available_balls)
 
     def testUnexpectedBallWithRouting(self):
         # device captures and ejects to same pf but ball has to routed through trough

--- a/mpf/tests/test_Playfield.py
+++ b/mpf/tests/test_Playfield.py
@@ -14,7 +14,7 @@ class TestPlayfield(MpfTestCase):
         return 'tests/machine_files/playfield/'
 
     def test_unexpected_ball_on_pf(self):
-        self.machine.ball_controller.num_balls_known = 1
+        self.set_num_balls_known(1)
         self.assertEqual(0, self.machine.ball_devices.playfield.balls)
         self.assertEqual(False, self.machine.config['machine']['glass_off_mode'])
 
@@ -25,7 +25,7 @@ class TestPlayfield(MpfTestCase):
         self.assertEqual(1, self.machine.ball_devices.playfield.balls)
 
     def test_unexpected_ball_on_pf_glass_off_mode(self):
-        self.machine.ball_controller.num_balls_known = 1
+        self.set_num_balls_known(1)
         self.machine.config['machine']['glass_off_mode'] = True
 
         self.assertEqual(0, self.machine.ball_devices.playfield.balls)

--- a/mpf/tests/test_Playfield.py
+++ b/mpf/tests/test_Playfield.py
@@ -23,6 +23,7 @@ class TestPlayfield(MpfTestCase):
         self.advance_time_and_run(.1)
 
         self.assertEqual(1, self.machine.ball_devices.playfield.balls)
+        self.assertEqual(1, self.machine.ball_devices.playfield.available_balls)
 
     def test_unexpected_ball_on_pf_glass_off_mode(self):
         self.set_num_balls_known(1)
@@ -36,3 +37,4 @@ class TestPlayfield(MpfTestCase):
         self.advance_time_and_run(.1)
 
         self.assertEqual(0, self.machine.ball_devices.playfield.balls)
+        self.assertEqual(0, self.machine.ball_devices.playfield.available_balls)

--- a/mpf/tests/test_Playfield.py
+++ b/mpf/tests/test_Playfield.py
@@ -14,6 +14,7 @@ class TestPlayfield(MpfTestCase):
         return 'tests/machine_files/playfield/'
 
     def test_unexpected_ball_on_pf(self):
+        self.machine.ball_controller.num_balls_known = 1
         self.assertEqual(0, self.machine.ball_devices.playfield.balls)
         self.assertEqual(False, self.machine.config['machine']['glass_off_mode'])
 
@@ -24,6 +25,7 @@ class TestPlayfield(MpfTestCase):
         self.assertEqual(1, self.machine.ball_devices.playfield.balls)
 
     def test_unexpected_ball_on_pf_glass_off_mode(self):
+        self.machine.ball_controller.num_balls_known = 1
         self.machine.config['machine']['glass_off_mode'] = True
 
         self.assertEqual(0, self.machine.ball_devices.playfield.balls)

--- a/mpf/tests/test_PlayfieldTransfer.py
+++ b/mpf/tests/test_PlayfieldTransfer.py
@@ -17,6 +17,7 @@ class TestPlayfieldTransfer(MpfTestCase):
         pf1 = self.machine.ball_devices['playfield1']
         pf2 = self.machine.ball_devices['playfield2']
 
+        self.machine.ball_controller.num_balls_known = 4
         pf1.balls = 2
         pf1.available_balls = 2
         pf2.balls = 2

--- a/mpf/tests/test_PlayfieldTransfer.py
+++ b/mpf/tests/test_PlayfieldTransfer.py
@@ -1,9 +1,5 @@
-import unittest
-
-from mpf.core.machine import MachineController
 from mpf.tests.MpfTestCase import MpfTestCase
-from mock import MagicMock
-import time
+
 
 class TestPlayfieldTransfer(MpfTestCase):
 
@@ -17,7 +13,7 @@ class TestPlayfieldTransfer(MpfTestCase):
         pf1 = self.machine.ball_devices['playfield1']
         pf2 = self.machine.ball_devices['playfield2']
 
-        self.machine.ball_controller.num_balls_known = 4
+        self.set_num_balls_known(4)
         pf1.balls = 2
         pf1.available_balls = 2
         pf2.balls = 2

--- a/mpf/tests/test_PlayfieldTransfer.py
+++ b/mpf/tests/test_PlayfieldTransfer.py
@@ -26,3 +26,4 @@ class TestPlayfieldTransfer(MpfTestCase):
         self.assertEqual(1, pf1.available_balls)
         self.assertEqual(3, pf2.balls)
         self.assertEqual(3, pf2.available_balls)
+

--- a/mpf/tests/test_TooLongExitCountDelay.py
+++ b/mpf/tests/test_TooLongExitCountDelay.py
@@ -21,6 +21,7 @@ class TestTooLongExitCountDelay(MpfTestCase):
         self.machine.switch_controller.process_switch('s_trough_4', 1)
         self.advance_time_and_run(1)
         self.assertEqual(4, self.machine.ball_devices.trough.balls)
+        self.assertEqual(0, self.machine.playfield.balls)
 
         self.trough_coil = self.machine.coils.trough_eject
         self.plunger_coil = self.machine.coils.plunger_eject

--- a/mpf/tests/test_TooLongExitCountDelay.py
+++ b/mpf/tests/test_TooLongExitCountDelay.py
@@ -1,6 +1,6 @@
-
 from mpf.tests.MpfTestCase import MpfTestCase
 from mock import MagicMock
+
 
 class TestTooLongExitCountDelay(MpfTestCase):
 
@@ -11,6 +11,7 @@ class TestTooLongExitCountDelay(MpfTestCase):
         return 'tests/machine_files/ball_device/'
 
     def _ball_drained(self, *kwargs):
+        del kwargs
         self._num_balls_drained += 1
 
     def put_four_balls_in_trough(self):

--- a/mpf/tests/test_TooLongExitCountDelay.py
+++ b/mpf/tests/test_TooLongExitCountDelay.py
@@ -14,7 +14,6 @@ class TestTooLongExitCountDelay(MpfTestCase):
         self._num_balls_drained += 1
 
     def put_four_balls_in_trough(self):
-        self.machine.ball_controller.num_balls_known = 4
         self.machine.switch_controller.process_switch('s_trough_1', 1)
         self.machine.switch_controller.process_switch('s_trough_2', 1)
         self.machine.switch_controller.process_switch('s_trough_3', 1)


### PR DESCRIPTION
prevents some ball search runs because of phantom balls. fixes multiple issues:
- available_balls were wrong with manual eject
- on failed balls we did not properly cancel the eject chain