### PR TITLE
Bcp changes

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,9 +10,9 @@ PyPI.
 
 """
 
-__version__ = '0.33.0-dev.11'
+__version__ = '0.33.0-dev.12'
 __short_version__ = '0.33'
-__bcp_version__ = '1.0'
+__bcp_version__ = '1.1'
 __config_version__ = '4'
 __show_version__ = '4'
 

--- a/mpf/core/mode_controller.py
+++ b/mpf/core/mode_controller.py
@@ -379,6 +379,14 @@ class ModeController(MpfController):
 
         self.start_methods.sort(key=lambda x: x.priority, reverse=True)
 
+    def remove_start_method(self, start_method, config_section_name=None, priority=0, **kwargs):
+        """Remove an existing start method."""
+        method = RemoteMethod(method=start_method, config_section=config_section_name,
+                              priority=priority, kwargs=kwargs)
+
+        if method in self.start_methods:
+            self.start_methods.remove(method)
+
     def register_stop_method(self, callback, priority=0):
         """Register a method which is called when the mode is stopped.
 
@@ -392,6 +400,12 @@ class ModeController(MpfController):
         self.stop_methods.append((callback, priority))
 
         self.stop_methods.sort(key=lambda x: x[1], reverse=True)
+
+    def remove_stop_method(self, callback, priority=0):
+        """Remove an existing stop method."""
+
+        if (callback, priority) in self.stop_methods:
+            self.stop_methods.remove((callback, priority))
 
     def set_mode_state(self, mode, active):
         """Called when a mode goes active or inactive."""

--- a/mpf/core/timer.py
+++ b/mpf/core/timer.py
@@ -40,7 +40,6 @@ class Timer(LogMixin):
         self.direction = self.config['direction'].lower()
         self.tick_secs = self.config['tick_interval'] / 1000.0
         self.timer = None
-        self.bcp = self.config['bcp']
         self.event_keys = set()
         self.delay = DelayManager(self.machine.delayRegistry)
 
@@ -185,11 +184,6 @@ class Timer(LogMixin):
             ticks_remaining: The number of ticks in this timer remaining.
         '''
 
-        if self.bcp:
-            self.machine.bcp.send('timer', name=self.name, action='started',
-                                  ticks=self.ticks,
-                                  ticks_remaining=self.ticks_remaining)
-
         self._post_tick_events()
         # since lots of slides and stuff are tied to the timer tick, we want
         # to post an initial tick event also that represents the starting
@@ -241,11 +235,6 @@ class Timer(LogMixin):
             ticks_remaining: The number of ticks in this timer remaining.
         '''
 
-        if self.bcp:
-            self.machine.bcp.send('timer', name=self.name, action='stopped',
-                                  ticks=self.ticks,
-                                  ticks_remaining=self.ticks_remaining)
-
     def pause(self, timer_value=0, **kwargs):
         """Pause the timer and posts the 'timer_<name>_paused' event.
 
@@ -280,10 +269,6 @@ class Timer(LogMixin):
             ticks: The current tick number this timer is at.
             ticks_remaining: The number of ticks in this timer remaining.
         '''
-        if self.bcp:
-            self.machine.bcp.send('timer', name=self.name, action='paused',
-                                  ticks=self.ticks,
-                                  ticks_remaining=self.ticks_remaining)
 
         if pause_secs > 0:
             self.delay.add(name='pause', ms=pause_secs, callback=self.start)
@@ -304,11 +289,6 @@ class Timer(LogMixin):
         self.info_log("Timer Complete")
 
         self.stop()
-
-        if self.bcp:  # must be before the event post in case it stops the mode
-            self.machine.bcp.send('timer', name=self.name, action='complete',
-                                  ticks=self.ticks,
-                                  ticks_remaining=self.ticks_remaining)
 
         self.machine.events.post('timer_' + self.name + '_complete',
                                  ticks=self.ticks,
@@ -372,11 +352,6 @@ class Timer(LogMixin):
                            self.ticks,
                            self.ticks_remaining)
 
-            if self.bcp:
-                self.machine.bcp.send('timer', name=self.name, action='tick',
-                                      ticks=self.ticks,
-                                      ticks_remaining=self.ticks_remaining)
-
     def add(self, timer_value, **kwargs):
         """Add ticks to this timer.
 
@@ -413,12 +388,6 @@ class Timer(LogMixin):
             ticks_added: How many ticks were just added.
         '''
 
-        if self.bcp:
-            self.machine.bcp.send('timer', name=self.name, action='time_added',
-                                  ticks=self.ticks,
-                                  ticks_added=ticks_added,
-                                  ticks_remaining=self.ticks_remaining)
-
         self._check_for_done()
 
     def subtract(self, timer_value, **kwargs):
@@ -452,13 +421,6 @@ class Timer(LogMixin):
                 timer. (This number will be positive, indicating the ticks
                 subtracted.)
         '''
-
-        if self.bcp:
-            self.machine.bcp.send('timer', name=self.name,
-                                  action='time_subtracted',
-                                  ticks=self.ticks,
-                                  ticks_subtracted=ticks_subtracted,
-                                  ticks_remaining=self.ticks_remaining)
 
         self._check_for_done()
 

--- a/mpf/tests/machine_files/bcp/config/config.yaml
+++ b/mpf/tests/machine_files/bcp/config/config.yaml
@@ -1,8 +1,11 @@
 #config_version=4
 
+modes:
+  - mode1
+  - Mode2
+
 switches:
     s_test:
         number:
     s_test2:
         number:
-

--- a/mpf/tests/machine_files/bcp/config/config.yaml
+++ b/mpf/tests/machine_files/bcp/config/config.yaml
@@ -9,3 +9,37 @@ switches:
         number:
     s_test2:
         number:
+    s_start:
+        number:
+        tags: start
+    s_ball_switch1:
+        number:
+    s_ball_switch2:
+        number:
+    s_ball_switch_launcher:
+        number:
+
+game:
+    balls_per_game: 3
+
+coils:
+    eject_coil1:
+        number:
+    eject_coil2:
+        number:
+
+ball_devices:
+    bd_trough:
+        eject_coil: eject_coil1
+        ball_switches: s_ball_switch1, s_ball_switch2
+        debug: true
+        confirm_eject_type: target
+        eject_targets: bd_launcher
+        tags: trough, drain, home
+    bd_launcher:
+        eject_coil: eject_coil2
+        ball_switches: s_ball_switch_launcher
+        debug: true
+        confirm_eject_type: target
+        eject_timeouts: 2s
+        tags: ball_add_live

--- a/mpf/tests/machine_files/bcp/modes/mode1/mode1.yaml
+++ b/mpf/tests/machine_files/bcp/modes/mode1/mode1.yaml
@@ -1,0 +1,6 @@
+#config_version=4
+
+mode:
+  start_events: start_mode1
+  stop_events: stop_mode1
+  game_mode: False

--- a/mpf/tests/machine_files/bcp/modes/mode2/mode2.yaml
+++ b/mpf/tests/machine_files/bcp/modes/mode2/mode2.yaml
@@ -1,0 +1,6 @@
+#config_version=4
+
+mode:
+  start_events: start_mode2
+  stop_events: stop_mode2
+  game_mode: False

--- a/mpf/tests/test_BcpInterface.py
+++ b/mpf/tests/test_BcpInterface.py
@@ -129,9 +129,9 @@ class TestBcpInterface(MpfBcpTestCase):
             self._bcp_client.send_queue)
 
         # Now stop the monitor
-        self._bcp_client.send_queue.clear()
         self._bcp_client.receive_queue.put_nowait(('monitor_start', {'category': 'devices'}))
         self.advance_time_and_run()
+        self._bcp_client.send_queue.clear()
 
         # Switch hit should not be in BCP queue
         self.hit_switch_and_run("s_test", .1)

--- a/mpf/tests/test_BcpInterface.py
+++ b/mpf/tests/test_BcpInterface.py
@@ -129,7 +129,7 @@ class TestBcpInterface(MpfBcpTestCase):
             self._bcp_client.send_queue)
 
         # Now stop the monitor
-        self._bcp_client.receive_queue.put_nowait(('monitor_start', {'category': 'devices'}))
+        self._bcp_client.receive_queue.put_nowait(('monitor_stop', {'category': 'devices'}))
         self.advance_time_and_run()
         self._bcp_client.send_queue.clear()
 
@@ -183,7 +183,7 @@ class TestBcpInterface(MpfBcpTestCase):
 
         # Stop switch monitor
         self._bcp_client.send_queue.clear()
-        self._bcp_client.receive_queue.put_nowait(('monitor_start', {'category': 'switches'}))
+        self._bcp_client.receive_queue.put_nowait(('monitor_stop', {'category': 'switches'}))
         self.advance_time_and_run()
 
         # Hit switch should not be in BCP queue

--- a/mpf/tests/test_PluginConfigPlayer.py
+++ b/mpf/tests/test_PluginConfigPlayer.py
@@ -148,6 +148,10 @@ class TestPluginConfigPlayer(MpfBcpTestCase):
         self._bcp_client.send = MagicMock()
 
     def test_plugin_config_player(self):
+        # Setup BCP to monitor mode events
+        self._bcp_client.receive_queue.put_nowait(('monitor_start', {'category': 'modes'}))
+        self.advance_time_and_run()
+
         self.assertIn('tests', self.machine.show_controller.show_players)
         self.assertIn('test2s', self.machine.show_controller.show_players)
 
@@ -195,9 +199,9 @@ class TestPluginConfigPlayer(MpfBcpTestCase):
         self.machine.modes['mode1'].stop()
         self.advance_time_and_run()
         self._bcp_client.send.assert_has_calls([
-            call('mode_stop', {'name': 'mode1'}),
             call('trigger', {'context': 'mode1', 'name': 'tests_clear'}),
-            call('trigger', {'context': 'mode1', 'name': 'test2s_clear'})]
+            call('trigger', {'context': 'mode1', 'name': 'test2s_clear'}),
+            call('mode_stop', {'name': 'mode1'})]
         )
         self._bcp_client.send.reset_mock()
 


### PR DESCRIPTION
Updated BCP version to 1.1.  Update code to restore some of the old behavior that was in version 0.21 and used in the Unity MPF interface.  Removed some unused BCP features.  Added ability to monitor various groups of events: all events, devices, switches, modes, core events (player, ball, turn, etc.), player vars, machine vars.  Added ability to stop monitoring and unregister triggers.  Added new tests.