### PR TITLE
Refactor mode device loading

### DIFF
--- a/mpf/core/mode.py
+++ b/mpf/core/mode.py
@@ -44,6 +44,8 @@ class Mode(object):
 
         self._validate_mode_config()
 
+        self._create_mode_devices()
+
         self.configure_mode_settings(config.get('mode', dict()))
 
         self.auto_stop_on_ball_end = self.config['mode']['stop_on_ball_end']
@@ -173,8 +175,6 @@ class Mode(object):
         self.start_event_kwargs = kwargs
 
         self.log.info('Mode Starting. Priority: %s', self.priority)
-
-        self._create_mode_devices()
 
         self._add_mode_devices()
 

--- a/mpf/core/mode.py
+++ b/mpf/core/mode.py
@@ -374,7 +374,7 @@ class Mode(object):
     def _remove_mode_devices(self):
 
         for device in self.mode_devices:
-            device.remove()
+            device.device_removed_from_mode()
 
         self.mode_devices = set()
 
@@ -405,7 +405,7 @@ class Mode(object):
             device_list.add(device)
 
         for device in device_list:
-            device.control_events_in_mode(self)
+            device.add_control_events_in_mode(self)
 
     def _control_event_handler(self, callback, ms_delay=0, **kwargs):
         del kwargs

--- a/mpf/core/mode_device.py
+++ b/mpf/core/mode_device.py
@@ -8,13 +8,16 @@ class ModeDevice(Device):
         del player
         self._initialize()
 
-    def control_events_in_mode(self, mode):
+    def add_control_events_in_mode(self, mode):
         del mode
         # Called on mode start if this device has any control events in that mode
         # start mb if no enable_events are specified
         if "enable_events" in self.config and not self.config['enable_events']:
             self.enable()
 
-    def remove(self):
+    def remove_control_events_in_mode(self):
+        pass
+
+    def device_removed_from_mode(self):
         raise NotImplementedError(
-            '{} does not have a remove() method'.format(self.name))
+            '{} does not have a device_removed_from_mode() method'.format(self.name))

--- a/mpf/core/mode_device.py
+++ b/mpf/core/mode_device.py
@@ -18,6 +18,7 @@ class ModeDevice(Device):
     def remove_control_events_in_mode(self):
         pass
 
-    def device_removed_from_mode(self):
+    def device_removed_from_mode(self, mode):
+        del mode
         raise NotImplementedError(
             '{} does not have a device_removed_from_mode() method'.format(self.name))

--- a/mpf/devices/ball_lock.py
+++ b/mpf/devices/ball_lock.py
@@ -18,7 +18,7 @@ class BallLock(SystemWideDevice, ModeDevice):
         self.enabled = False
         self.lock_queue = deque()
 
-    def remove(self):
+    def device_removed_from_mode(self):
         self.disable()
 
     def prepare_config(self, config, is_mode_config):

--- a/mpf/devices/ball_lock.py
+++ b/mpf/devices/ball_lock.py
@@ -18,7 +18,8 @@ class BallLock(SystemWideDevice, ModeDevice):
         self.enabled = False
         self.lock_queue = deque()
 
-    def device_removed_from_mode(self):
+    def device_removed_from_mode(self, mode):
+        del mode
         self.disable()
 
     def prepare_config(self, config, is_mode_config):

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -170,7 +170,8 @@ class BallSave(SystemWideDevice, ModeDevice):
 
         return {'balls': balls - balls_to_save}
 
-    def device_removed_from_mode(self):
+    def device_removed_from_mode(self, mode):
+        del mode
         if self.debug:
             self.log.debug("Removing...")
 

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -170,7 +170,7 @@ class BallSave(SystemWideDevice, ModeDevice):
 
         return {'balls': balls - balls_to_save}
 
-    def remove(self):
+    def device_removed_from_mode(self):
         if self.debug:
             self.log.debug("Removing...")
 

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -302,5 +302,6 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
         not all down or not all up. This event is posted every time a member
         drop target changes but the overall bank is not not complete.'''
 
-    def remove(self):
+    def device_removed_from_mode(self):
+        # TODO implement this
         pass

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -302,6 +302,6 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
         not all down or not all up. This event is posted every time a member
         drop target changes but the overall bank is not not complete.'''
 
-    def device_removed_from_mode(self):
+    def device_removed_from_mode(self, mode):
         # TODO implement this
         pass

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -18,7 +18,7 @@ class Multiball(SystemWideDevice, ModeDevice):
         self.enabled = False
         self.shoot_again = False
 
-    def remove(self):
+    def device_removed_from_mode(self):
         # disable mb when mode ends
         self.disable()
 

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -18,7 +18,8 @@ class Multiball(SystemWideDevice, ModeDevice):
         self.enabled = False
         self.shoot_again = False
 
-    def device_removed_from_mode(self):
+    def device_removed_from_mode(self, mode):
+        del mode
         # disable mb when mode ends
         self.disable()
 

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -324,11 +324,11 @@ class Shot(ModeDevice, SystemWideDevice):
         self.player = None
         self.remove_profile_by_mode(None)
 
-    def control_events_in_mode(self, mode):
+    def add_control_events_in_mode(self, mode):
         enable = not mode.config['shots'][self.name]['enable_events']
         self.update_profile(enable=enable, mode=mode)
 
-    def remove(self):
+    def device_removed_from_mode(self):
         """Remove this shot device. Destroys it and removes it from the shots
         collection.
 

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -42,6 +42,9 @@ class Shot(ModeDevice, SystemWideDevice):
         # todo is this a hack??
         self.machine.events.add_handler('game_ended', self.disable)
 
+        # todo remove this hack
+        self._created_system_wide = False
+
     @property
     def enabled(self):
         return [x for x in self.profiles if x['enable']]
@@ -59,6 +62,7 @@ class Shot(ModeDevice, SystemWideDevice):
     def device_added_system_wide(self):
         # Called when a device is added system wide
         super().device_added_system_wide()
+        self._created_system_wide = True
 
         self.update_profile(profile=self.config['profile'], enable=False,
                             mode=None)
@@ -328,18 +332,19 @@ class Shot(ModeDevice, SystemWideDevice):
         enable = not mode.config['shots'][self.name]['enable_events']
         self.update_profile(enable=enable, mode=mode)
 
-    def device_removed_from_mode(self):
+    def device_removed_from_mode(self, mode):
         """Remove this shot device. Destroys it and removes it from the shots
         collection.
 
         """
+        del mode
+        if self._created_system_wide:
+            return
 
         self.debug_log("Removing...")
         self.disable()
         self._remove_switch_handlers()
         self._stop_shows()
-
-        del self.machine.shots[self.name]
 
     def hit(self, mode='default#$%', _wf=None, **kwargs):
         """Method which is called to indicate this shot was just hit. This

--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -49,7 +49,7 @@ class ShotGroup(ModeDevice, SystemWideDevice):
         if 'profile' in self.config:
             for shot in self.config['shots']:
                 shot.update_profile(profile=self.config['profile'],
-                                         mode=None)
+                                    mode=None)
 
     def device_added_to_mode(self, mode, player):
         super().device_added_to_mode(mode, player)
@@ -243,8 +243,8 @@ class ShotGroup(ModeDevice, SystemWideDevice):
 
         if not (self._enabled and self.rotation_enabled):
             self.debug_log("Received rotation request. "
-                               "Rotation Enabled: %s. Will NOT rotate",
-                               self.rotation_enabled)
+                           "Rotation Enabled: %s. Will NOT rotate",
+                           self.rotation_enabled)
 
             return
 
@@ -281,14 +281,12 @@ class ShotGroup(ModeDevice, SystemWideDevice):
 
         for shot in shot_list:
             try:
-                current_show_step = shot.get_profile_by_key('mode', mode)[
-                    'running_show'].next_step_index
+                current_show_step = shot.get_profile_by_key('mode', mode)['running_show'].next_step_index
             except AttributeError:
                 current_show_step = None
 
             shot_state_list.append(
-                (shot.player[shot.get_profile_by_key('mode',
-                mode)['settings']['player_variable']], current_show_step))
+                (shot.player[shot.get_profile_by_key('mode', mode)['settings']['player_variable']], current_show_step))
 
         if self.debug:
             self.log.debug('Rotating. Mode: %s, Direction: %s, Include states:'
@@ -298,8 +296,7 @@ class ShotGroup(ModeDevice, SystemWideDevice):
 
             for shot in shot_list:
                 shot.log.debug("This shot is part of a rotation event. Current"
-                               " state: %s", shot.get_profile_by_key(
-                    'mode', mode)['current_state_name'])
+                               " state: %s", shot.get_profile_by_key('mode', mode)['current_state_name'])
 
         # figure out which direction we're going to rotate
         if not direction:
@@ -384,7 +381,7 @@ class ShotGroup(ModeDevice, SystemWideDevice):
             self.machine.events.post(self.name + '_' + profile + '_' + state +
                                      '_complete')
 
-    def control_events_in_mode(self, mode):
+    def add_control_events_in_mode(self, mode):
         # called if any control_events for this shot_group exist in the mode
         # config, regardless of whether or not the shot_group device was
         # initially created in this mode
@@ -404,7 +401,7 @@ class ShotGroup(ModeDevice, SystemWideDevice):
 
                 shot.update_profile(profile=profile, enable=enable, mode=mode)
 
-    def remove(self):
+    def device_removed_from_mode(self):
         self.debug_log("Removing this shot group")
         self._enabled = False
         del self.machine.shot_groups[self.name]

--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -26,6 +26,9 @@ class ShotGroup(ModeDevice, SystemWideDevice):
         self.rotation_enabled = True
         self._enabled = False
 
+        # todo remove this hack
+        self._created_system_wide = False
+
     @property
     def enabled(self):
         return self._enabled
@@ -45,6 +48,8 @@ class ShotGroup(ModeDevice, SystemWideDevice):
     def device_added_system_wide(self):
         # Called when a device is added system wide
         super().device_added_system_wide()
+
+        self._created_system_wide = True
 
         if 'profile' in self.config:
             for shot in self.config['shots']:
@@ -401,7 +406,9 @@ class ShotGroup(ModeDevice, SystemWideDevice):
 
                 shot.update_profile(profile=profile, enable=enable, mode=mode)
 
-    def device_removed_from_mode(self):
+    def device_removed_from_mode(self, mode):
+        del mode
+        if self._created_system_wide:
+            return
         self.debug_log("Removing this shot group")
         self._enabled = False
-        del self.machine.shot_groups[self.name]

--- a/mpf/tests/test_BallLock.py
+++ b/mpf/tests/test_BallLock.py
@@ -39,6 +39,18 @@ class TestBallLock(MpfTestCase):
         # mode stopped. should ball_lock be disabled
         self.assertFalse(self.machine.ball_locks.lock_test2.enabled)
 
+        # start mode (again)
+        self.post_event("start_mode1")
+
+        # mode loaded. ball_lock2 should be enabled
+        self.assertTrue(self.machine.ball_locks.lock_test2.enabled)
+
+        # stop mode
+        self.post_event("stop_mode1")
+
+        # mode stopped. should ball_lock be disabled
+        self.assertFalse(self.machine.ball_locks.lock_test2.enabled)
+
     def test_lock_and_release_at_game_end(self):
         coil1 = self.machine.coils['eject_coil1']
         coil2 = self.machine.coils['eject_coil2']

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -38,12 +38,12 @@ class TestShots(MpfTestCase):
         self.assertIn('shot_4', self.machine.shots)
         self.assertIn('led_1', self.machine.shots)
 
-        self.assertNotIn('mode1_shot_1', self.machine.shots)
+        self.assertFalse(self.machine.shots.mode1_shot_1.enabled)
 
         # Start the mode and make sure those shots load
         self.machine.modes.mode1.start()
         self.advance_time_and_run()
-        self.assertIn('mode1_shot_1', self.machine.shots)
+        self.assertTrue(self.machine.shots.mode1_shot_1.enabled)
 
         self.assertIn('shot_1', self.machine.shots)
         self.assertIn('shot_2', self.machine.shots)
@@ -54,7 +54,7 @@ class TestShots(MpfTestCase):
         # Stop the mode and make sure those shots go away
         self.machine.modes.mode1.stop()
         self.advance_time_and_run()
-        self.assertNotIn('mode1_shot_1', self.machine.shots)
+        self.assertFalse(self.machine.shots.mode1_shot_1.enabled)
 
         self.assertIn('shot_1', self.machine.shots)
         self.assertIn('shot_2', self.machine.shots)
@@ -575,7 +575,7 @@ class TestShots(MpfTestCase):
         # mode1 is not active, so make sure none of the events from
         # mode1_shot_17
 
-        self.assertNotIn('mode1_shot_17', self.machine.shots)
+        self.assertFalse(self.machine.shots.mode1_shot_17.enabled)
         self.mock_event("mode1_shot_17_hit")
 
         # Also verify hit event does not register a hit


### PR DESCRIPTION
Properly add and remove devices from modes.

Shot and ShotGroups need some more. See #262.

Solved the loading part of #162. However, some double validation still occurs in ShotProfiles