### PR TITLE
Wpc tests for p roc

### DIFF
--- a/mpf/platforms/p_roc.py
+++ b/mpf/platforms/p_roc.py
@@ -145,7 +145,14 @@ class HardwarePlatform(PROCBasePlatform, DmdPlatform):
                 `7/5`. This `proc_num` is an int between 0 and 255.
 
         """
-        proc_num = self.pinproc.decode(self.machine_type, str(config['number']))
+        if self.machine_type == self.pinproc.MachineTypePDB:
+            proc_num = self.pdbconfig.get_proc_number("switch", str(config['number']))
+            if proc_num == -1:
+                raise AssertionError("Switch {} cannot be controlled by the P-ROC. ".format(
+                    str(config['number'])))
+
+        else:
+            proc_num = self.pinproc.decode(self.machine_type, str(config['number']))
         return self._configure_switch(config, proc_num)
 
     def get_hw_switch_states(self):

--- a/mpf/platforms/p_roc_common.py
+++ b/mpf/platforms/p_roc_common.py
@@ -9,14 +9,14 @@ from mpf.platforms.interfaces.gi_platform_interface import GIPlatformInterface
 from mpf.platforms.interfaces.matrix_light_platform_interface import MatrixLightPlatformInterface
 from mpf.platforms.interfaces.rgb_led_platform_interface import RGBLEDPlatformInterface
 
-try:
+try:    # pragma: no cover
     import pinproc
     pinproc_imported = True
 except ImportError:
     pinproc_imported = False
     pinproc = None
 
-if not pinproc_imported:
+if not pinproc_imported:    # pragma: no cover
     try:
         if sys.platform == 'darwin':
             from mpf.platforms.pinproc.osx import pinproc
@@ -69,7 +69,7 @@ class PROCBasePlatform(MatrixLightsPlatform, GiPlatform, LedPlatform, SwitchPlat
             try:
                 self.proc = pinproc.PinPROC(self.machine_type)
                 self.proc.reset(1)
-            except IOError:
+            except IOError:     # pragma: no cover
                 print("Retrying...")
                 time.sleep(1)
 
@@ -106,8 +106,8 @@ class PROCBasePlatform(MatrixLightsPlatform, GiPlatform, LedPlatform, SwitchPlat
             switch.hw_switch.hw_rules[self._get_event_type(not switch.invert, switch.config['debounce'])].append(
                 (switch.hw_switch.number, coil.hw_driver.number,
                  self.pinproc.driver_state_patter(
-                    coil.hw_driver.state(), coil.hw_driver.get_pwm_on_ms(coil), coil.hw_driver.get_pwm_off_ms(coil),
-                    coil.hw_driver.get_pulse_ms(coil), True))
+                     coil.hw_driver.state(), coil.hw_driver.get_pwm_on_ms(coil), coil.hw_driver.get_pwm_off_ms(coil),
+                     coil.hw_driver.get_pulse_ms(coil), True))
             )
         else:
             if not coil.config['allow_enable']:
@@ -115,7 +115,8 @@ class PROCBasePlatform(MatrixLightsPlatform, GiPlatform, LedPlatform, SwitchPlat
                     coil.hw_driver.number
                 ))
             switch.hw_switch.hw_rules[self._get_event_type(not switch.invert, switch.config['debounce'])].append(
-                (switch.hw_switch.number, coil.hw_driver.number, self.pinproc.driver_state_pulse(coil.hw_driver.state(), 0))
+                (switch.hw_switch.number, coil.hw_driver.number,
+                 self.pinproc.driver_state_pulse(coil.hw_driver.state(), 0))
             )
 
     def add_relase_disable_rule_to_switch(self, switch, coil):
@@ -580,7 +581,7 @@ class PDBSwitch(object):
         if upper_str.startswith('SD'):  # only P-ROC
             self.sw_type = 'dedicated'
             self.sw_number = int(upper_str[2:])
-        elif '/' in upper_str:  # only P-ROC
+        elif upper_str.count("/") == 1:  # only P-ROC
             self.sw_type = 'matrix'
             self.sw_number = self.parse_matrix_num(upper_str)
         else:   # only P3-Roc
@@ -920,7 +921,7 @@ class PROCGiString(GIPlatformInterface):
             brightness = 255
 
         # run the GIs at 50Hz
-        duty_on = int(brightness/12.75)
+        duty_on = int(brightness / 12.75)
         duty_off = 20 - duty_on
         self.proc.driver_patter(self.number,
                                 int(duty_on),

--- a/mpf/tests/machine_files/p3_roc/config/config.yaml
+++ b/mpf/tests/machine_files/p3_roc/config/config.yaml
@@ -9,7 +9,7 @@ switches:
     s_test_000:
         number: A0-B0-0
     s_test_001:
-        number: A0-B0-1
+        number: 0/0/1
     s_test:
         number: A1-B0-7
     s_test_no_debounce:

--- a/mpf/tests/machine_files/p_roc/config/config.yaml
+++ b/mpf/tests/machine_files/p_roc/config/config.yaml
@@ -3,7 +3,6 @@
 hardware:
     driverboards: pdb
     platform: p_roc
-    servo_controllers: i2c_servo_controller
 
 P_ROC:
   dmd_timing_cycles: 1, 2, 3, 4
@@ -20,6 +19,11 @@ switches:
         debounce: quick
     s_slingshot_test:
         number: 40
+    s_direct:
+        number: SD01
+    s_matrix:
+        number: 2/3
+
 
 coils:
     c_test:
@@ -34,22 +38,19 @@ coils:
         number: A0-B1-0
     c_test2:  # unused. just to configure bank 0
         number: A0-B0-0
+    c_direct:
+        number: C01
 
 autofire_coils:
     ac_slingshot_test:
         coil: c_slingshot_test
         switch: s_slingshot_test
 
-servo_controller:
-    address: 0x40
-
-servos:
-    servo1:
-        number: 3
-
 matrix_lights:
   test_pdb_light:
     number: C-A2-B0-0:R-A2-B1-0
+  test_direct_light:
+    number: L01
 
 gis:
   test_gi:

--- a/mpf/tests/machine_files/p_roc/config/wpc.yaml
+++ b/mpf/tests/machine_files/p_roc/config/wpc.yaml
@@ -1,0 +1,29 @@
+#config_version=4
+
+hardware:
+    driverboards: wpc
+    platform: p_roc
+
+switches:
+    s_test_fliptronics:
+        number: sf1
+    s_test_direct:
+        number: sd1
+    s_test_matrix:
+        number: s26
+
+coils:
+    c_test_direct:
+        number: c01
+        pulse_ms: 23
+    c_test_fliptronics:
+        number: fllm
+        pulse_ms: 23
+
+matrix_lights:
+  test_light:
+    number: l11
+
+gis:
+  test_gi_direct:
+    number: g01


### PR DESCRIPTION
fixes matrix switch syntax 0/6 for P-ROC (only when enabling pdb mode)