### PR TITLE
Test machine vars

### DIFF
--- a/mpf/core/data_manager.py
+++ b/mpf/core/data_manager.py
@@ -11,6 +11,8 @@ from mpf.core.file_manager import FileManager
 
 class DataManager(object):
 
+    """Handles key value data loading and saving for the machine."""
+
     def __init__(self, machine, name):
         """
         The DataManager is responsible for reading and writing data to/from a
@@ -131,6 +133,7 @@ class DataManager(object):
         self.save_all(delay_secs=delay_secs)
 
     def remove_key(self, key):
+        """Remove key by name."""
         try:
             del self.data[key]
             self.save_all()
@@ -139,4 +142,9 @@ class DataManager(object):
 
     def _writing_thread(self, data):
         self.log.debug("Writing %s to: %s", self.name, self.filename)
-        FileManager.save(self.filename, data)
+        # save to temp file and move afterwards. prevents broken files
+        temp_file = os.path.dirname(self.filename) + os.sep + "_" + os.path.basename(self.filename)
+        FileManager.save(temp_file, data)
+
+        # move temp file
+        os.rename(temp_file, self.filename)

--- a/mpf/core/data_manager.py
+++ b/mpf/core/data_manager.py
@@ -143,7 +143,7 @@ class DataManager(object):
         except KeyError:
             pass
 
-    def _writing_thread(self):
+    def _writing_thread(self):  # pragma: no cover
         while not self.machine.thread_stopper.is_set():
             if not self._dirty.wait(1):
                 continue

--- a/mpf/core/file_manager.py
+++ b/mpf/core/file_manager.py
@@ -160,10 +160,17 @@ class FileManager(object):
 
     @staticmethod
     def save(filename, data, **kwargs):
+        """Save data to file."""
         ext = os.path.splitext(filename)[1]
 
+        # save to temp file and move afterwards. prevents broken files
+        temp_file = os.path.dirname(filename) + os.sep + "_" + os.path.basename(filename)
+
         try:
-            FileManager.file_interfaces[ext].save(filename, data,
+            FileManager.file_interfaces[ext].save(temp_file, data,
                                                   **kwargs)
         except KeyError:
             raise AssertionError("No config file processor available for file type {}".format(ext))
+
+        # move temp file
+        os.rename(temp_file, filename)

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -222,8 +222,16 @@ class MachineController(object):
             self.log.debug("Registering %s", entry_point)
             entry_point.load()(self)
 
+    def create_data_manager(self, config_name):
+        """Return a new DataManager for a certain config.
+
+        Args:
+            config_name: Name of the config
+        """
+        return DataManager(self, config_name)
+
     def _load_machine_vars(self):
-        self.machine_var_data_manager = DataManager(self, 'machine_vars')
+        self.machine_var_data_manager = self.create_data_manager('machine_vars')
 
         current_time = self.clock.get_time()
 

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -238,7 +238,7 @@ class MachineController(object):
         for name, settings in (
                 iter(self.machine_var_data_manager.get_data().items())):
 
-            if not isinstance(settings, dict):
+            if not isinstance(settings, dict) or "value" not in settings:
                 continue
 
             if ('expire' in settings and settings['expire'] and

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -238,6 +238,9 @@ class MachineController(object):
         for name, settings in (
                 iter(self.machine_var_data_manager.get_data().items())):
 
+            if not isinstance(settings, dict):
+                continue
+
             if ('expire' in settings and settings['expire'] and
                     settings['expire'] < current_time):
 

--- a/mpf/modes/credits/code/credits.py
+++ b/mpf/modes/credits/code/credits.py
@@ -1,7 +1,6 @@
 """Contains the Credit (coin play) mode code"""
 
 from math import floor
-from mpf.core.data_manager import DataManager
 
 from mpf.core.mode import Mode
 
@@ -21,7 +20,7 @@ class Credits(Mode):
         super().__init__(machine, config, name, path)
 
     def mode_init(self):
-        self.data_manager = DataManager(self.machine, 'earnings')
+        self.data_manager = self.machine.create_data_manager('earnings')
         self.earnings = self.data_manager.get_data()
 
         self.credit_units_per_game = 0

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -1,7 +1,6 @@
 """Contains the High Score mode code"""
 
 from collections import OrderedDict
-from mpf.core.data_manager import DataManager
 from mpf.core.mode import Mode
 from mpf.core.player import Player
 
@@ -17,7 +16,7 @@ class HighScore(Mode):
         super().__init__(machine, config, name, path)
 
     def mode_init(self):
-        self.data_manager = DataManager(self.machine, 'high_scores')
+        self.data_manager = self.machine.create_data_manager('high_scores')
         self.high_scores = self.data_manager.get_data()
 
         self.high_score_config = self.machine.config_validator.validate_config(

--- a/mpf/plugins/auditor.py
+++ b/mpf/plugins/auditor.py
@@ -2,7 +2,6 @@
 etc."""
 
 import logging
-from mpf.core.data_manager import DataManager
 from mpf.devices.shot import Shot
 
 
@@ -35,7 +34,7 @@ class Auditor(object):
         disable() methods.
         """
 
-        self.data_manager = DataManager(self.machine, 'audits')
+        self.data_manager = self.machine.create_data_manager('audits')
 
         self.machine.events.add_handler('init_phase_4', self._initialize)
 

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -152,7 +152,6 @@ class MpfTestCase(unittest.TestCase):
         self.loop.run_until_complete(asyncio.sleep(delay=delta, loop=self.loop))
 
     def machine_run(self):
-        #self.machine.events.process_event_queue()
         self.advance_time_and_run(0)
 
     def unittest_verbosity(self):

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -11,11 +11,12 @@ from unittest.mock import *
 
 import asyncio
 import ruamel.yaml as yaml
+
+from mpf.tests.TestDataManager import TestDataManager
 from mpf.tests.loop import TimeTravelLoop, TestClock
 
 import mpf.core
 import mpf.core.config_validator
-from mpf.core.data_manager import DataManager
 from mpf.core.machine import MachineController
 from mpf.core.utility_functions import Util
 from mpf.file_interfaces.yaml_interface import YamlInterface
@@ -40,13 +41,17 @@ class TestMachineController(MachineController):
 
     local_mpf_config_cache = {}
 
-    def __init__(self, mpf_path, machine_path, options, config_patches, clock,
+    def __init__(self, mpf_path, machine_path, options, config_patches, clock, mock_data,
                  enable_plugins=False):
         self.test_config_patches = config_patches
         self.test_init_complete = False
         self._enable_plugins = enable_plugins
         self._test_clock = clock
+        self._mock_data = mock_data
         super().__init__(mpf_path, machine_path, options)
+
+    def create_data_manager(self, config_name):
+        return TestDataManager(self._mock_data.get(config_name, {}))
 
     def _load_clock(self):
         return self._test_clock
@@ -79,7 +84,6 @@ class MpfTestCase(unittest.TestCase):
         self.machine_config_patches = dict()
         self.machine_config_patches['mpf'] = dict()
         self.machine_config_patches['mpf']['default_platform_hz'] = 100
-        self.machine_config_patches['mpf']['save_machine_vars_to_disk'] = False
         self.machine_config_patches['mpf']['plugins'] = list()
         self.machine_config_patches['bcp'] = []
         self._last_event_kwargs = {}
@@ -185,27 +189,9 @@ class MpfTestCase(unittest.TestCase):
         # restore sys path
         sys.path = self._sys_path
 
-    def _get_data(self, section=None):
-        del section
+    def _get_mock_data(self):
+        """Return data for MockDataMangager in test."""
         return dict()
-
-    def _setup_file(self):
-        pass
-
-    def _save_all(self, data=None, delay_secs=0):
-        pass
-
-    def _mock_data_manager(self):
-        self._data_manager = (DataManager._setup_file, DataManager.save_all, DataManager.get_data)
-
-        DataManager._setup_file = self._setup_file
-        DataManager.save_all = self._save_all
-        DataManager.get_data = self._get_data
-
-    def _unmock_data_manager(self):
-        DataManager._setup_file = self._data_manager[0]
-        DataManager.save_all = self._data_manager[1]
-        DataManager.get_data = self._data_manager[2]
 
     def _mock_loop(self):
         pass
@@ -234,8 +220,6 @@ class MpfTestCase(unittest.TestCase):
         # init machine
         machine_path = self.getAbsoluteMachinePath()
 
-        self._mock_data_manager()
-
         self.loop = TimeTravelLoop()
         self.clock = TestClock(self.loop)
         self._mock_loop()
@@ -244,7 +228,7 @@ class MpfTestCase(unittest.TestCase):
             self.machine = TestMachineController(
                 os.path.abspath(os.path.join(
                     mpf.core.__path__[0], os.pardir)), machine_path,
-                self.getOptions(), self.machine_config_patches, self.clock,
+                self.getOptions(), self.machine_config_patches, self.clock, self._get_mock_data(),
                 self.get_enable_plugins())
 
             start = time.time()
@@ -312,7 +296,6 @@ class MpfTestCase(unittest.TestCase):
         self.machine.clock.loop.close()
         self.machine = None
 
-        self._unmock_data_manager()
         self.restore_sys_path()
 
     def add_to_config_validator(self, key, new_dict):

--- a/mpf/tests/TestDataManager.py
+++ b/mpf/tests/TestDataManager.py
@@ -1,0 +1,11 @@
+"""In-memory DataManager."""
+from mpf.core.data_manager import DataManager
+
+
+class TestDataManager(DataManager):
+
+    def __init__(self, data):
+        self.data = data
+
+    def save_all(self, data=None, delay_secs=0):
+        pass

--- a/mpf/tests/test_Auditor.py
+++ b/mpf/tests/test_Auditor.py
@@ -1,17 +1,5 @@
 from mpf.plugins.auditor import Auditor
 from mpf.tests.MpfTestCase import MpfTestCase
-from unittest.mock import patch, MagicMock
-from mpf.plugins import auditor
-
-class TestDataManager:
-    def __init__(self, machine, section):
-        pass
-
-    def get_data(self):
-        return dict()
-
-    def save_all(self, data, delay_secs):
-        pass
 
 
 class TestAuditor(MpfTestCase):
@@ -27,13 +15,7 @@ class TestAuditor(MpfTestCase):
 
     def setUp(self):
         self.machine_config_patches['mpf']['plugins'] = ['mpf.plugins.auditor.Auditor']
-        self.dataManager = auditor.DataManager
-        auditor.DataManager = TestDataManager
         super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-        auditor.DataManager = self.dataManager
 
     def test_auditor_switches(self):
         self.machine.ball_controller.num_balls_known = 1

--- a/mpf/tests/test_DataManager.py
+++ b/mpf/tests/test_DataManager.py
@@ -9,12 +9,18 @@ from mpf.tests.MpfTestCase import MpfTestCase
 
 class TestDataManager(MpfTestCase):
 
-    def test_save_and_load(self):
+    def setUp(self):
+        super().setUp()
         YamlInterface.cache = False
+
+    def tearDown(self):
+        YamlInterface.cache = True
+        super().tearDown()
+
+    def test_save_and_load(self):
         open_mock = mock_open(read_data="")
         with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
             manager = DataManager(self.machine, "machine_vars")
-            self.assertTrue(open_mock.called)
 
         self.assertNotIn("hallo", manager.get_data())
 
@@ -30,13 +36,9 @@ class TestDataManager(MpfTestCase):
         open_mock = mock_open(read_data='hallo: world\n')
         with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
             manager2 = DataManager(self.machine, "machine_vars")
-            self.assertTrue(open_mock.called)
 
         self.assertEqual("world", manager2.get_data()["hallo"])
         self.assertEqual({}, manager.get_data("hallo"))
-
-        YamlInterface.cache = True
-
 
     def test_get_data(self):
         open_mock = mock_open(read_data='hallo:\n  test: world\n')

--- a/mpf/tests/test_DataManager.py
+++ b/mpf/tests/test_DataManager.py
@@ -9,7 +9,7 @@ from mpf.tests.MpfTestCase import MpfTestCase
 
 class TestDataManager(MpfTestCase):
 
-    def testSaveAndLoad(self):
+    def test_save_and_load(self):
         YamlInterface.cache = False
         open_mock = mock_open(read_data="")
         with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
@@ -33,5 +33,16 @@ class TestDataManager(MpfTestCase):
             self.assertTrue(open_mock.called)
 
         self.assertEqual("world", manager2.get_data()["hallo"])
+        self.assertEqual({}, manager.get_data("hallo"))
 
         YamlInterface.cache = True
+
+
+    def test_get_data(self):
+        open_mock = mock_open(read_data='hallo:\n  test: world\n')
+        with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
+            manager = DataManager(self.machine, "machine_vars")
+            self.assertTrue(open_mock.called)
+
+        self.assertEqual({"test": "world"}, manager.get_data("hallo"))
+        self.assertEqual({}, manager.get_data("invalid"))

--- a/mpf/tests/test_DataManager.py
+++ b/mpf/tests/test_DataManager.py
@@ -1,0 +1,37 @@
+"""Test the bonus mode."""
+import time
+from unittest.mock import mock_open, patch
+
+from mpf.file_interfaces.yaml_interface import YamlInterface
+from mpf.core.data_manager import DataManager
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestDataManager(MpfTestCase):
+
+    def testSaveAndLoad(self):
+        YamlInterface.cache = False
+        open_mock = mock_open(read_data="")
+        with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
+            manager = DataManager(self.machine, "machine_vars")
+            self.assertTrue(open_mock.called)
+
+        self.assertNotIn("hallo", manager.get_data())
+
+        open_mock = mock_open(read_data="")
+        with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
+            with patch('mpf.core.file_manager.os.rename') as move_mock:
+                manager.save_key("hallo", "world")
+                while not move_mock.called:
+                    time.sleep(.00001)
+                open_mock().write.assert_called_once_with('hallo: world\n')
+                self.assertTrue(move_mock.called)
+
+        open_mock = mock_open(read_data='hallo: world\n')
+        with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
+            manager2 = DataManager(self.machine, "machine_vars")
+            self.assertTrue(open_mock.called)
+
+        self.assertEqual("world", manager2.get_data()["hallo"])
+
+        YamlInterface.cache = True

--- a/mpf/tests/test_DataManager.py
+++ b/mpf/tests/test_DataManager.py
@@ -20,7 +20,11 @@ class TestDataManager(MpfTestCase):
     def test_save_and_load(self):
         open_mock = mock_open(read_data="")
         with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
-            manager = DataManager(self.machine, "machine_vars")
+            with patch('os.path.isfile') as isfile_mock:
+                isfile_mock.return_value = True
+                manager = DataManager(self.machine, "machine_vars")
+                self.assertTrue(isfile_mock.called)
+                self.assertTrue(open_mock.called)
 
         self.assertNotIn("hallo", manager.get_data())
 
@@ -35,7 +39,11 @@ class TestDataManager(MpfTestCase):
 
         open_mock = mock_open(read_data='hallo: world\n')
         with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
-            manager2 = DataManager(self.machine, "machine_vars")
+            with patch('os.path.isfile') as isfile_mock:
+                isfile_mock.return_value = True
+                manager2 = DataManager(self.machine, "machine_vars")
+                self.assertTrue(isfile_mock.called)
+                self.assertTrue(open_mock.called)
 
         self.assertEqual("world", manager2.get_data()["hallo"])
         self.assertEqual({}, manager.get_data("hallo"))
@@ -43,8 +51,10 @@ class TestDataManager(MpfTestCase):
     def test_get_data(self):
         open_mock = mock_open(read_data='hallo:\n  test: world\n')
         with patch('mpf.file_interfaces.yaml_interface.open', open_mock, create=True):
-            manager = DataManager(self.machine, "machine_vars")
-            self.assertTrue(open_mock.called)
+            with patch('os.path.isfile') as isfile_mock:
+                manager = DataManager(self.machine, "machine_vars")
+                self.assertTrue(isfile_mock.called)
+                self.assertTrue(open_mock.called)
 
         self.assertEqual({"test": "world"}, manager.get_data("hallo"))
         self.assertEqual({}, manager.get_data("invalid"))

--- a/mpf/tests/test_MachineVariables.py
+++ b/mpf/tests/test_MachineVariables.py
@@ -1,0 +1,43 @@
+"""Test the bonus mode."""
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestMachineVariables(MpfTestCase):
+
+    def _get_mock_data(self):
+        return {"machine_vars": {"player2_score": {"value": 118208660},
+                                 "player3_score": {"value": 17789290},
+                                 "player4_score": {"value": 3006600},
+                                 "another_score": {"value": 123}},
+                }
+
+    def testVarLoadAndRemove(self):
+        self.assertTrue(self.machine.is_machine_var("player2_score"))
+        self.assertEqual(118208660, self.machine.get_machine_var("player2_score"))
+
+        self.machine.remove_machine_var("player2_score")
+
+        self.assertFalse(self.machine.is_machine_var("player2_score"))
+        self.assertTrue(self.machine.is_machine_var("player3_score"))
+
+        self.machine.remove_machine_var_search(startswith="player", endswith="_score")
+        self.assertFalse(self.machine.is_machine_var("player2_score"))
+        self.assertFalse(self.machine.is_machine_var("player3_score"))
+
+        self.assertEqual(123, self.machine.get_machine_var("another_score"))
+
+
+class TestMalformedMachineVariables(MpfTestCase):
+
+    def _get_mock_data(self):
+        return {"machine_vars": {"player2_score": {"value": 118208660},
+                                 "player3_score": {"value": 17789290},
+                                 "player4_score": {"value": 3006600},
+                                 "player5_score": 123,
+                                 "value": 0}}
+
+    def testVarLoads(self):
+        self.assertTrue(self.machine.is_machine_var("player2_score"))
+        self.assertEqual(118208660, self.machine.get_machine_var("player2_score"))
+        self.assertFalse(self.machine.is_machine_var("player5_score"))
+        self.assertEqual(None, self.machine.get_machine_var("player5_score"))

--- a/mpf/tests/test_MachineVariables.py
+++ b/mpf/tests/test_MachineVariables.py
@@ -34,6 +34,7 @@ class TestMalformedMachineVariables(MpfTestCase):
                                  "player3_score": {"value": 17789290},
                                  "player4_score": {"value": 3006600},
                                  "player5_score": 123,
+                                 "player6_score": {"asd": 3006600},
                                  "value": 0}}
 
     def testVarLoads(self):

--- a/mpf/tests/test_OSC.py
+++ b/mpf/tests/test_OSC.py
@@ -4,8 +4,6 @@ from mpf.plugins import auditor
 from mpf.tests.MpfTestCase import MpfTestCase
 from unittest.mock import MagicMock
 
-from mpf.tests.test_Auditor import TestDataManager
-
 
 class MockMessage:
     def __init__(self, cat):
@@ -49,9 +47,6 @@ class TestOSC(MpfTestCase):
         osc.OSCmodule.OSCMessage = MockMessage
         osc.threading = MagicMock()
 
-        self.dataManager = auditor.DataManager
-        auditor.DataManager = TestDataManager
-
         self.machine_config_patches['mpf']['plugins'] = ['mpf.plugins.osc.OSC', 'mpf.plugins.auditor.Auditor']
         super().setUp()
 
@@ -61,10 +56,6 @@ class TestOSC(MpfTestCase):
         self.assertIsInstance(self.auditor, auditor.Auditor)
         # self.auditor.enable()
         # TODO: test audits
-
-    def tearDown(self):
-        super().tearDown()
-        auditor.DataManager = self.dataManager
 
     def test_unknown_message(self):
         # should not crash


### PR DESCRIPTION
- Fix crash when loading corrupted machine variables
- Write to temp file and move to final location to prevent broken files on crash
- Prevent races during concurrent saves
