### PR TITLE
Fix bug with show token in led express config

### DIFF
--- a/mpf/config_players/led_player.py
+++ b/mpf/config_players/led_player.py
@@ -61,12 +61,9 @@ class LedPlayer(ConfigPlayer):
         value = str(value).replace(' ', '').lower()
         fade = 0
         if '-f' in value:
+            # Value contains both a color value and a fade value, parse it into
+            # its individual components
             composite_value = value.split('-f')
-
-            # test that the color is valid, but we don't save it now so we can
-            # dynamically set it later
-            RGBColor(RGBColor.string_to_rgb(composite_value[0]))
-
             value = composite_value[0]
             fade = Util.string_to_ms(composite_value[1])
 

--- a/mpf/tests/machine_files/shows/config/test_shows.yaml
+++ b/mpf/tests/machine_files/shows/config/test_shows.yaml
@@ -102,6 +102,14 @@ shows:
         led_02: red
     - time: 10s
       duration: 3s
+  leds_color_token_and_fade:
+    - time: 0
+      leds:
+        led_01: (color1)
+    - time: +1
+      leds:
+        led_02: (color2)-f900ms
+    - time: +1
 
 show_player:
   play_test_show1: test_show1

--- a/mpf/tests/test_Shows.py
+++ b/mpf/tests/test_Shows.py
@@ -357,6 +357,7 @@ class TestShows(MpfTestCase):
     def test_tokens_in_shows(self):
         self.assertIn('leds_name_token', self.machine.shows)
         self.assertIn('leds_color_token', self.machine.shows)
+        self.assertIn('leds_color_token_and_fade', self.machine.shows)
         self.assertIn('leds_extended', self.machine.shows)
         self.assertIn('lights_basic', self.machine.shows)
         self.assertIn('multiple_tokens', self.machine.shows)
@@ -403,6 +404,17 @@ class TestShows(MpfTestCase):
         self.advance_time_and_run()
 
         show = self.machine.shows['leds_color_token'].play(
+            show_tokens=dict(color1='blue', color2='green'))
+        self.advance_time_and_run(2)
+        self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,
+                         list(RGBColor('blue').rgb))
+        self.assertEqual(self.machine.leds.led_02.hw_driver.current_color,
+                         list(RGBColor('green').rgb))
+
+        show.stop()
+
+        # Test passing color as a token and include a fade string in express config
+        show = self.machine.shows['leds_color_token_and_fade'].play(
             show_tokens=dict(color1='blue', color2='green'))
         self.advance_time_and_run(2)
         self.assertEqual(self.machine.leds.led_01.hw_driver.current_color,


### PR DESCRIPTION
Fixed bug with show tokens in led express config when also providing a
fade value (ex: (secondcolor)-f500ms).  Added test to catch bug.
