### PR TITLE
Reset changes

### DIFF
--- a/mpf/core/assets.py
+++ b/mpf/core/assets.py
@@ -546,7 +546,7 @@ class BaseAssetManager(MpfController, LogMixin):
                       self.num_assets_loaded + self.num_bcp_assets_loaded,
                       total, self.loading_percent)
 
-        if not remaining and not self.machine.is_init_done:
+        if not remaining and not self.machine.is_init_done.is_set():
             self.machine.clear_boot_hold('assets')
 
 

--- a/mpf/core/ball_controller.py
+++ b/mpf/core/ball_controller.py
@@ -29,7 +29,7 @@ class BallController(MpfController):
         # register for events
         self.machine.events.add_handler('request_to_start_game',
                                         self.request_to_start_game)
-        self.machine.events.add_handler('machine_reset_phase_2',
+        self.machine.events.add_handler('init_phase_2',
                                         self._initialize)
         self.machine.events.add_handler('init_phase_4',
                                         self._init4, priority=100)

--- a/mpf/core/bcp/bcp.py
+++ b/mpf/core/bcp/bcp.py
@@ -1,4 +1,7 @@
 """BCP module."""
+import asyncio
+
+from mpf.core.events import QueuedEvent
 from mpf.core.mpf_controller import MpfController
 
 from mpf.core.bcp.bcp_server import BcpServer
@@ -37,31 +40,49 @@ class Bcp(MpfController):
         """
         self.transport.send_to_all_clients(bcp_command, **kwargs)
 
-    def _setup_bcp_connections(self, **kwargs):
+    def _setup_bcp_connections(self, queue: QueuedEvent, **kwargs):
         """Connect to BCP servers from MPF config."""
         del kwargs
         if ('connections' not in self.machine.config['bcp'] or not
                 self.machine.config['bcp']['connections']):
             return
 
+        client_connect_futures = []
         for name, settings in self.machine.config['bcp']['connections'].items():
             settings = self.machine.config_validator.validate_config("bcp:connections", settings)
             client = Util.string_to_class(settings['type'])(self.machine, name, self.machine.bcp)
-            if client.connect(settings):
-                client.exit_on_close = settings['exit_on_close']
-                self.transport.register_transport(client)
+            client.exit_on_close = settings['exit_on_close']
+            connect_future = Util.ensure_future(client.connect(settings), loop=self.machine.clock.loop)
+            connect_future.add_done_callback(lambda x: self.transport.register_transport(client))
+            client_connect_futures.append(connect_future)
 
-    def _setup_bcp_servers(self, **kwargs):
+        # block init until all clients are connected
+        if client_connect_futures:
+            queue.wait()
+            future = Util.ensure_future(asyncio.wait(iter(client_connect_futures), loop=self.machine.clock.loop),
+                                        loop=self.machine.clock.loop)
+            future.add_done_callback(lambda x: queue.clear())
+
+    def _setup_bcp_servers(self, queue: QueuedEvent, **kwargs):
         """Start BCP servers to allow other clients to connect."""
         del kwargs
         if 'servers' not in self.machine.config['bcp'] or not self.machine.config['bcp']['servers']:
             return
 
+        servers_start_futures = []
         for settings in self.machine.config['bcp']['servers'].values():
             settings = self.machine.config_validator.validate_config("bcp:servers", settings)
             server = BcpServer(self.machine, settings['ip'], settings['port'], settings['type'])
-            self.machine.clock.loop.run_until_complete(server.start())
-            self.servers.append(server)
+            server_future = Util.ensure_future(server.start(), loop=self.machine.clock.loop)
+            server_future.add_done_callback(lambda x: self.servers.append(server))
+            servers_start_futures.append(server_future)
+
+        # block init until all servers were started
+        if servers_start_futures:
+            queue.wait()
+            future = Util.ensure_future(asyncio.wait(iter(servers_start_futures), loop=self.machine.clock.loop),
+                                        loop=self.machine.clock.loop)
+            future.add_done_callback(lambda x: queue.clear())
 
     def _stop_servers(self, **kwargs):
         """Stop BCP servers."""

--- a/mpf/core/bcp/bcp_client.py
+++ b/mpf/core/bcp/bcp_client.py
@@ -17,6 +17,7 @@ class BaseBcpClient(MpfController, metaclass=abc.ABCMeta):
         self.bcp = bcp
         self.exit_on_close = False
 
+    @asyncio.coroutine
     def connect(self, config):
         """Actively connect client."""
         raise NotImplementedError("implement")

--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -386,9 +386,11 @@ class BcpInterface(MpfController):
 
         if cmd in self.bcp_receive_commands:
             try:
-                self.bcp_receive_commands[cmd](client=client, **kwargs)
+                callback = self.bcp_receive_commands[cmd]
             except TypeError as e:
                 self.machine.bcp.transport.send_to_client(client, "error", cmd=cmd, error=str(e), kwargs=kwargs)
+            else:
+                callback(client=client, **kwargs)
 
         else:
             self.warning_log("Received invalid BCP command: %s from client: %s", cmd, client.name)

--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -43,7 +43,11 @@ class BcpInterface(MpfController):
 
         self.config = machine.config['bcp']
 
+        self._client_reset_queue = None
+        self._client_reset_complete_status = None
+
         self.bcp_receive_commands = dict(
+            reset_complete=self._bcp_receive_reset_complete,
             error=self._bcp_receive_error,
             switch=self._bcp_receive_switch,
             trigger=self._bcp_receive_trigger,
@@ -398,6 +402,19 @@ class BcpInterface(MpfController):
         self.warning_log('Received Error command from host with parameters: %s, from client %s',
                          kwargs, str(client))
 
+    def _bcp_receive_reset_complete(self, client, **kwargs):
+        """A remote BCP host has sent a BCP reset_complete message indicating their reset process
+        has completed."""
+        self.debug_log("Received reset_complete from client: %s %s", client.name)
+        self._client_reset_complete_status[client] = True
+
+        # Check if reset_complete status is True from all clients
+        if all(status is True for item, status in self._client_reset_complete_status.items()):
+            self._client_reset_queue.clear()
+            self._client_reset_queue = None
+            self._client_reset_complete_status = None
+            self.debug_log("Received reset_complete from all clients. Clearing wait from queue event.")
+
     def bcp_mode_start(self, config, priority, mode, **kwargs):
         """Send BCP 'mode_start' to the connected BCP hosts.
 
@@ -418,10 +435,23 @@ class BcpInterface(MpfController):
                                                                 'mode_stop',
                                                                 name=name)
 
-    def bcp_reset(self, **kwargs):
+    def bcp_reset(self, queue, **kwargs):
         """Send the 'reset' command to the remote BCP host."""
         del kwargs
-        self.machine.bcp.transport.send_to_all_clients("reset")
+
+        # Will hold the queue event until all clients respond with a "reset_complete" command
+        clients = self.machine.bcp.transport.get_all_clients()
+        if len(clients) > 0:
+            queue.wait()
+            self._client_reset_queue = queue
+            self._client_reset_complete_status = {}
+            for client in clients:
+                self._client_reset_complete_status[client] = False
+
+            # Send the reset command
+            self.debug_log("Sending reset to all clients (will now wait for reset_complete "
+                           "to be received from all clients).")
+            self.machine.bcp.transport.send_to_all_clients("reset")
 
     def _bcp_receive_switch(self, client, name, state, **kwargs):
         """Process an incoming switch state change request from a remote BCP host.

--- a/mpf/core/bcp/bcp_socket_client.py
+++ b/mpf/core/bcp/bcp_socket_client.py
@@ -152,8 +152,8 @@ class BCPClientSocket(BaseBcpClient):
         config = self.machine.config_validator.validate_config(
             'bcp:connections', config, 'bcp:connections')
 
-        return self.machine.clock.loop.run_until_complete(
-            self._setup_client_socket(config['host'], config['port'], config.get('required')))
+        # return a future
+        return self._setup_client_socket(config['host'], config['port'], config.get('required'))
 
     @asyncio.coroutine
     def _setup_client_socket(self, client_host, client_port, required=True):

--- a/mpf/core/bcp/bcp_transport.py
+++ b/mpf/core/bcp/bcp_transport.py
@@ -80,6 +80,10 @@ class BcpTransportManager:
         if transport.exit_on_close:
             self._machine.stop()
 
+    def get_all_clients(self):
+        """Get a list of all clients."""
+        return self._transports
+
     def get_named_client(self, client_name) -> BaseBcpClient:
         """Get a client by name."""
         for client in self._transports:

--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -475,19 +475,19 @@ gis:
     __allow_others__:
 hardware:
     __valid_in__: machine
-    platform: single|str|virtual
-    coils: single|str|default
-    switches: single|str|default
-    matrix_lights: single|str|default
-    leds: single|str|default
-    dmd: single|str|default
-    rgb_dmd: single|str|default
-    gis: single|str|default
-    flashers: single|str|default
+    platform: list|str|virtual
+    coils: list|str|default
+    switches: list|str|default
+    matrix_lights: list|str|default
+    leds: list|str|default
+    dmd: list|str|default
+    rgb_dmd: list|str|default
+    gis: list|str|default
+    flashers: list|str|default
     driverboards: single|str|
-    servo_controllers: single|str|
-    accelerometers: single|str|
-    i2c: single|str|
+    servo_controllers: list|str|
+    accelerometers: list|str|
+    i2c: list|str|
 high_score:
     __valid_in__: mode
     award_slide_display_time: single|ms|4s

--- a/mpf/core/service_controller.py
+++ b/mpf/core/service_controller.py
@@ -6,6 +6,8 @@ the service mode or other components.
 import logging
 from collections import namedtuple
 
+import asyncio
+
 from mpf.core.mpf_controller import MpfController
 
 CoilMap = namedtuple("CoilMap", ["board", "coil"])
@@ -46,6 +48,7 @@ class ServiceController(MpfController):
 
         # TODO: reset hardware interface
 
+    @asyncio.coroutine
     def stop_service(self):
         """Stop service mode."""
         if not self.is_in_service():
@@ -54,7 +57,7 @@ class ServiceController(MpfController):
 
         # this event starts attract mode again
         self.machine.events.post("service_mode_exited")
-        self.machine.reset()
+        yield from self.machine.reset()
 
     def get_switch_map(self):
         """Return a map of all switches in the machine."""

--- a/mpf/devices/ball_device/ball_device.py
+++ b/mpf/devices/ball_device/ball_device.py
@@ -4,6 +4,7 @@ from collections import deque
 
 import asyncio
 
+from mpf.core.events import QueuedEvent
 from mpf.devices.ball_device.ball_count_handler import BallCountHandler
 from mpf.devices.ball_device.ball_device_ball_counter import BallDeviceBallCounter
 from mpf.devices.ball_device.ball_device_ejector import BallDeviceEjector
@@ -127,14 +128,17 @@ class BallDevice(SystemWideDevice):
                     "'playfield_active' tag from that switch.".format(
                         self.name, switch.name))
 
-    def _create_ball_counters(self, **kwargs):
+    def _create_ball_counters(self, queue: QueuedEvent, **kwargs):
+        """Create ball counters."""
         del kwargs
         if self.config['ball_switches']:
-            self.counter = SwitchCounter(self, self.config)     # pylint: disable-msg=redefined-variable-type
+            self.counter = SwitchCounter(self, self.config)
         else:
-            self.counter = EntranceSwitchCounter(self, self.config)  # pylint: disable-msg=redefined-variable-type
+            self.counter = EntranceSwitchCounter(self, self.config)
 
-        self.machine.clock.loop.run_until_complete(self._initialize_async())
+        queue.wait()
+        complete_future = Util.ensure_future(self._initialize_async(), loop=self.machine.clock.loop)
+        complete_future.add_done_callback(lambda x: queue.clear())
 
     def stop(self, **kwargs):
         """Stop device."""

--- a/mpf/modes/attract/config/attract.yaml
+++ b/mpf/modes/attract/config/attract.yaml
@@ -1,6 +1,6 @@
 #config_version=4
 mode:
-  start_events: game_ended, reset_complete, service_mode_exited
+  start_events: game_ended, reset_complete
   stop_events: game_start, service_mode_entered
   priority: 10
   game_mode: False

--- a/mpf/modes/credits/config/credits.yaml
+++ b/mpf/modes/credits/config/credits.yaml
@@ -2,7 +2,7 @@
 mode:
   code: mpf.modes.credits.code.credits.Credits
   priority: 1000010
-  start_events: machine_reset_phase_3
+  start_events: reset_complete
   game_mode: False
   stop_on_ball_end: False
 

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -27,8 +27,9 @@ up_events: list|str|sw_service_up_active
 down_events: list|str|sw_service_down_active
 '''
 
+    @asyncio.coroutine
     def _service_mode_exit(self):
-        self.machine.service.stop_service()
+        yield from self.machine.service.stop_service()
 
     def _get_key(self):
         return Util.race({
@@ -68,7 +69,7 @@ down_events: list|str|sw_service_down_active
         self.machine.events.post("service_main_menu")
         yield from self._service_mode_main_menu()
 
-        self._service_mode_exit()
+        yield from self._service_mode_exit()
 
     def _update_main_menu(self, items: [ServiceMenuEntry], position: int):
         self.machine.events.post("service_menu_deselected")

--- a/mpf/platforms/openpixel.py
+++ b/mpf/platforms/openpixel.py
@@ -38,6 +38,8 @@ class HardwarePlatform(LedPlatform):
         if self.machine.config['open_pixel_control']['debug']:
             self.debug = True
 
+        self._setup_opc_client()
+
     def stop(self):
         """Stop platform."""
         # disconnect sender
@@ -52,9 +54,6 @@ class HardwarePlatform(LedPlatform):
         """
         if channels > 3:
             raise AssertionError("More channels not yet implemented")
-
-        if not self.opc_client:
-            self._setup_opc_client()
 
         if isinstance(config['number'], str) and '-' in config['number']:
             channel, led = config['number'].split('-')

--- a/mpf/platforms/smart_virtual.py
+++ b/mpf/platforms/smart_virtual.py
@@ -228,7 +228,7 @@ class HardwarePlatform(VirtualPlatform):
 
     def initialize(self):
         """Initialise platform."""
-        self.machine.events.add_handler('machine_reset_phase_1',
+        self.machine.events.add_handler('init_phase_5',
                                         self._initialize2)
 
     def _initialize2(self, **kwargs):

--- a/mpf/plugins/info_lights.py
+++ b/mpf/plugins/info_lights.py
@@ -26,7 +26,7 @@ class InfoLights(object):
                                    'will not be used.')
             return
 
-        self.machine.events.add_handler('machine_reset_phase_3', self._initialize)
+        self.machine.events.add_handler('init_phase_5', self._initialize)
 
     def _initialize(self, **kwargs):
         del kwargs

--- a/mpf/tests/MpfBcpTestCase.py
+++ b/mpf/tests/MpfBcpTestCase.py
@@ -15,8 +15,9 @@ class MockBcpClient(BaseBcpClient):
         self.receive_queue = asyncio.Queue(loop=self.machine.clock.loop)
         self.send_queue = []
 
+    @asyncio.coroutine
     def connect(self, config):
-        return True
+        return
 
     @asyncio.coroutine
     def read_message(self):
@@ -27,6 +28,9 @@ class MockBcpClient(BaseBcpClient):
         pass
 
     def send(self, bcp_command, bcp_command_args):
+        if bcp_command == "reset":
+            self.receive_queue.put_nowait(("reset_complete", {}))
+            return
         if bcp_command == "error":
             raise AssertionError("Got bcp error")
         self.send_queue.append((bcp_command, bcp_command_args))

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -266,9 +266,13 @@ class MpfTestCase(unittest.TestCase):
                 self.machine.stop()
             except AttributeError:
                 pass
+            if self._exception and 'exception' in self._exception:
+                raise self._exception['exception']
+            elif self._exception:
+                raise Exception(self._exception, e)
             raise e
 
-        self.assertFalse(self.machine._done, "Machine crashed during start")
+        self.assertTrue(self.machine.test_init_complete, "Machine crashed during start")
 
     def _mock_event_handler(self, event_name, **kwargs):
         self._last_event_kwargs[event_name] = kwargs

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -40,6 +40,7 @@ class TestMachineController(MachineController):
         self._test_clock = clock
         self._mock_data = mock_data
         super().__init__(mpf_path, machine_path, options)
+        self.test_init_complete = True
 
     def create_data_manager(self, config_name):
         return TestDataManager(self._mock_data.get(config_name, {}))
@@ -55,10 +56,6 @@ class TestMachineController(MachineController):
         for socket, callback in self.clock.read_sockets.items():
             if socket.ready():
                 callback()
-
-    def _reset_complete(self):
-        self.test_init_complete = True
-        super()._reset_complete()
 
     def _register_plugin_config_players(self):
         if self._enable_plugins:

--- a/mpf/tests/machine_files/platform/config/test_platform.yaml
+++ b/mpf/tests/machine_files/platform/config/test_platform.yaml
@@ -1,7 +1,7 @@
 #config_version=4
 
-#hardware:
-#  leds: fadecandy
+hardware:
+  leds: smart_virtual, fadecandy
 
 leds:
   led1:

--- a/mpf/tests/test_BcpMc.py
+++ b/mpf/tests/test_BcpMc.py
@@ -12,6 +12,8 @@ class TestBcpClient(MockBcpClient):
         self.exit_on_close = False
 
     def send(self, bcp_command, kwargs):
+        if bcp_command == "reset":
+            self.receive_queue.put_nowait(("reset_complete", {}))
         self.queue.put((bcp_command, kwargs))
 
     def receive(self, bcp_command, callback=None, rawbytes=None, **kwargs):

--- a/mpf/tests/test_BcpSocketClient.py
+++ b/mpf/tests/test_BcpSocketClient.py
@@ -98,6 +98,17 @@ class TestBcpSocketClientEncoding(unittest.TestCase):
                          dict(key3='value5', key4='value6'))
 
 
+class MockBcpQueueSocket(MockQueueSocket):
+
+    """Mock Queue Socket for BCP which emulates reset."""
+
+    def send(self, data):
+        if data == b'reset\n':
+            self.recv_queue.append(b'reset_complete\n')
+            return len(data)
+        return super().send(data)
+
+
 class TestBcpSocketClient(MpfTestCase):
 
     def __init__(self, methodName='runTest'):
@@ -115,7 +126,7 @@ class TestBcpSocketClient(MpfTestCase):
         self._bcp_client = self.machine.bcp.transport.get_named_client("local_display")
 
     def _mock_loop(self):
-        self.client_socket = MockQueueSocket()
+        self.client_socket = MockBcpQueueSocket()
         self.clock.mock_socket("localhost", 5050, self.client_socket)
 
     def testReceiveMessages(self):

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -60,6 +60,7 @@ class TestServiceMode(MpfFakeGameTestCase):
 
         # exit service
         self.hit_and_release_switch("s_service_esc")
+        self.advance_time_and_run()
         self.assertEventCalled('service_mode_exited', 2)
         self.assertEventCalled('service_door_closed', 1)
         self.assertModeRunning("attract")
@@ -109,6 +110,7 @@ class TestServiceMode(MpfFakeGameTestCase):
 
         # exit service mode
         self.hit_and_release_switch("s_service_esc")
+        self.advance_time_and_run()
         self.assertModeRunning("attract")
         self.assertEventCalled('service_mode_exited')
 


### PR DESCRIPTION
Improved initialization and reset process (now using queue events). BCP clients must respond to a "reset" message with a "reset_complete" or the MPF reset process will not complete.