### PR TITLE
Prevent 'ff' value propagating to color conversion for leds

### DIFF
--- a/mpf/config_players/led_player.py
+++ b/mpf/config_players/led_player.py
@@ -47,7 +47,7 @@ class LedPlayer(DeviceConfigPlayer):
 
     @staticmethod
     def _led_color(led, instance_dict, full_context, color, **s):
-        if color == "on":
+        if color in ['on', 'ff']:
             color = led.config['default_color']
         else:
             color = RGBColor(color)


### PR DESCRIPTION
Setting a specific value (tried "white" and "red") for `color` in the leds config caused **mpf** to hang. According to the docs, `color` is supposed to be optional, but leaving it out caused the value `"ff"` to propagate into the RGBColor utility function as the `color` variable which seems incorrect.