### PR TITLE
#794: Service Menu - Items sorted in wrong order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,5 +15,6 @@ their spare time, unpaid, for the love of pinball!
  * Philip Dixon <epotech@ntlworld.com>
  * Thomas O'Connell <shastada@gmail.com>
  * Adina Shanholtz <ashanhol@gmail.com>
+ * Fabian Gand <gandfabian@gmail.com>
 
 Want to contribute to MPF? Get started here: http://docs.missionpinball.org/en/latest/about/contributing_to_mpf.html

--- a/mpf/core/service_controller.py
+++ b/mpf/core/service_controller.py
@@ -75,4 +75,5 @@ class ServiceController(MpfController):
 
         # sort by board + driver number
         coil_map.sort(key=lambda x: x[0] + str(x[1].hw_driver.number))
+        coil_map.sort(key=lambda x: len(x[0] + str(x[1].hw_driver.number)))
         return coil_map

--- a/mpf/tests/machine_files/service_mode/config/config.yaml
+++ b/mpf/tests/machine_files/service_mode/config/config.yaml
@@ -17,6 +17,19 @@ coils:
     c_test2:
         number: 2
         label: Second coil
+    c_test3:
+        number: 111
+        label: Sixth coil
+    c_test4:
+        number: 000
+        label: Fifth coil
+    c_test5:
+        number: 3
+        label: Third coil
+    c_test6:
+        number: 10
+        label: Fourth coil
+
 
 switches:
     s_door_open:

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -190,6 +190,28 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.hit_and_release_switch("s_service_enter")
         self.advance_time_and_run()
         self.machine.coils.c_test2.pulse.assert_called_with()
+       
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='Third coil',
+                                   coil_name='c_test5', coil_num='3')
+        
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='Fourth coil',
+                                   coil_name='c_test6', coil_num='10')
+        
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='Fifth coil',
+                                   coil_name='c_test4', coil_num='000')
+        
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='Sixth coil',
+                                   coil_name='c_test3', coil_num='111')
+        
+        
 
         # wrap to first
         self.hit_and_release_switch("s_service_up")
@@ -202,8 +224,8 @@ class TestServiceMode(MpfFakeGameTestCase):
         # wrap back to last
         self.hit_and_release_switch("s_service_down")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='Second coil',
-                                   coil_name='c_test2', coil_num='2')
+        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='Sixth coil',
+                                   coil_name='c_test3', coil_num='111')
 
         # leave coil test
         self.hit_and_release_switch("s_service_esc")


### PR DESCRIPTION
Hey,
i believe the problem was that strings were sorted and therefore lexicographic sorting was used. So the coils were sorted by 1,2,10,3 for example. Taking into account the length of the objects gets rid of this problem. I haven't done a lot of python so far so feedback is always welcome. Adding a unit test to cover this issue should also be possible.