### PR TITLE
always handle trough as drain device

### DIFF
--- a/mpf/core/ball_controller.py
+++ b/mpf/core/ball_controller.py
@@ -194,7 +194,7 @@ class BallController(MpfController):
             return
 
         for device in self.machine.ball_devices:
-            if 'drain' in device.tags:  # device is used to drain balls from pf
+            if 'drain' in device.tags or 'trough' in device.tags:  # device is used to drain balls from pf
                 self.machine.events.add_handler('balldevice_' + device.name +
                                                 '_ball_enter',
                                                 self._ball_drained_handler)


### PR DESCRIPTION
Prevent this issue in the future https://github.com/GabeKnuth/BnD/issues/57.

Currently, there is no usecase for a trough which is not a drain device (because that would be a lock)