### PR TITLE
Allow different types of leds

### DIFF
--- a/mpf/core/config_validator.py
+++ b/mpf/core/config_validator.py
@@ -433,6 +433,7 @@ leds:
     color_correction_profile: single|str|None
     fade_ms: single|int|None
     tags: list|str|None
+    type: single|lstr|rgb
     label: single|str|%
     debug: single|bool|False
     on_events:  dict|str:ms|None

--- a/mpf/core/platform.py
+++ b/mpf/core/platform.py
@@ -19,6 +19,7 @@ class BasePlatform(object):
         self.features['has_servos'] = False
         self.features['has_matrix_lights'] = False
         self.features['has_gis'] = False
+        self.features['has_leds'] = False
         self.features['has_switches'] = False
         self.features['has_drivers'] = False
 
@@ -151,9 +152,9 @@ class GiPlatform(BasePlatform):
 class LedPlatform(BasePlatform):
     def __init__(self, machine):
         super().__init__(machine)
-        self.features['has_gis'] = True
+        self.features['has_leds'] = True
 
-    def configure_led(self, config):
+    def configure_led(self, config, channels):
         """Subclass this method in a platform module to configure an LED.
 
         This method should return a reference to the LED's platform interface

--- a/mpf/core/platform.py
+++ b/mpf/core/platform.py
@@ -219,8 +219,6 @@ class DriverPlatform(BasePlatform):
         # these to notify the framework of the specific features it supports.
         self.features['has_drivers'] = True
         self.features['max_pulse'] = 255
-        self.features['hw_rule_coil_delay'] = False
-        self.features['variable_recycle_time'] = False
 
     def configure_driver(self, config):
         """Subclass this method in a platform module to configure a driver.

--- a/mpf/devices/led.py
+++ b/mpf/devices/led.py
@@ -343,7 +343,7 @@ class Led(SystemWideDevice):
 
             reordered_color = self._get_color_channels_for_hw(corrected_color)
 
-            self.hw_driver.color(RGBColor(tuple(reordered_color)))
+            self.hw_driver.color(reordered_color)
 
             if self.registered_handlers:
                 # Handlers are not sent color corrected colors

--- a/mpf/platforms/fast.py
+++ b/mpf/platforms/fast.py
@@ -20,7 +20,6 @@ from mpf.platforms.interfaces.rgb_led_platform_interface import RGBLEDPlatformIn
 from mpf.platforms.interfaces.matrix_light_platform_interface import MatrixLightPlatformInterface
 from mpf.platforms.interfaces.gi_platform_interface import GIPlatformInterface
 from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface
-from mpf.core.rgb_color import RGBColor
 
 try:
     import serial
@@ -1100,7 +1099,6 @@ class FASTDirectLED(RGBLEDPlatformInterface):
     def __init__(self, number):
         self.log = logging.getLogger('FASTLED')
         self.number = number
-        self._color_order_function = FASTDirectLED._color_rgb
         self._current_color = '000000'
 
         # All FAST LEDs are 3 element RGB and are set using hex strings
@@ -1108,63 +1106,15 @@ class FASTDirectLED(RGBLEDPlatformInterface):
         self.log.debug("Creating FAST RGB LED at hardware address: %s",
                        self.number)
 
-    @property
-    def color_order(self):
-        return {
-            FASTDirectLED._color_rgb: 'rgb',
-            FASTDirectLED._color_rbg: 'rbg',
-            FASTDirectLED._color_grb: 'grb',
-            FASTDirectLED._color_gbr: 'gbr',
-            FASTDirectLED._color_bgr: 'bgr',
-            FASTDirectLED._color_brg: 'brg'
-        }.get(self._color_order_function, 'error')
-
-    @color_order.setter
-    def color_order(self, order):
-        self._color_order_function = FASTDirectLED._determine_color_order_function(order)
-
-    @staticmethod
-    def _determine_color_order_function(order):
-        return {
-            'rgb': FASTDirectLED._color_rgb,
-            'rbg': FASTDirectLED._color_rbg,
-            'grb': FASTDirectLED._color_grb,
-            'gbr': FASTDirectLED._color_gbr,
-            'bgr': FASTDirectLED._color_bgr,
-            'brg': FASTDirectLED._color_brg
-        }.get(order, FASTDirectLED._color_rgb)
-
-    @staticmethod
-    def _color_rgb(color):
-        return color.hex
-
-    @staticmethod
-    def _color_rbg(color):
-        return RGBColor.rgb_to_hex((color.red, color.blue, color.green))
-
-    @staticmethod
-    def _color_grb(color):
-        return RGBColor.rgb_to_hex((color.green, color.red, color.blue))
-
-    @staticmethod
-    def _color_gbr(color):
-        return RGBColor.rgb_to_hex((color.green, color.blue, color.red))
-
-    @staticmethod
-    def _color_bgr(color):
-        return RGBColor.rgb_to_hex((color.blue, color.green, color.red))
-
-    @staticmethod
-    def _color_brg(color):
-        return RGBColor.rgb_to_hex((color.blue, color.red, color.green))
-
     def color(self, color):
         """Instantly sets this LED to the color passed.
 
         Args:
             color: an RGBColor object
         """
-        self._current_color = self._color_order_function(color)
+        self._current_color = "{0}{1}{2}".format(hex(int(color[0]))[2:].zfill(2),
+                                                 hex(int(color[1]))[2:].zfill(2),
+                                                 hex(int(color[2]))[2:].zfill(2))
 
     @property
     def current_color(self):

--- a/mpf/platforms/fast.py
+++ b/mpf/platforms/fast.py
@@ -545,7 +545,9 @@ class HardwarePlatform(ServoPlatform, MatrixLightsPlatform, GiPlatform,
 
         return switch
 
-    def configure_led(self, config):
+    def configure_led(self, config, channels):
+        if channels > 3:
+            raise AssertionError("FAST only supports RGB LEDs")
         if not self.rgb_connection:
             raise AssertionError('A request was made to configure a FAST LED, '
                                  'but no connection to an LED processor is '

--- a/mpf/platforms/fast.py
+++ b/mpf/platforms/fast.py
@@ -60,17 +60,6 @@ class HardwarePlatform(ServoPlatform, MatrixLightsPlatform, GiPlatform,
             raise AssertionError('Could not import "pySerial". This is '
                                  'required for the FAST platform interface')
 
-        # ----------------------------------------------------------------------
-        # Platform-specific hardware features. WARNING: Do not edit these. They
-        # are based on what the FAST hardware can and cannot do.
-        self.features['max_pulse'] = 255  # todo
-        self.features['hw_rule_coil_delay'] = True  # todo
-        self.features['variable_recycle_time'] = True  # todo
-        self.features['variable_debounce_time'] = True  # todo
-        # Make the platform features available to everyone
-        self.machine.config['platform'] = self.features
-        # ----------------------------------------------------------------------
-
         self.dmd_connection = None
         self.net_connection = None
         self.rgb_connection = None

--- a/mpf/platforms/interfaces/rgb_led_platform_interface.py
+++ b/mpf/platforms/interfaces/rgb_led_platform_interface.py
@@ -11,9 +11,9 @@ class RGBLEDPlatformInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def color(self, color):
         """
-        Sets the RGB LED to the specified color.
+        Sets the LED to the specified color.
         Args:
-            color: an RGBColor object
+            color: a list of int colors. one for each channel.
 
         Returns:
             None

--- a/mpf/platforms/new_platform_template.py
+++ b/mpf/platforms/new_platform_template.py
@@ -32,18 +32,6 @@ class HardwarePlatform(MatrixLightsPlatform, GiPlatform, DmdPlatform, LedPlatfor
         self.log.debug("Configuring template hardware interface.")
         self.initial_states_sent = False
 
-        # The following "features" are supposed to be constants that you can
-        # use to define was is or is not in your own platform. However they
-        # have not been implemented at this time. So for now just keep them
-        # as-is below and we'll deal with them in some future version of MPF.
-        self.features['max_pulse'] = 255
-        self.features['hw_rule_coil_delay'] = False
-        self.features['variable_recycle_time'] = False
-        self.features['variable_debounce_time'] = False
-
-        # Make the platform features available to everyone
-        self.machine.config['platform'] = self.features
-
     def __repr__(self):
         """String name you'd like to show up in logs and stuff when a
         reference to this platform is printed."""

--- a/mpf/platforms/openpixel.py
+++ b/mpf/platforms/openpixel.py
@@ -34,7 +34,9 @@ class HardwarePlatform(LedPlatform):
     def __repr__(self):
         return '<Platform.OpenPixel>'
 
-    def configure_led(self, config):
+    def configure_led(self, config, channels):
+        if channels > 3:
+            raise AssertionError("More channels not yet implemented")
 
         if not self.opc_client:
             self._setup_opc_client()

--- a/mpf/platforms/openpixel.py
+++ b/mpf/platforms/openpixel.py
@@ -70,7 +70,7 @@ class OpenPixelLED(RGBLEDPlatformInterface):
 
     def color(self, color):
         self.log.debug("Setting color: %s", color)
-        self.opc_client.set_pixel_color(self.channel, self.led, color.rgb)
+        self.opc_client.set_pixel_color(self.channel, self.led, color)
 
 
 class OpenPixelClient(object):

--- a/mpf/platforms/opp.py
+++ b/mpf/platforms/opp.py
@@ -543,7 +543,9 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
 
         return self.inpDict[config['number']]
 
-    def configure_led(self, config):
+    def configure_led(self, config, channels):
+        if channels > 3:
+            raise AssertionError("OPP only supports RGB LEDs")
         if not self.opp_connection:
             raise AssertionError("A request was made to configure an OPP LED, "
                                  "but no OPP connection is available")

--- a/mpf/platforms/opp.py
+++ b/mpf/platforms/opp.py
@@ -878,7 +878,9 @@ class OPPNeopixel(object):
             0-255 each.
         """
 
-        new_color = color.hex
+        new_color = "{0}{1}{2}".format(hex(int(color[0]))[2:].zfill(2),
+                                       hex(int(color[1]))[2:].zfill(2),
+                                       hex(int(color[2]))[2:].zfill(2))
         error = False
 
         # Check if this color exists in the color table

--- a/mpf/platforms/p3_roc.py
+++ b/mpf/platforms/p3_roc.py
@@ -36,20 +36,6 @@ class HardwarePlatform(PROCBasePlatform, I2cPlatform, AccelerometerPlatform):
         # validate config for p3_roc
         self.machine.config_validator.validate_config("p3_roc", self.machine.config['p_roc'])
 
-        # ----------------------------------------------------------------------
-        # Platform-specific hardware features. WARNING: Do not edit these. They
-        # are based on what the P3-ROC hardware can and cannot do.
-        self.features['max_pulse'] = 255
-        self.features['hw_rule_coil_delay'] = False
-        self.features['variable_recycle_time'] = False
-        self.features['variable_debounce_time'] = False
-        self.features['hw_led_fade'] = True
-        # todo need to add differences between patter and pulsed_patter
-
-        # Make the platform features available to everyone
-        self.machine.config['platform'] = self.features
-        # ----------------------------------------------------------------------
-
         if self.machine_type != self.pinproc.MachineTypePDB:
             raise AssertionError("P3-Roc can only handle PDB driver boards")
 

--- a/mpf/platforms/p_roc.py
+++ b/mpf/platforms/p_roc.py
@@ -40,20 +40,6 @@ class HardwarePlatform(PROCBasePlatform, DmdPlatform):
         # validate config for p_roc
         self.machine.config_validator.validate_config("p_roc", self.machine.config['p_roc'])
 
-        # ----------------------------------------------------------------------
-        # Platform-specific hardware features. WARNING: Do not edit these. They
-        # are based on what the P-ROC hardware can and cannot do.
-        self.features['max_pulse'] = 255
-        self.features['hw_rule_coil_delay'] = False
-        self.features['variable_recycle_time'] = False
-        self.features['variable_debounce_time'] = False
-        self.features['hw_led_fade'] = True
-        # todo need to add differences between patter and pulsed_patter
-
-        # Make the platform features available to everyone
-        self.machine.config['platform'] = self.features
-        # ----------------------------------------------------------------------
-
         self.dmd = None
 
         self.connect()

--- a/mpf/platforms/p_roc_common.py
+++ b/mpf/platforms/p_roc_common.py
@@ -210,8 +210,11 @@ class PROCBasePlatform(MatrixLightsPlatform, GiPlatform, LedPlatform, SwitchPlat
 
         return bool(coil_number)
 
-    def configure_led(self, config):
+    def configure_led(self, config, channels):
         """ Configures a P/P3-ROC RGB LED controlled via a PD-LED."""
+
+        if channels > 3:
+            raise AssertionError("More than 3 channels not yet implemented")
 
         # split the number (which comes in as a string like w-x-y-z) into parts
         number_parts = str(config['number']).split('-')

--- a/mpf/platforms/p_roc_common.py
+++ b/mpf/platforms/p_roc_common.py
@@ -746,7 +746,6 @@ class PDBLED(RGBLEDPlatformInterface):
         else:
             return value
 
-
     def color(self, color):
         """Instantly sets this LED to the color passed.
 
@@ -757,9 +756,9 @@ class PDBLED(RGBLEDPlatformInterface):
         # self.log.debug("Setting Color. Board: %s, Address: %s, Color: %s",
         #               self.board, self.address, color)
 
-        self.proc.led_color(self.board, self.address[0], self.normalise_color(color.red))
-        self.proc.led_color(self.board, self.address[1], self.normalise_color(color.green))
-        self.proc.led_color(self.board, self.address[2], self.normalise_color(color.blue))
+        self.proc.led_color(self.board, self.address[0], self.normalise_color(color[0]))
+        self.proc.led_color(self.board, self.address[1], self.normalise_color(color[1]))
+        self.proc.led_color(self.board, self.address[2], self.normalise_color(color[2]))
 
 
 def is_pdb_address(addr):

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -2,7 +2,7 @@
 
 import logging
 from mpf.core.platform import ServoPlatform, MatrixLightsPlatform, GiPlatform, LedPlatform, \
-                              SwitchPlatform, DriverPlatform, AccelerometerPlatform, I2cPlatform
+    SwitchPlatform, DriverPlatform, AccelerometerPlatform, I2cPlatform
 from mpf.core.utility_functions import Util
 from mpf.platforms.interfaces.rgb_led_platform_interface import RGBLEDPlatformInterface
 from mpf.platforms.interfaces.matrix_light_platform_interface import MatrixLightPlatformInterface
@@ -59,7 +59,7 @@ class HardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform, Matrix
 
                 initial_active_switches = [self.machine.switches[x].hw_switch.number for x in
                                            Util.string_to_list(
-                        self.machine.config['virtual_platform_start_active_switches'])]
+                                               self.machine.config['virtual_platform_start_active_switches'])]
 
                 for k in self.hw_switches:
                     if k in initial_active_switches:
@@ -129,7 +129,7 @@ class HardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform, Matrix
     def configure_matrixlight(self, config):
         return VirtualMatrixLight(config['number'])
 
-    def configure_led(self, config):
+    def configure_led(self, config, channels):
         return VirtualLED(config['number'])
 
     def configure_gi(self, config):

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -27,18 +27,6 @@ class HardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform, Matrix
         self.hw_switches = dict()
         self.initial_states_sent = False
 
-        # ----------------------------------------------------------------------
-        # Platform-specific hardware features. WARNING: Do not edit these. They
-        # are based on what the virtual hardware can and cannot do.
-        self.features['max_pulse'] = 255
-        self.features['hw_rule_coil_delay'] = False
-        self.features['variable_recycle_time'] = False
-        self.features['variable_debounce_time'] = False
-
-        # Make the platform features available to everyone
-        self.machine.config['platform'] = self.features
-        # ----------------------------------------------------------------------
-
     def __repr__(self):
         return '<Platform.Virtual>'
 

--- a/mpf/tests/machine_files/led/config/led.yaml
+++ b/mpf/tests/machine_files/led/config/led.yaml
@@ -2,4 +2,10 @@
 
 leds:
   led1:
-    number:
+    number: 1
+  led2:
+    number: 2, 3, 4
+    type: bgr
+  led3:
+    number: 7, 8, 9, 10
+    type: rgbw

--- a/mpf/tests/test_DeviceLED.py
+++ b/mpf/tests/test_DeviceLED.py
@@ -284,3 +284,20 @@ class TestLed(MpfTestCase):
     # TODO
     # color correction profiles
     # default fades
+
+    def test_non_rgb_leds(self):
+        # test bgr
+        led = self.machine.leds.led2
+
+        led.color(RGBColor((11, 23, 42)))
+        self.advance_time_and_run(1)
+
+        self.assertEqual(RGBColor((42, 23, 11)), led.hw_driver.current_color)
+
+        # test rgbw
+        led = self.machine.leds.led3
+
+        led.color(RGBColor((11, 23, 42)))
+        self.advance_time_and_run(1)
+
+        self.assertEqual(RGBColor((11, 23, 42, 11)), led.hw_driver.current_color)

--- a/mpf/tests/test_DeviceLED.py
+++ b/mpf/tests/test_DeviceLED.py
@@ -21,7 +21,7 @@ class TestLed(MpfTestCase):
         # need to advance time since LEDs are updated once per frame via a
         # clock.schedule_interval
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         color_setting = led1.stack[0]
@@ -38,7 +38,7 @@ class TestLed(MpfTestCase):
         # set to blue & test
         led1.color('blue')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         color_setting = led1.stack[0]
         self.assertEqual(color_setting['priority'], 0)
@@ -55,7 +55,7 @@ class TestLed(MpfTestCase):
         led1.color('green', priority=100)
 
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(len(led1.stack), 1)
         color_setting = led1.stack[0]
@@ -71,7 +71,7 @@ class TestLed(MpfTestCase):
         led1.color('orange', key='test')
 
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(len(led1.stack), 2)
         color_setting = led1.stack[0]
@@ -93,22 +93,22 @@ class TestLed(MpfTestCase):
         # test the stack ordering with different priorities & keys
         led1.color('red', priority=200, key='red')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         led1.color('blue', priority=300, key='blue')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         led1.color('green', priority=200, key='green')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         led1.color('orange', priority=100, key='orange')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         # verify the stack is right
@@ -122,7 +122,7 @@ class TestLed(MpfTestCase):
         # test that a replacement key slots in properly
         led1.color('red', priority=300, key='red')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(RGBColor('red'), led1.stack[0]['color'])
         self.assertEqual(RGBColor('blue'), led1.stack[1]['color'])
@@ -155,7 +155,7 @@ class TestLed(MpfTestCase):
         self.assertEqual(color_setting['dest_color'], RGBColor('red'))
         self.assertEqual(color_setting['color'], RGBColor((127, 0, 0)))
         self.assertIsNone(color_setting['key'])
-        self.assertEqual(RGBColor((127, 0, 0)),
+        self.assertEqual([127, 0, 0],
                          self.machine.leds.led1.hw_driver.current_color)
 
         # advance to after the fade is done
@@ -168,7 +168,7 @@ class TestLed(MpfTestCase):
         self.assertEqual(color_setting['dest_color'], RGBColor('red'))
         self.assertEqual(color_setting['color'], RGBColor('red'))
         self.assertIsNone(color_setting['key'])
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
     def test_interrupted_fade(self):
@@ -197,7 +197,7 @@ class TestLed(MpfTestCase):
         self.assertEqual(color_setting['dest_color'], RGBColor('red'))
         self.assertEqual(color_setting['color'], RGBColor((127, 0, 0)))
         self.assertIsNone(color_setting['key'])
-        self.assertEqual(RGBColor((127, 0, 0)),
+        self.assertEqual([127, 0, 0],
                          self.machine.leds.led1.hw_driver.current_color)
 
         # kill the fade
@@ -215,7 +215,7 @@ class TestLed(MpfTestCase):
         self.assertEqual(color_setting['dest_color'], RGBColor('red'))
         self.assertEqual(color_setting['color'], RGBColor((127, 0, 0)))
         self.assertIsNone(color_setting['key'])
-        self.assertEqual(RGBColor((127, 0, 0)),
+        self.assertEqual([127, 0, 0],
                          self.machine.leds.led1.hw_driver.current_color)
 
     def test_restore_to_fade_in_progress(self):
@@ -225,7 +225,7 @@ class TestLed(MpfTestCase):
         self.advance_time_and_run(1)
 
         # fade is 25% complete
-        self.assertEqual(RGBColor((63, 0, 0)),
+        self.assertEqual([63, 0, 0],
                          self.machine.leds.led1.hw_driver.current_color)
 
         # higher priority color which goes on top of fade (higher priority
@@ -233,20 +233,20 @@ class TestLed(MpfTestCase):
         # the same)
         led1.color('blue', key='test')
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertFalse(led1.fade_in_progress)
 
         led1.remove_from_stack_by_key('test')
         # should go back to the fade in progress, which is now 75% complete
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor((191, 0, 0)),
+        self.assertEqual([191, 0, 0],
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertTrue(led1.fade_in_progress)
 
         # go to 1 sec after fade and make sure it finished
         self.advance_time_and_run(2)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertFalse(led1.fade_in_progress)
 
@@ -260,7 +260,7 @@ class TestLed(MpfTestCase):
         self.advance_time_and_run(1)
 
         # fade is 25% complete
-        self.assertEqual(RGBColor((63, 0, 0)),
+        self.assertEqual([63, 0, 0],
                          self.machine.leds.led1.hw_driver.current_color)
 
         # start a blue 2s fade
@@ -272,12 +272,12 @@ class TestLed(MpfTestCase):
         # faded to blue, but meh, we'll handle that with alpha channels in the
         # future
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor((32, 0, 127)),
+        self.assertEqual([32, 0, 127],
                          self.machine.leds.led1.hw_driver.current_color)
 
         # advance past the end
         self.advance_time_and_run(2)
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertFalse(led1.fade_in_progress)
 
@@ -292,7 +292,7 @@ class TestLed(MpfTestCase):
         led.color(RGBColor((11, 23, 42)))
         self.advance_time_and_run(1)
 
-        self.assertEqual(RGBColor((42, 23, 11)), led.hw_driver.current_color)
+        self.assertEqual([42, 23, 11], led.hw_driver.current_color)
 
         # test rgbw
         led = self.machine.leds.led3
@@ -300,4 +300,4 @@ class TestLed(MpfTestCase):
         led.color(RGBColor((11, 23, 42)))
         self.advance_time_and_run(1)
 
-        self.assertEqual(RGBColor((11, 23, 42, 11)), led.hw_driver.current_color)
+        self.assertEqual([11, 23, 42, 11], led.hw_driver.current_color)

--- a/mpf/tests/test_LedPlayer.py
+++ b/mpf/tests/test_LedPlayer.py
@@ -51,15 +51,15 @@ class TestLedPlayer(MpfTestCase):
         # led_player just sets these colors and that's it.
         self.machine.events.post('event1')
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led1.stack[0]['priority'])
 
-        self.assertEqual(RGBColor('ff0000'),
+        self.assertEqual(list(RGBColor('ff0000').rgb),
                          self.machine.leds.led2.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led2.stack[0]['priority'])
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led3.stack[0]['priority'])
 
@@ -68,7 +68,7 @@ class TestLedPlayer(MpfTestCase):
         self.advance_time_and_run(1)
         self.advance_time_and_run(1)
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led1.stack[0]['priority'])
 
@@ -80,19 +80,19 @@ class TestLedPlayer(MpfTestCase):
         self.machine.events.post('event2')
         self.advance_time_and_run(.01)
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led1.stack[0]['priority'])
 
         # fade is half way from red to blue
-        self.assertEqual(RGBColor((128, 0, 127)),
+        self.assertEqual([128, 0, 127],
                          self.machine.leds.led2.hw_driver.current_color)
         self.assertEqual(100, self.machine.leds.led2.stack[0]['priority'])
 
         self.advance_time_and_run()
 
         # fade is done
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led2.hw_driver.current_color)
 
         # reset leds
@@ -101,15 +101,15 @@ class TestLedPlayer(MpfTestCase):
         self.machine.leds.led3.clear_stack()
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led1.stack[0]['priority'])
 
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led2.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led2.stack[0]['priority'])
 
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led3.stack[0]['priority'])
 
@@ -118,20 +118,20 @@ class TestLedPlayer(MpfTestCase):
 
         # fades are 500ms, so advance 250 and check
         self.advance_time_and_run(.25)
-        self.assertEqual(RGBColor((0, 127, 0)),
+        self.assertEqual([0, 127, 0],
                          self.machine.leds.led1.hw_driver.current_color)
-        self.assertEqual(RGBColor((0, 127, 0)),
+        self.assertEqual([0, 127, 0],
                          self.machine.leds.led2.hw_driver.current_color)
-        self.assertEqual(RGBColor((0, 127, 0)),
+        self.assertEqual([0, 127, 0],
                          self.machine.leds.led3.hw_driver.current_color)
 
         # finish the fade
         self.advance_time_and_run()
-        self.assertEqual(RGBColor((0, 255, 0)),
+        self.assertEqual([0, 255, 0],
                          self.machine.leds.led1.hw_driver.current_color)
-        self.assertEqual(RGBColor((0, 255, 0)),
+        self.assertEqual([0, 255, 0],
                          self.machine.leds.led2.hw_driver.current_color)
-        self.assertEqual(RGBColor((0, 255, 0)),
+        self.assertEqual([0, 255, 0],
                          self.machine.leds.led3.hw_driver.current_color)
 
         # reset leds
@@ -144,13 +144,13 @@ class TestLedPlayer(MpfTestCase):
         self.machine.events.post('event4')
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor((0, 255, 255)),
+        self.assertEqual([0, 255, 255],
                          self.machine.leds.led1.hw_driver.current_color)
-        self.assertEqual(RGBColor((0, 255, 255)),
+        self.assertEqual([0, 255, 255],
                          self.machine.leds.led2.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
 
     def test_single_step_show(self):
@@ -160,7 +160,7 @@ class TestLedPlayer(MpfTestCase):
         self.machine.shows['show1'].play()
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         # when a show ends with hold, the final step of the show will cache
@@ -173,7 +173,7 @@ class TestLedPlayer(MpfTestCase):
         self.machine.shows['show2'].play(loops=0, hold=True)
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         self.assertEqual(RGBColor('red'),
@@ -185,7 +185,7 @@ class TestLedPlayer(MpfTestCase):
         self.advance_time_and_run(.1)
 
         # led should be red while show is running
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         self.advance_time_and_run()
@@ -200,7 +200,7 @@ class TestLedPlayer(MpfTestCase):
         self.machine.shows['show2'].play()
         self.advance_time_and_run(.5)
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         # start show3 at same priority, leds should be blue
@@ -209,7 +209,7 @@ class TestLedPlayer(MpfTestCase):
         # again
         self.advance_time_and_run(.1)
 
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
     def test_show_higher_priority(self):
@@ -218,7 +218,7 @@ class TestLedPlayer(MpfTestCase):
         self.machine.shows['show2'].play()
         self.advance_time_and_run(.5)
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         # start show3 at same priority, leds should be blue
@@ -227,18 +227,18 @@ class TestLedPlayer(MpfTestCase):
         # again
         self.advance_time_and_run(.1)
 
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         # stop show3, leds should go back to red
         show3.stop()
         self.advance_time_and_run(.1)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
         # and they should stay red
         self.advance_time_and_run(.5)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
 
     def test_led_player_in_mode(self):
@@ -246,24 +246,24 @@ class TestLedPlayer(MpfTestCase):
         self.machine.events.post('event1')
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led2.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
 
         # post event5, nothing should change
         self.machine.events.post('event5')
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led1.stack[0]['priority'])
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led2.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led2.stack[0]['priority'])
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led3.stack[0]['priority'])
 
@@ -276,20 +276,20 @@ class TestLedPlayer(MpfTestCase):
         self.advance_time_and_run()
 
         # led1 was red @200, mode1 is @100, so should still be red @200
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led1.stack[0]['priority'])
         self.assertEqual(2, len(self.machine.leds.led1.stack))
 
         # led2 was red @0, so now it should be orange @100
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led2.hw_driver.current_color)
         self.assertEqual(100, self.machine.leds.led2.stack[0]['priority'])
         self.assertEqual(2, len(self.machine.leds.led2.stack))
 
         # led3 was red @0, mode1 led_player has led3 @200 which should be
         # added to the mode's base priority
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
         self.assertEqual(300, self.machine.leds.led3.stack[0]['priority'])
         self.assertEqual(2, len(self.machine.leds.led3.stack))
@@ -298,15 +298,15 @@ class TestLedPlayer(MpfTestCase):
         self.machine.modes['mode1'].stop()
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led1.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led1.stack[0]['priority'])
         self.assertEqual(1, len(self.machine.leds.led1.stack))
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led2.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led2.stack[0]['priority'])
         self.assertEqual(1, len(self.machine.leds.led2.stack))
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led3.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led3.stack[0]['priority'])
         self.assertEqual(1, len(self.machine.leds.led3.stack))

--- a/mpf/tests/test_ShotGroups.py
+++ b/mpf/tests/test_ShotGroups.py
@@ -278,82 +278,82 @@ class TestShotGroups(MpfTestCase):
 
         # advance the shots a bit
 
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_10.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_11.hw_driver.current_color)
 
         self.hit_and_release_switch('switch_10')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_10.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_11.hw_driver.current_color)
 
         self.hit_and_release_switch('switch_10')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_10.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_11.hw_driver.current_color)
 
         self.hit_and_release_switch('switch_11')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_10.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_11.hw_driver.current_color)
 
         # rotate
         self.machine.events.post('rotate_11_left')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_10.hw_driver.current_color)
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_11.hw_driver.current_color)
 
         # make sure they don't auto advance since the shows should be set to
         # manual advance
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_10.hw_driver.current_color)
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_11.hw_driver.current_color)
 
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_10.hw_driver.current_color)
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_11.hw_driver.current_color)
 
     def test_no_profile_in_shot_group_uses_profile_from_shot(self):
         self.start_game()
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_30.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_31.hw_driver.current_color)
 
         self.hit_and_release_switch('switch_30')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_30.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_31.hw_driver.current_color)
 
         self.hit_and_release_switch('switch_30')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_30.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_31.hw_driver.current_color)
 
         self.hit_and_release_switch('switch_31')
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_30.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_31.hw_driver.current_color)
 
     def test_control_events(self):
@@ -385,19 +385,19 @@ class TestShotGroups(MpfTestCase):
 
         # test advance event
         self.assertEqual(shot32.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_32.hw_driver.current_color)
         self.assertEqual(shot33.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_33.hw_driver.current_color)
 
         self.machine.events.post('group32_advance')
         self.advance_time_and_run()
         self.assertEqual(shot32.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot33.profiles[0]['current_state_name'], 'red')
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_32.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_33.hw_driver.current_color)
 
         # test reset event
@@ -405,9 +405,9 @@ class TestShotGroups(MpfTestCase):
         self.advance_time_and_run()
         self.assertEqual(shot32.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot33.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_32.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_33.hw_driver.current_color)
 
         # test rotate without rotation enabled
@@ -415,9 +415,9 @@ class TestShotGroups(MpfTestCase):
         self.advance_time_and_run()
         self.assertEqual(shot32.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot33.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_32.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_33.hw_driver.current_color)
         self.assertFalse(group32.rotation_enabled)
 
@@ -425,9 +425,9 @@ class TestShotGroups(MpfTestCase):
         self.advance_time_and_run()
         self.assertEqual(shot32.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot33.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_32.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_33.hw_driver.current_color)
 
         # test rotation enable
@@ -440,9 +440,9 @@ class TestShotGroups(MpfTestCase):
         self.advance_time_and_run()
         self.assertEqual(shot32.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot33.profiles[0]['current_state_name'], 'red')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_32.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_33.hw_driver.current_color)
 
         # test disable rotation
@@ -457,9 +457,9 @@ class TestShotGroups(MpfTestCase):
         # test that rotate did not happen
         self.assertEqual(shot32.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot33.profiles[0]['current_state_name'], 'red')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_32.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_33.hw_driver.current_color)
 
         # test disable event
@@ -484,11 +484,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot34.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot35.profiles[0]['current_state_name'], 'green')
         self.assertEqual(shot36.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_34.hw_driver.current_color)
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
             self.machine.leds.led_35.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_36.hw_driver.current_color)
 
         # rotate, only the red and green states should be rotated
@@ -497,11 +497,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot34.profiles[0]['current_state_name'], 'green')
         self.assertEqual(shot35.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot36.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
             self.machine.leds.led_34.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_35.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_36.hw_driver.current_color)
 
     def test_state_names_to_not_rotate(self):
@@ -519,11 +519,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot37.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot38.profiles[0]['current_state_name'], 'orange')
         self.assertEqual(shot39.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_37.hw_driver.current_color)
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_38.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_39.hw_driver.current_color)
 
         # rotate, only the red and green states should be rotated
@@ -532,11 +532,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot37.profiles[0]['current_state_name'], 'orange')
         self.assertEqual(shot38.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot39.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
             self.machine.leds.led_37.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_38.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_39.hw_driver.current_color)
 
     def test_rotation_pattern(self):
@@ -552,11 +552,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot40.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot41.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot42.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_40.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_41.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_42.hw_driver.current_color)
 
         group40.rotate()
@@ -564,11 +564,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot40.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot41.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot42.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_40.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_41.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_42.hw_driver.current_color)
 
         group40.rotate()
@@ -576,11 +576,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot40.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot41.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot42.profiles[0]['current_state_name'], 'red')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_40.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_41.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_42.hw_driver.current_color)
 
         group40.rotate()
@@ -588,11 +588,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot40.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot41.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot42.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_40.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_41.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_42.hw_driver.current_color)
 
         group40.rotate()
@@ -600,11 +600,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot40.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot41.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot42.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_40.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_41.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_42.hw_driver.current_color)
 
         group40.rotate()
@@ -612,11 +612,11 @@ class TestShotGroups(MpfTestCase):
         self.assertEqual(shot40.profiles[0]['current_state_name'], 'unlit')
         self.assertEqual(shot41.profiles[0]['current_state_name'], 'red')
         self.assertEqual(shot42.profiles[0]['current_state_name'], 'unlit')
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_40.hw_driver.current_color)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
             self.machine.leds.led_41.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.led_42.hw_driver.current_color)
 
     def test_block_in_shot_group_profile(self):
@@ -665,29 +665,29 @@ class TestShotGroups(MpfTestCase):
         self.machine.modes.mode_shot_groups.start()
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.l_gas_g.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.l_gas_a.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.l_gas_s.hw_driver.current_color)
 
         self.hit_and_release_switch('s_gas_g')
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('white'),
+        self.assertEqual(list(RGBColor('white').rgb),
             self.machine.leds.l_gas_g.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.l_gas_a.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.l_gas_s.hw_driver.current_color)
 
         self.machine.events.post('s_upper_left_flipper_active')
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.l_gas_g.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
             self.machine.leds.l_gas_a.hw_driver.current_color)
-        self.assertEqual(RGBColor('white'),
+        self.assertEqual(list(RGBColor('white').rgb),
             self.machine.leds.l_gas_s.hw_driver.current_color)

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -290,64 +290,64 @@ class TestShots(MpfTestCase):
 
     def test_default_show_led(self):
         self.start_game()
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led_1.hw_driver.current_color)
 
         self.hit_and_release_switch("switch_7")
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('white'),
+        self.assertEqual(list(RGBColor('white').rgb),
                          self.machine.leds.led_1.hw_driver.current_color)
 
     def test_default_show_leds(self):
         self.start_game()
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led_1.hw_driver.current_color)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led_2.hw_driver.current_color)
 
         self.hit_and_release_switch("switch_8")
         self.advance_time_and_run()
 
-        self.assertEqual(RGBColor('white'),
+        self.assertEqual(list(RGBColor('white').rgb),
                          self.machine.leds.led_1.hw_driver.current_color)
-        self.assertEqual(RGBColor('white'),
+        self.assertEqual(list(RGBColor('white').rgb),
                          self.machine.leds.led_2.hw_driver.current_color)
 
     def test_show_in_shot_profile_root(self):
         self.start_game()
 
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led_3.hw_driver.current_color)
 
         # make sure the show is not auto advancing
         self.advance_time_and_run(5)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led_3.hw_driver.current_color)
 
         self.advance_time_and_run(5)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led_3.hw_driver.current_color)
 
         self.hit_and_release_switch("switch_9")
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_3.hw_driver.current_color)
 
         self.hit_and_release_switch("switch_9")
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('yellow'),
+        self.assertEqual(list(RGBColor('yellow').rgb),
                          self.machine.leds.led_3.hw_driver.current_color)
 
         self.hit_and_release_switch("switch_9")
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led_3.hw_driver.current_color)
 
         # make sure it stays on green
 
         self.advance_time_and_run(5)
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led_3.hw_driver.current_color)
 
     def test_show_in_step(self):
@@ -355,23 +355,23 @@ class TestShots(MpfTestCase):
         # start_game() advances the time 1 sec, so by now we're already on
         # step 2 of the rainbow show
 
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_11.hw_driver.current_color)
 
         # make sure show is advancing on its own
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('yellow'),
+        self.assertEqual(list(RGBColor('yellow').rgb),
                          self.machine.leds.led_11.hw_driver.current_color)
 
         # hit the shot, changes to show1
         self.hit_and_release_switch("switch_11")
         self.advance_time_and_run(0.1)
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_11.hw_driver.current_color)
 
         # make sure show is advancing on its own
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_11.hw_driver.current_color)
 
     def test_combined_show_in_profile_root_and_step(self):
@@ -382,47 +382,47 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run()
 
         # we're on step 1
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # step 2
         self.hit_and_release_switch("switch_12")
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # since this is a root show, it should not be advancing on its own, so
         # advance the time a few times and make sure the led doesn't change
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # step 3 is rainbow 2 show, so make sure it switches
         self.hit_and_release_switch("switch_12")
         self.machine_run()
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # since this is a show in a step, it should be auto advancing, so keep
         # checking every sec to make sure the colors are changing
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('aquamarine'),
+        self.assertEqual(list(RGBColor('aquamarine').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('azure'),
+        self.assertEqual(list(RGBColor('azure').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # it should loop
@@ -430,28 +430,28 @@ class TestShots(MpfTestCase):
         # .5 because the time drifts due to how LEDs are updated and how the
         # advance_time_and_run() test method works
 
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # hit the switch, should advance to step 4, which is back to the
         # rainbow show
         self.hit_and_release_switch("switch_12")
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # show should not be advancing without a hit
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
         # hit to verify advance
         self.hit_and_release_switch("switch_12")
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led_12.hw_driver.current_color)
 
     def test_step_with_no_show_after_step_with_show(self):
@@ -461,33 +461,33 @@ class TestShots(MpfTestCase):
         # step 2 of the rainbow show
 
         # profile step 1, show1 is running
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_13.hw_driver.current_color)
 
         # step 2 has no show, so rainbow should still be running
         self.hit_and_release_switch("switch_13")
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('yellow'),
+        self.assertEqual(list(RGBColor('yellow').rgb),
                          self.machine.leds.led_13.hw_driver.current_color)
 
         # make sure it's still advancing even with no switch hits
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led_13.hw_driver.current_color)
 
         # hit the shot again, we switch to show 2
         self.hit_and_release_switch("switch_13")
         self.advance_time_and_run(0.1)
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_13.hw_driver.current_color)
 
         # make sure that show is running with no more hits
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_13.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('aquamarine'),
+        self.assertEqual(list(RGBColor('aquamarine').rgb),
                          self.machine.leds.led_13.hw_driver.current_color)
 
     def test_show_ending_no_loop(self):
@@ -497,29 +497,29 @@ class TestShots(MpfTestCase):
         # settings will work in a show tied to a shot.
 
         self.start_game()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_14.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('yellow'),
+        self.assertEqual(list(RGBColor('yellow').rgb),
                          self.machine.leds.led_14.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led_14.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led_14.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('purple'),
+        self.assertEqual(list(RGBColor('purple').rgb),
                          self.machine.leds.led_14.hw_driver.current_color)
 
         # show is done, but hold is true by default in shows started from shots
         # so make sure the led stays in its final state
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('purple'),
+        self.assertEqual(list(RGBColor('purple').rgb),
                          self.machine.leds.led_14.hw_driver.current_color)
 
     def test_control_events(self):
@@ -698,12 +698,12 @@ class TestShots(MpfTestCase):
 
         # start_game() includes a 1 sec advance time, so by now this show is
         # already on step 2
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
         # make sure the show keeps running
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('yellow'),
+        self.assertEqual(list(RGBColor('yellow').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
         # enable the shot
@@ -714,12 +714,12 @@ class TestShots(MpfTestCase):
             shot19.get_profile_by_key('mode', None)['settings']['show_when_disabled'])
 
         # show should still be at the same step
-        self.assertEqual(RGBColor('yellow'),
+        self.assertEqual(list(RGBColor('yellow').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
         # but it should also still be running
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('green'),
+        self.assertEqual(list(RGBColor('green').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
         # hit the shot
@@ -727,24 +727,24 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run(.1)
 
         # should switch to the second show
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
         # and that show should be running
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
         # disable the shot
         shot19.disable()
 
         # color should not change
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
         # and show should still be running
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('aquamarine'),
+        self.assertEqual(list(RGBColor('aquamarine').rgb),
                          self.machine.leds.led_19.hw_driver.current_color)
 
     def test_no_show_when_disabled(self):
@@ -756,7 +756,7 @@ class TestShots(MpfTestCase):
         self.assertFalse(shot20.enabled)
 
         # make sure the show is not running and not affecting the LED
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led_20.hw_driver.current_color)
 
         # enable the shot, show should start
@@ -766,24 +766,24 @@ class TestShots(MpfTestCase):
             shot20.get_profile_by_key('mode', None)['settings']['show_when_disabled'])
 
         self.advance_time_and_run(.1)
-        self.assertEqual(RGBColor('red'),
+        self.assertEqual(list(RGBColor('red').rgb),
                          self.machine.leds.led_20.hw_driver.current_color)
 
         # make sure show is advancing
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_20.hw_driver.current_color)
 
         # hit the shot, show should switch
         shot20.hit()
         self.advance_time_and_run(.1)
 
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_20.hw_driver.current_color)
 
         # and that show should be running
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_20.hw_driver.current_color)
 
         # disable the shot
@@ -791,7 +791,7 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run()
 
         # LEDs should be off since show_when_disabled == false
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led_20.hw_driver.current_color)
 
     def test_block(self):
@@ -871,43 +871,43 @@ class TestShots(MpfTestCase):
         shot23 = self.machine.shots.shot_23
 
         # make sure show is running from base config
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_23.hw_driver.current_color)
 
         # advance to make sure show is running
         self.advance_time_and_run()
-        self.assertEqual(RGBColor('yellow'),
+        self.assertEqual(list(RGBColor('yellow').rgb),
                          self.machine.leds.led_23.hw_driver.current_color)
 
         # start mode1, should flip to show 2 colors
         self.machine.modes.mode1.start()
         self.machine_run()
 
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_23.hw_driver.current_color)
 
         # advance to make sure show is running
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('antiquewhite'),
+        self.assertEqual(list(RGBColor('antiquewhite').rgb),
                          self.machine.leds.led_23.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('aquamarine'),
+        self.assertEqual(list(RGBColor('aquamarine').rgb),
                          self.machine.leds.led_23.hw_driver.current_color)
 
         # stop the mode, make sure the show from the base is still running
         self.machine.modes.mode1.stop()
         self.machine_run()
-        self.assertEqual(RGBColor('blue'),
+        self.assertEqual(list(RGBColor('blue').rgb),
                          self.machine.leds.led_23.hw_driver.current_color)
 
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('purple'),
+        self.assertEqual(list(RGBColor('purple').rgb),
                          self.machine.leds.led_23.hw_driver.current_color)
 
     def test_hold_true(self):
         self.start_game()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_24.hw_driver.current_color)
 
         # advance the time past the end of the show and make sure that the
@@ -924,12 +924,12 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run(1)
         self.advance_time_and_run(1)
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('purple'),
+        self.assertEqual(list(RGBColor('purple').rgb),
                          self.machine.leds.led_24.hw_driver.current_color)
 
     def test_hold_false(self):
         self.start_game()
-        self.assertEqual(RGBColor('orange'),
+        self.assertEqual(list(RGBColor('orange').rgb),
                          self.machine.leds.led_25.hw_driver.current_color)
 
         # advance the time past the end of the show and make sure that the
@@ -945,7 +945,7 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run(1)
         self.advance_time_and_run(1)
         self.advance_time_and_run(1)
-        self.assertEqual(RGBColor('off'),
+        self.assertEqual(list(RGBColor('off').rgb),
                          self.machine.leds.led_25.hw_driver.current_color)
 
     def test_hit_in_lower_priority_profile_with_higher_disabled_profile(self):
@@ -985,7 +985,7 @@ class TestShots(MpfTestCase):
         self.assertTrue(shot26.profiles[2]['enable'])  # base
 
         # make sure the led is a color from mode 1
-        self.assertEqual(RGBColor('aliceblue'),
+        self.assertEqual(list(RGBColor('aliceblue').rgb),
                          self.machine.leds.led_26.hw_driver.current_color)
 
         self.hit_and_release_switch('switch_26')

--- a/mpf/tests/test_Shows.py
+++ b/mpf/tests/test_Shows.py
@@ -90,10 +90,10 @@ class TestShows(MpfTestCase):
         self.assertEqual(running_show1.priority, 200)
 
         # Check LEDs, lights, and GI after first show step
-        self.assertEqual(RGBColor('006400'),
+        self.assertEqual(list(RGBColor('006400').rgb),
                          self.machine.leds.led_01.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_01.stack[0]['priority'])
-        self.assertEqual(RGBColor('CCCCCC'),
+        self.assertEqual(list(RGBColor('CCCCCC').rgb),
                          self.machine.leds.led_02.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_02.stack[0]['priority'])
         self.assertEqual(204,
@@ -107,11 +107,11 @@ class TestShows(MpfTestCase):
 
         # Check LEDs, lights, and GI after 2nd step
         self.advance_time_and_run(1.0)
-        self.assertEqual(RGBColor('DarkGreen'),
+        self.assertEqual(list(RGBColor('DarkGreen').rgb),
                          self.machine.leds.led_01.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_01.stack[0]['priority'])
 
-        self.assertEqual(RGBColor('Black'),
+        self.assertEqual(list(RGBColor('Black').rgb),
                          self.machine.leds.led_02.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_02.stack[0]['priority'])
         self.assertEqual(204,
@@ -125,10 +125,10 @@ class TestShows(MpfTestCase):
 
         # Check LEDs, lights, and GI after 3rd step
         self.advance_time_and_run(1.0)
-        self.assertEqual(RGBColor('DarkSlateGray'),
+        self.assertEqual(list(RGBColor('DarkSlateGray').rgb),
                          self.machine.leds.led_01.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_01.stack[0]['priority'])
-        self.assertEqual(RGBColor('Tomato'),
+        self.assertEqual(list(RGBColor('Tomato').rgb),
                          self.machine.leds.led_02.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_02.stack[0]['priority'])
         self.assertEqual(255,
@@ -145,10 +145,10 @@ class TestShows(MpfTestCase):
         # Check LEDs, lights, and GI after 4th step (includes a fade to next
         #  color)
         self.advance_time_and_run(1.0)
-        self.assertNotEqual(RGBColor('MidnightBlue'),
+        self.assertNotEqual(list(RGBColor('MidnightBlue').rgb),
                             self.machine.leds.led_01.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_01.stack[0]['priority'])
-        self.assertNotEqual(RGBColor('DarkOrange'),
+        self.assertNotEqual(list(RGBColor('DarkOrange').rgb),
                             self.machine.leds.led_02.hw_driver.current_color)
         self.assertEqual(200, self.machine.leds.led_02.stack[0]['priority'])
         self.assertEqual(255,
@@ -169,16 +169,16 @@ class TestShows(MpfTestCase):
         self.advance_time_and_run(0.1)
         self.advance_time_and_run(0.1)
         self.advance_time_and_run(0.1)
-        self.assertEqual(RGBColor('MidnightBlue'),
+        self.assertEqual(list(RGBColor('MidnightBlue').rgb),
                          self.machine.leds.led_01.hw_driver.current_color)
-        self.assertEqual(RGBColor('DarkOrange'),
+        self.assertEqual(list(RGBColor('DarkOrange').rgb),
                          self.machine.leds.led_02.hw_driver.current_color)
 
         # Check LEDs after 5th step (includes a fade to black/off)
         self.advance_time_and_run(0.4)
-        self.assertNotEqual(RGBColor('Off'),
+        self.assertNotEqual(list(RGBColor('Off').rgb),
                             self.machine.leds.led_01.hw_driver.current_color)
-        self.assertNotEqual(RGBColor('Off'),
+        self.assertNotEqual(list(RGBColor('Off').rgb),
                             self.machine.leds.led_02.hw_driver.current_color)
         self.assertNotEqual(0,
                             self.machine.lights.light_01.hw_driver.current_brightness)
@@ -191,9 +191,9 @@ class TestShows(MpfTestCase):
         self.advance_time_and_run(0.2)
         self.advance_time_and_run(0.2)
         self.advance_time_and_run(0.2)
-        self.assertEqual(RGBColor('Off'),
+        self.assertEqual(list(RGBColor('Off').rgb),
                          self.machine.leds.led_01.hw_driver.current_color)
-        self.assertEqual(RGBColor('Off'),
+        self.assertEqual(list(RGBColor('Off').rgb),
                          self.machine.leds.led_02.hw_driver.current_color)
         self.assertEqual(0,
                          self.machine.lights.light_01.hw_driver
@@ -205,9 +205,9 @@ class TestShows(MpfTestCase):
 
         # Make sure show loops back to the first step
         self.advance_time_and_run(1.1)
-        self.assertEqual(RGBColor('006400'),
+        self.assertEqual(list(RGBColor('006400').rgb),
                          self.machine.leds.led_01.hw_driver.current_color)
-        self.assertEqual(RGBColor('CCCCCC'),
+        self.assertEqual(list(RGBColor('CCCCCC').rgb),
                          self.machine.leds.led_02.hw_driver.current_color)
         self.assertEqual(204,
                          self.machine.lights.light_01.hw_driver
@@ -232,10 +232,10 @@ class TestShows(MpfTestCase):
         # Make sure the lights and LEDs have reverted back to their prior
         # states from before the show started
 
-        self.assertEqual(RGBColor(),
+        self.assertEqual(list(RGBColor().rgb),
                          self.machine.leds.led_01.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led_01.stack[0]['priority'])
-        self.assertEqual(RGBColor(),
+        self.assertEqual(list(RGBColor().rgb),
                          self.machine.leds.led_02.hw_driver.current_color)
         self.assertEqual(0, self.machine.leds.led_02.stack[0]['priority'])
         self.assertEqual(0,
@@ -361,8 +361,8 @@ class TestShows(MpfTestCase):
             show_tokens=dict(leds='led_01'))
         self.advance_time_and_run(.5)
 
-        self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
-                         RGBColor('red'))
+        self.assertEqual(list(RGBColor('red').rgb),
+                         self.machine.leds.led_01.hw_driver.current_color)
 
         # test passing tag instead of LED name
         self.machine.leds.led_01.clear_stack()
@@ -372,9 +372,9 @@ class TestShows(MpfTestCase):
             leds='tag1'))
         self.advance_time_and_run(.5)
         self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
-                         RGBColor('red'))
+                         list(RGBColor('red').rgb))
         self.assertEqual(self.machine.leds.led_02.hw_driver.current_color,
-                         RGBColor('red'))
+                         list(RGBColor('red').rgb))
 
         # test passing multiple LEDs as string list
         self.machine.leds.led_01.clear_stack()
@@ -384,9 +384,9 @@ class TestShows(MpfTestCase):
             leds='led_01, led_02'))
         self.advance_time_and_run(.5)
         self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
-                         RGBColor('red'))
+                         list(RGBColor('red').rgb))
         self.assertEqual(self.machine.leds.led_02.hw_driver.current_color,
-                         RGBColor('red'))
+                         list(RGBColor('red').rgb))
 
         # test passing color as a token
         self.machine.leds.led_01.clear_stack()
@@ -397,9 +397,9 @@ class TestShows(MpfTestCase):
             show_tokens=dict(color1='blue', color2='green'))
         self.advance_time_and_run(2)
         self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
-                         RGBColor('blue'))
+                         list(RGBColor('blue').rgb))
         self.assertEqual(self.machine.leds.led_02.hw_driver.current_color,
-                         RGBColor('green'))
+                         list(RGBColor('green').rgb))
 
         show.stop()
 
@@ -414,7 +414,7 @@ class TestShows(MpfTestCase):
 
         # show has fade of 1s, so after 0.5s it should be halfway to red
         self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
-                         RGBColor((127, 0, 0)))
+                         [127, 0, 0])
 
         # test tag in show with extended LED config
         self.machine.leds.led_01.clear_stack()
@@ -427,9 +427,9 @@ class TestShows(MpfTestCase):
 
         # show has fade of 1s, so after 0.5s it should be halfway to red
         self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
-                         RGBColor((127, 0, 0)))
+                         [127, 0, 0])
         self.assertEqual(self.machine.leds.led_02.hw_driver.current_color,
-                         RGBColor((127, 0, 0)))
+                         [127, 0, 0])
 
         # test single light in show
         self.machine.shows['lights_basic'].play(
@@ -476,7 +476,7 @@ class TestShows(MpfTestCase):
             show_tokens=dict(leds='led_01', lights='light_01'))
         self.advance_time_and_run(.5)
         self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
-                         RGBColor('blue'))
+                         list(RGBColor('blue').rgb))
         self.assertEqual(255,
             self.machine.lights.light_01.hw_driver.current_brightness)
 


### PR DESCRIPTION
Fixes #204. BGR and other channel order work with all platforms. Only "virtual/smart_virtual" supports leds with more than 3 channels so far. 