### PR TITLE
Force 'utf8' encoding when loading config files

### DIFF
--- a/mpf/file_interfaces/yaml_interface.py
+++ b/mpf/file_interfaces/yaml_interface.py
@@ -188,7 +188,7 @@ class YamlInterface(FileInterface):
     @staticmethod
     def get_config_file_version(filename):
         """Return config file version."""
-        with open(filename) as f:
+        with open(filename, 'r', encoding='utf8') as f:
             file_version = f.readline().split('config_version=')[-1:][0]
 
         try:
@@ -199,7 +199,7 @@ class YamlInterface(FileInterface):
     @staticmethod
     def get_show_file_version(filename):
         """Return show file version."""
-        with open(filename) as f:
+        with open(filename, 'r', encoding='utf8') as f:
             try:
                 file_version = f.readline().split('show_version=')[-1:][0]
             except ValueError:
@@ -268,7 +268,7 @@ class YamlInterface(FileInterface):
         try:
             self.log.debug("Loading file: %s", filename)
 
-            with open(filename) as f:
+            with open(filename, 'r', encoding='utf8') as f:
                 config = YamlInterface.process(f, round_trip)
         except yaml.YAMLError as exc:
             if hasattr(exc, 'problem_mark'):
@@ -309,7 +309,7 @@ class YamlInterface(FileInterface):
         except KeyError:
             include_comments = False
 
-        with open(filename, 'w') as output_file:
+        with open(filename, 'w', encoding='utf8') as output_file:
 
             if include_comments:
                 output_file.write(yaml.dump(data, Dumper=RoundTripDumper,


### PR DESCRIPTION
We ran into an encoding issue trying to run mpf for a machine config (that I have been iterating on from a Mac) on a Windows 10 system. It seems like this was addressed prior via https://github.com/missionpinball/mpf/commit/cbaff2b4b15268de039fba173d6817aa381d0cb8, but I checked and neither desktop.ini, Thumbs.db or .DS_Store were found among my machine config files. Passing the encoding when loading the yaml files as changed here allowed Windows to load my machine config.