### PR TITLE
Create failing test for scenario blocking multiple events scoring

### DIFF
--- a/mpf/tests/machine_files/scoring/config/config.yaml
+++ b/mpf/tests/machine_files/scoring/config/config.yaml
@@ -27,16 +27,6 @@ ball_devices:
         eject_coil: eject_coil1
         tags: trough, drain, home, ball_add_live
 
-logic_blocks:
-  counters:
-    counter_target:
-      count_events: s_counter_target_active
-      starting_count: 3
-      count_complete_value: 0
-      direction: down
-      events_when_complete: counter_target_complete
-      reset_on_complete: true
-
 modes:
   - mode1
   - mode2

--- a/mpf/tests/machine_files/scoring/config/config.yaml
+++ b/mpf/tests/machine_files/scoring/config/config.yaml
@@ -16,6 +16,10 @@ switches:
         number:
     s_ball_switch2:
         number:
+    s_counter_target:
+        number:
+    s_kills_counter_target:
+        number:
 
 ball_devices:
     test_trough:
@@ -23,7 +27,18 @@ ball_devices:
         eject_coil: eject_coil1
         tags: trough, drain, home, ball_add_live
 
+logic_blocks:
+  counters:
+    counter_target:
+      count_events: s_counter_target_active
+      starting_count: 3
+      count_complete_value: 0
+      direction: down
+      events_when_complete: counter_target_complete
+      reset_on_complete: true
+
 modes:
   - mode1
   - mode2
   - mode3
+  - mode_for_logic_block

--- a/mpf/tests/machine_files/scoring/modes/mode1/config/mode1.yaml
+++ b/mpf/tests/machine_files/scoring/modes/mode1/config/mode1.yaml
@@ -34,3 +34,7 @@ scoring:
           action: add_machine
     test_score_mode:
         score: 100
+    s_counter_target_active:
+        score: 10
+    s_kills_counter_target_active:
+        score: 100

--- a/mpf/tests/machine_files/scoring/modes/mode1/config/mode1.yaml
+++ b/mpf/tests/machine_files/scoring/modes/mode1/config/mode1.yaml
@@ -4,6 +4,15 @@ mode:
     stop_events: stop_mode1
     priority: 200
 
+counters:
+  counter_target:
+    count_events: s_counter_target_active
+    starting_count: 3
+    count_complete_value: 0
+    direction: down
+    events_when_complete: counter_target_complete
+    reset_on_complete: true
+
 scoring:
     test_event1:
         score: 100

--- a/mpf/tests/machine_files/scoring/modes/mode_for_logic_block/config/mode_for_logic_block.yaml
+++ b/mpf/tests/machine_files/scoring/modes/mode_for_logic_block/config/mode_for_logic_block.yaml
@@ -1,0 +1,15 @@
+#config_version=4
+# actived when all 5 drop targets have dropped
+# user wants to continue hitting those
+# hitting the special kills the mode
+mode:
+  start_events: counter_target_complete # from logic_block
+  # priority higher that mode1 priority
+  priority: 300
+  stop_events: s_kills_counter_target_active
+
+scoring:
+  s_counter_target_active:
+    score: 100|block
+  s_kills_counter_target_active:
+    score: 500|block

--- a/mpf/tests/test_Scoring.py
+++ b/mpf/tests/test_Scoring.py
@@ -192,3 +192,42 @@ class TestScoring(MpfGameTestCase):
         self.post_event("test_score_mode", 1)
         # should score 100 again (+ 1100 from the previous)
         self.assertPlayerVarEqual(1200, "score")
+
+    def test_blocking_multiple_with_logic_block(self):
+        # start game
+        self.hit_switch_and_run("s_ball_switch1", 1)
+        self.advance_time_and_run(2)
+        self.start_game()
+
+        self.advance_time_and_run(1)
+        self.release_switch_and_run("s_ball_switch1", 20)
+
+        # start mode 1
+        self.post_event("start_mode1", 1)
+
+        # hit target 3 times for 10 points each
+        # and complete the logic block
+        for x in range(0, 3):
+            self.hit_and_release_switch("s_counter_target")
+        self.assertPlayerVarEqual(30, "score")
+
+        # both modes running now
+        self.assertModeRunning('mode_for_logic_block')
+        self.assertModeRunning('mode1')
+
+        # hit the target while in the new mode
+        self.hit_and_release_switch("s_counter_target")
+        self.assertPlayerVarEqual(130, "score")
+
+        # trigger the end of the counter_targer mode
+        # which also blocks its mode1 scoring this once
+        self.hit_and_release_switch("s_kills_counter_target")
+        self.assertPlayerVarEqual(630, "score")
+
+        # only mode1 running now
+        self.assertModeNotRunning('mode_for_logic_block')
+        self.assertModeRunning('mode1')
+
+        # target only scores 10 again... or does it???
+        self.hit_and_release_switch("s_counter_target")
+        self.assertPlayerVarEqual(640, "score")


### PR DESCRIPTION
Here is a test that reproduces the scenario I was describing on #925. It appears the bug might be in`clear_context()` found in `mpf/mpf/config_players/score_player.py` as it seems to only clear the tuple for the switch that triggered the end of the mode. In this case, we have two different score blocking events occur, so one of the tuples ( namely `(300, 'mode_for_logic_block', 's_counter_target_active')` ) remains in the `blocks` attribute of the game state. This prevents the scoring of both switches' lower priority modes.