### PR TITLE
Added default color correction profile

### DIFF
--- a/mpf/core/rgb_color.py
+++ b/mpf/core/rgb_color.py
@@ -498,6 +498,30 @@ class RGBColorCorrectionProfile(object):
                 # Clamp the lookup table value between 0 and 255
                 self._lookup_table[channel][index] = max(0, min(value, 255))
 
+    def assign_channel_lookup_table_values(self, channel, table_values):
+        """
+        Assigns the specified lookup table values to the profile channel
+        Args:
+            channel: The channel number (0..2)
+            table_values: A list of 256 integer values between 0 and 255
+
+        """
+
+        if channel not in range(3):
+            raise ValueError('Invalid channel number in color correction profile')
+
+        if not isinstance(table_values, list) or len(table_values) != 256:
+            raise TypeError('Invalid lookup table values type for color correction profile - '
+                            'must be a list of 256 integer values')
+
+        for index in range(256):
+            value = table_values[index]
+            if not isinstance(value, int) or value < 0 or value > 255:
+                raise ValueError('Invalid value in color correction profile channel lookup table - '
+                                 'must be integers between 0 and 255')
+
+            self._lookup_table[channel][index] = value
+
     @property
     def name(self):
         """
@@ -520,3 +544,38 @@ class RGBColorCorrectionProfile(object):
         return RGBColor((self._lookup_table[0][color.red],
                          self._lookup_table[1][color.green],
                          self._lookup_table[2][color.blue]))
+
+    @staticmethod
+    def default():
+        """Creates a default profile (gamma-corrected).
+
+        The values for this table come from a web article:
+        https://learn.adafruit.com/led-tricks-gamma-correction/the-quick-fix
+        """
+
+        default_profile = RGBColorCorrectionProfile('default')
+
+        # Create standard gamma correction lookup table values
+        table = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2,
+                 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5,
+                 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10,
+                 10, 10, 11, 11, 11, 12, 12, 13, 13, 13, 14, 14, 15, 15, 16, 16,
+                 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22, 23, 24, 24, 25,
+                 25, 26, 27, 27, 28, 29, 29, 30, 31, 32, 32, 33, 34, 35, 35, 36,
+                 37, 38, 39, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 50,
+                 51, 52, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 67, 68,
+                 69, 70, 72, 73, 74, 75, 77, 78, 79, 81, 82, 83, 85, 86, 87, 89,
+                 90, 92, 93, 95, 96, 98, 99, 101, 102, 104, 105, 107, 109, 110, 112, 114,
+                 115, 117, 119, 120, 122, 124, 126, 127, 129, 131, 133, 135, 137, 138, 140, 142,
+                 144, 146, 148, 150, 152, 154, 156, 158, 160, 162, 164, 167, 169, 171, 173, 175,
+                 177, 180, 182, 184, 186, 189, 191, 193, 196, 198, 200, 203, 205, 208, 210, 213,
+                 215, 218, 220, 223, 225, 228, 231, 233, 236, 239, 241, 244, 247, 249, 252, 255]
+
+        # Assign the color correction profile channel lookup table values
+        default_profile.assign_channel_lookup_table_values(0, table)
+        default_profile.assign_channel_lookup_table_values(1, table)
+        default_profile.assign_channel_lookup_table_values(2, table)
+
+        return default_profile

--- a/mpf/devices/led.py
+++ b/mpf/devices/led.py
@@ -17,6 +17,7 @@ class Led(SystemWideDevice):
 
     @classmethod
     def device_class_init(cls, machine):
+        """Class initializer method"""
 
         cls.machine = machine
 
@@ -28,6 +29,12 @@ class Led(SystemWideDevice):
 
         # Generate and add color correction profiles to the machine
         machine.led_color_correction_profiles = dict()
+
+        # Create the default color correction profile and add it to the machine
+        default_profile = RGBColorCorrectionProfile.default()
+        machine.led_color_correction_profiles['default'] = default_profile
+
+        # Add any user-defined profiles specified in the machine config file
         for profile_name, profile_parameters in (
                 machine.config['led_settings']
                 ['color_correction_profiles'].items()):

--- a/mpf/devices/led.py
+++ b/mpf/devices/led.py
@@ -143,11 +143,11 @@ class Led(SystemWideDevice):
                 if profile is not None:
                     self.set_color_correction_profile(profile)
             else:
-                self.log.warning(
-                    "Color correction profile '%s' was specified for the LED"
-                    " but the color correction profile does not exist."
-                    " Color correction will not be applied to this LED.",
-                    self.config['color_correction_profile'])
+                error = "Color correction profile '{}' was specified for LED '{}'"\
+                        " but the color correction profile does not exist."\
+                    .format(self.config['color_correction_profile'], self.name)
+                self.log.error(error)
+                raise ValueError(error)
 
         if self.config['fade_ms'] is not None:
             self.default_fade_ms = self.config['fade_ms']

--- a/mpf/tests/machine_files/asset_manager/config/test_asset_loading.yaml
+++ b/mpf/tests/machine_files/asset_manager/config/test_asset_loading.yaml
@@ -3,10 +3,8 @@
 leds:
     led_01:
         number: 0
-        color_correction_profile: default
     led_02:
         number: 1
-        color_correction_profile: default
 
 matrix_lights:
     light_01:

--- a/mpf/tests/machine_files/device/config/config.yaml
+++ b/mpf/tests/machine_files/device/config/config.yaml
@@ -3,7 +3,6 @@
 leds:
     led_01:
         number: 0
-        color_correction_profile: default
     led_02:
         number: 1
         color_correction_profile: correction_profile_1

--- a/mpf/tests/machine_files/shows/config/test_shows.yaml
+++ b/mpf/tests/machine_files/shows/config/test_shows.yaml
@@ -8,11 +8,9 @@ modes:
 leds:
     led_01:
         number: 0
-        color_correction_profile: default
         tags: tag1
     led_02:
         number: 1
-        color_correction_profile: default
         tags: tag1
     led_03:
         number: 2

--- a/mpf/tests/test_RGBColor.py
+++ b/mpf/tests/test_RGBColor.py
@@ -93,6 +93,13 @@ class TestRGBColor(unittest.TestCase):
         corrected_color = color_correction_profile.apply(color)
         self.assertEqual((77, 67, 77), corrected_color.rgb)
 
+        # Test default correction profile
+        default_profile = RGBColorCorrectionProfile.default()
+        corrected_color = default_profile.apply(color)
+        self.assertEqual((81, 81, 81), corrected_color.rgb)
+        corrected_color = default_profile.apply(RGBColor((254, 254, 254)))
+        self.assertEqual((252, 252, 252), corrected_color.rgb)
+
     def test_init_and_equal(self):
         black = RGBColor("black")
         color = RGBColor(red=1, green=2, blue=3)


### PR DESCRIPTION
Added new 'default' color correction profile (and associated tests).  These changes add the profile to the machine, but do not automatically associate it with any led devices. It can be overridden by the user in their machine config.

This addresses issue #370.

You can decide whether or not to pull this into 0.30 (even though it is a new feature, although very limited in scope) or wait for 0.31.
