### PR TITLE
add dependency on pyserial-asyncio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
       brew install python3;
   fi;
 - pip3 install coveralls
-- python3 setup.py --process-dependency-links install
+- pip3 install --process-dependency-links install -e .
 - git clone --branch $TRAVIS_BRANCH https://github.com/missionpinball/mpf-examples.git || git clone --branch `python3 get_version.py` https://github.com/missionpinball/mpf-examples.git || git clone --branch dev https://github.com/missionpinball/mpf-examples.git
 - git clone --branch $TRAVIS_BRANCH https://github.com/missionpinball/mpf-mc.git || git clone --branch `python3 get_version.py` https://github.com/missionpinball/mpf-mc.git || git clone --branch dev https://github.com/missionpinball/mpf-mc.git
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ install:
       brew install python3;
   fi;
 - pip3 install coveralls
-- pip3 install https://github.com/pyserial/pyserial-asyncio/archive/master.zip
-- python3 setup.py install
+- python3 setup.py --process-dependency-links install
 - git clone --branch $TRAVIS_BRANCH https://github.com/missionpinball/mpf-examples.git || git clone --branch `python3 get_version.py` https://github.com/missionpinball/mpf-examples.git || git clone --branch dev https://github.com/missionpinball/mpf-examples.git
 - git clone --branch $TRAVIS_BRANCH https://github.com/missionpinball/mpf-mc.git || git clone --branch `python3 get_version.py` https://github.com/missionpinball/mpf-mc.git || git clone --branch dev https://github.com/missionpinball/mpf-mc.git
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
       brew install python3;
   fi;
 - pip3 install coveralls
-- pip3 install --process-dependency-links install -e .
+- pip3 install --process-dependency-links -e .
 - git clone --branch $TRAVIS_BRANCH https://github.com/missionpinball/mpf-examples.git || git clone --branch `python3 get_version.py` https://github.com/missionpinball/mpf-examples.git || git clone --branch dev https://github.com/missionpinball/mpf-examples.git
 - git clone --branch $TRAVIS_BRANCH https://github.com/missionpinball/mpf-mc.git || git clone --branch `python3 get_version.py` https://github.com/missionpinball/mpf-mc.git || git clone --branch dev https://github.com/missionpinball/mpf-mc.git
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 
 install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools wheel pip mock twine"
-  - "%PYTHON%\\python.exe setup.py install --process-dependency-links -e ."
+  - "%PYTHON%\\python.exe -m pip install --process-dependency-links -e ."
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,11 @@ environment:
 
 install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools wheel pip mock twine"
-  - "%PYTHON%\\python.exe -m pip install https://github.com/jabdoa2/pyserial-asyncio/zipball/master"
 
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe setup.py test -q"
+  - "%PYTHON%\\python.exe setup.py --process-dependency-links test -q"
 
 after_test:
   - "%PYTHON%\\python.exe setup.py sdist --formats=gztar"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,11 +17,12 @@ environment:
 
 install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools wheel pip mock twine"
+  - "%PYTHON%\\python.exe setup.py install --process-dependency-links -e ."
 
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe setup.py test --process-dependency-links -q"
+  - "%PYTHON%\\python.exe setup.py test -q"
 
 after_test:
   - "%PYTHON%\\python.exe setup.py sdist --formats=gztar"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe setup.py --process-dependency-links test -q"
+  - "%PYTHON%\\python.exe setup.py test --process-dependency-links -q"
 
 after_test:
   - "%PYTHON%\\python.exe setup.py sdist --formats=gztar"

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ community.''',
 
     zip_safe=False,
 
-    install_requires=['ruamel.yaml>=0.10, <0.11', 'pyserial'],
+    dependency_links=['https://github.com/pyserial/pyserial-asyncio/archive/master.zip#egg=pyserial-asyncio-0.0.1'],
+    install_requires=['ruamel.yaml>=0.10, <0.11', 'pyserial', 'pyserial-asyncio==0.0.1'],
 
     tests_require=[],
     test_suite="mpf.tests",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ community.''',
     zip_safe=False,
 
     dependency_links=['https://github.com/pyserial/pyserial-asyncio/archive/master.zip#egg=pyserial-asyncio-0.0.1'],
-    install_requires=['ruamel.yaml>=0.10, <0.11', 'pyserial', 'pyserial-asyncio==0.0.1'],
+    install_requires=['ruamel.yaml>=0.10, <0.11', 'pyserial', 'pyserial-asyncio>=0.0.1'],
 
     tests_require=[],
     test_suite="mpf.tests",


### PR DESCRIPTION
only works with `pip3 install --process-dependency-links mpf`until https://github.com/pyserial/pyserial-asyncio/issues/9 is resolved

kind of fix for #429
