### PR TITLE
Added OPP support for processing switch matrices.  This includes adding

### DIFF
--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -13,6 +13,7 @@ from mpf.platforms.opp.opp_coil import OPPSolenoidCard
 from mpf.platforms.opp.opp_incand import OPPIncandCard
 from mpf.platforms.opp.opp_neopixel import OPPNeopixelCard
 from mpf.platforms.opp.opp_switch import OPPInputCard
+from mpf.platforms.opp.opp_switch import OPPMatrixCard
 from mpf.platforms.opp.opp_rs232_intf import OppRs232Intf
 from mpf.devices.driver import ConfiguredHwDriver
 from mpf.core.platform import MatrixLightsPlatform, LedPlatform, SwitchPlatform, DriverPlatform
@@ -47,6 +48,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         self.opp_inputs = []
         self.inpDict = dict()
         self.inpAddrDict = dict()
+        self.matrixInpAddrDict = dict()
         self.read_input_msg = {}
         self.opp_neopixels = []
         self.neoCardDict = dict()
@@ -68,7 +70,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
 
         if self.machine_type == 'gen1':
             self.log.debug("Configuring the original OPP boards")
-            raise AssertionError("Original OPP boards not currently supported.")
+            raise AssertionError("Gen1 OPP boards will never be supported.")
         elif self.machine_type == 'gen2':
             self.log.debug("Configuring the OPP Gen2 boards")
         else:
@@ -80,13 +82,15 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
             ord(OppRs232Intf.EOM_CMD): self.eom_resp,
             ord(OppRs232Intf.GET_GEN2_CFG): self.get_gen2_cfg_resp,
             ord(OppRs232Intf.READ_GEN2_INP_CMD): self.read_gen2_inp_resp_initial,
-            ord(OppRs232Intf.GET_GET_VERS_CMD): self.vers_resp,
+            ord(OppRs232Intf.GET_VERS_CMD): self.vers_resp,
+            ord(OppRs232Intf.READ_MATRIX_INP): self.read_matrix_inp_resp_initial,
         }
 
     def initialize(self):
         """Initialise connections to OPP hardware."""
         self._connect_to_hardware()
         self.opp_commands[ord(OppRs232Intf.READ_GEN2_INP_CMD)] = self.read_gen2_inp_resp
+        self.opp_commands[ord(OppRs232Intf.READ_MATRIX_INP)] = self.read_matrix_inp_resp
         self._poll_task = self.machine.clock.loop.create_task(self._poll_sender())
         self._poll_task.add_done_callback(self._done)
 
@@ -113,8 +117,8 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
             msg: Message to parse.
         """
         if len(msg) >= 1:
-            if ((msg[0] >= ord(OppRs232Intf.CARD_ID_GEN2_CARD)) and
-                    (msg[0] < (ord(OppRs232Intf.CARD_ID_GEN2_CARD) + 0x20))):
+            # Verify valid Gen2 address
+            if (msg[0] & 0xe0) == 0x20:
                 if len(msg) >= 2:
                     cmd = msg[1]
                 else:
@@ -137,6 +141,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
 
             # TODO: This means synchronization is lost.  Send EOM characters
             #  until they come back
+            self.opp_connection[chain_serial].lost_synch()
 
     def _connect_to_hardware(self):
         """Connect to each port from the config.
@@ -171,12 +176,9 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
 
         This is done once per game loop if changes have been made.
 
-        It is currently assumed that the oversampling will guarantee proper communication
-        with the boards.  If this does not end up being the case, this will be changed
-        to update all the incandescents each loop.
-
-        Note:  This could be made much more efficient by supporting a command
-        that simply sets the state of all 32 of the LEDs as either on or off.
+        It is currently assumed that the UART oversampling will guarantee proper
+        communication with the boards.  If this does not end up being the case,
+        this will be changed to update all the incandescents each loop.
         """
         for incand in self.opp_incands:
             whole_msg = bytearray()
@@ -196,7 +198,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
                 whole_msg.extend(msg)
 
             if len(whole_msg) != 0:
-                whole_msg.extend(OppRs232Intf.EOM_CMD)
+                # Note:  No need to send EOM at end of cmds
                 send_cmd = bytes(whole_msg)
 
                 self.send_to_processor(incand.chain_serial, send_cmd)
@@ -208,17 +210,28 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         return "opp_coils"
 
     def get_hw_switch_states(self):
-        """Get initial hardware switch states."""
+        """Get initial hardware switch states.
+        
+        This changes switches from active low to active high
+        """
         hw_states = dict()
         for opp_inp in self.opp_inputs:
-            curr_bit = 1
-            for index in range(0, 32):
-                if (curr_bit & opp_inp.mask) != 0:
-                    if (curr_bit & opp_inp.oldState) == 0:
-                        hw_states[opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index)] = 1
+            if not opp_inp.isMatrix:
+                curr_bit = 1
+                for index in range(0, 32):
+                    if (curr_bit & opp_inp.mask) != 0:
+                        if (curr_bit & opp_inp.oldState) == 0:
+                            hw_states[opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index)] = 1
+                        else:
+                            hw_states[opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index)] = 0
+                    curr_bit <<= 1
+            else:
+                for index in range(0, 64):
+                    if ((1 << (index & 0x1f)) & opp_inp.oldState[(index & 0x20) >> 5]) == 0:
+                        hw_states[opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index + 32)] = 1
                     else:
-                        hw_states[opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index)] = 0
-                curr_bit <<= 1
+                        hw_states[opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index + 32)] = 0
+                
         return hw_states
 
     def inv_resp(self, chain_serial, msg):
@@ -253,6 +266,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
 
     def _parse_gen2_board(self, chain_serial, msg, read_input_msg):
         has_neo = False
+        has_matrix = False
         wing_index = 0
         sol_mask = 0
         inp_mask = 0
@@ -265,8 +279,12 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
                 inp_mask |= (0xff << (8 * wing_index))
             elif msg[2 + wing_index] == ord(OppRs232Intf.WING_INCAND):
                 incand_mask |= (0xff << (8 * wing_index))
+            elif msg[2 + wing_index] == ord(OppRs232Intf.WING_SW_MATRIX_OUT):
+                has_matrix = True
             elif msg[2 + wing_index] == ord(OppRs232Intf.WING_NEO):
                 has_neo = True
+            elif msg[2 + wing_index] == ord(OppRs232Intf.WING_HI_SIDE_INCAND):
+                incand_mask |= (0xff << (8 * wing_index))
             wing_index += 1
         if incand_mask != 0:
             self.opp_incands.append(OPPIncandCard(chain_serial, msg[0], incand_mask, self.incandDict))
@@ -289,6 +307,25 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
             inp_msg.extend(OppRs232Intf.calc_crc8_whole_msg(inp_msg))
             read_input_msg.extend(inp_msg)
 
+        if has_matrix:
+            # Create the matrix object, and add to the command to read all matrix inputs
+            self.opp_inputs.append(OPPMatrixCard(chain_serial, msg[0], self.inpDict,
+                                   self.matrixInpAddrDict))
+
+            # Add command to read all matrix inputs to read input message
+            inp_msg = bytearray()
+            inp_msg.append(msg[0])
+            inp_msg.extend(OppRs232Intf.READ_MATRIX_INP)
+            inp_msg.append(0)
+            inp_msg.append(0)
+            inp_msg.append(0)
+            inp_msg.append(0)
+            inp_msg.append(0)
+            inp_msg.append(0)
+            inp_msg.append(0)
+            inp_msg.append(0)
+            inp_msg.extend(OppRs232Intf.calc_crc8_whole_msg(inp_msg))
+            read_input_msg.extend(inp_msg)
         if has_neo:
             self.opp_neopixels.append(OPPNeopixelCard(chain_serial, msg[0], self.neoCardDict, self))
 
@@ -304,22 +341,22 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         curr_index = 0
         read_input_msg = bytearray()
         while True:
-            # check that message is long enough
-            if len(msg) < curr_index + 6:
+            # check that message is long enough, must include crc8
+            if len(msg) < curr_index + 7:
                 self.log.warning("Msg is too short: %s.", "".join(" 0x%02x" % b for b in msg))
                 self.opp_connection[chain_serial].lost_synch()
+                break
             # Verify the CRC8 is correct
             crc8 = OppRs232Intf.calc_crc8_part_msg(msg, curr_index, 6)
             if msg[curr_index + 6] != ord(crc8):
                 self.badCRC += 1
                 self.log.warning("Msg contains bad CRC:%s.", "".join(" 0x%02x" % b for b in msg))
                 break
-            else:
-                self._parse_gen2_board(chain_serial, msg[curr_index:curr_index + 6], read_input_msg)
+            self._parse_gen2_board(chain_serial, msg[curr_index:curr_index + 6], read_input_msg)
 
-            if msg[curr_index + 7] == ord(OppRs232Intf.EOM_CMD):
+            if (len(msg) > curr_index + 7) and (msg[curr_index + 7] == ord(OppRs232Intf.EOM_CMD)):
                 break
-            elif msg[curr_index + 8] == ord(OppRs232Intf.GET_GEN2_CFG):
+            elif (len(msg) > curr_index + 8) and (msg[curr_index + 8] == ord(OppRs232Intf.GET_GEN2_CFG)):
                 curr_index += 7
             else:
                 self.log.warning("Malformed GET_GEN2_CFG response:%s.",
@@ -339,40 +376,40 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         """
         # Multiple get version responses can be received at once
         self.log.debug("Received Version Response:%s", "".join(" 0x%02x" % b for b in msg))
-        end = False
         curr_index = 0
-        while not end:
+        while True:
+            # check that message is long enough, must include crc8
+            if len(msg) < curr_index + 7:
+                self.log.warning("Msg is too short: %s.", "".join(" 0x%02x" % b for b in msg))
+                self.opp_connection[chain_serial].lost_synch()
+                break
             # Verify the CRC8 is correct
             crc8 = OppRs232Intf.calc_crc8_part_msg(msg, curr_index, 6)
             if msg[curr_index + 6] != ord(crc8):
                 self.badCRC += 1
-                hex_string = "".join(" 0x%02x" % b for b in msg)
-                self.log.warning("Msg contains bad CRC:%s.", hex_string)
-                end = True
+                self.log.warning("Msg contains bad CRC:%s.", "".join(" 0x%02x" % b for b in msg))
+                break
+            version = (msg[curr_index + 2] << 24) | \
+                (msg[curr_index + 3] << 16) | \
+                (msg[curr_index + 4] << 8) | \
+                msg[curr_index + 5]
+            self.log.debug("Firmware version: %d.%d.%d.%d", msg[curr_index + 2],
+                           msg[curr_index + 3], msg[curr_index + 4],
+                           msg[curr_index + 5])
+            if version < self.minVersion:
+                self.minVersion = version
+            if version == BAD_FW_VERSION:
+                raise AssertionError("Original firmware sent only to Brian before adding "
+                                     "real version numbers. The firmware must be updated before "
+                                     "MPF will work.")
+            if (len(msg) > curr_index + 7) and (msg[curr_index + 7] == ord(OppRs232Intf.EOM_CMD)):
+                break
+            elif (len(msg) > curr_index + 8) and (msg[curr_index + 8] == ord(OppRs232Intf.GET_VERS_CMD)):
+                curr_index += 7
             else:
-                version = (msg[curr_index + 2] << 24) | \
-                    (msg[curr_index + 3] << 16) | \
-                    (msg[curr_index + 4] << 8) | \
-                    msg[curr_index + 5]
-                self.log.debug("Firmware version: %d.%d.%d.%d", msg[curr_index + 2],
-                               msg[curr_index + 3], msg[curr_index + 4],
-                               msg[curr_index + 5])
-                if version < self.minVersion:
-                    self.minVersion = version
-                if version == BAD_FW_VERSION:
-                    raise AssertionError("Original firmware sent only to Brian before adding "
-                                         "real version numbers. The firmware must be updated before "
-                                         "MPF will work.")
-            if not end:
-                if msg[curr_index + 7] == ord(OppRs232Intf.EOM_CMD):
-                    end = True
-                elif msg[curr_index + 8] == ord(OppRs232Intf.GET_GET_VERS_CMD):
-                    curr_index += 7
-                else:
-                    hex_string = "".join(" 0x%02x" % b for b in msg)
-                    self.log.warning("Malformed GET_VERS_CMD response:%s.", hex_string)
-                    end = True
-                    self.opp_connection[chain_serial].lost_synch()
+                self.log.warning("Malformed GET_VERS_CMD response:%s.", "".join(" 0x%02x" % b for b in msg))
+                self.opp_connection[chain_serial].lost_synch()
+                break
 
     def read_gen2_inp_resp_initial(self, chain_serial, msg):
         """Read initial switch states.
@@ -382,7 +419,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
             msg: Message to parse.
         """
         # Verify the CRC8 is correct
-        if len(msg) < 6:
+        if len(msg) < 7:
             raise AssertionError("Received too short initial input response: " + "".join(" 0x%02x" % b for b in msg))
         crc8 = OppRs232Intf.calc_crc8_part_msg(msg, 0, 6)
         if msg[6] != ord(crc8):
@@ -407,8 +444,8 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         # Single read gen2 input response.  Receive function breaks them down
 
         # Verify the CRC8 is correct
-        if len(msg) < 6:
-            self.log.warning("Msg too shortC: %s.", "".join(" 0x%02x" % b for b in msg))
+        if len(msg) < 7:
+            self.log.warning("Msg too short: %s.", "".join(" 0x%02x" % b for b in msg))
             self.opp_connection[chain_serial].lost_synch()
             return
 
@@ -442,6 +479,69 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
                     curr_bit <<= 1
             opp_inp.oldState = new_state
 
+    def read_matrix_inp_resp_initial(self, chain_serial, msg):
+        """Read initial matrix switch states.
+
+        Args:
+            chain_serial: Serial of the chain which received the message.
+            msg: Message to parse.
+        """
+        # Verify the CRC8 is correct
+        if len(msg) < 11:
+            raise AssertionError("Received too short initial input response: " + "".join(" 0x%02x" % b for b in msg))
+        crc8 = OppRs232Intf.calc_crc8_part_msg(msg, 0, 10)
+        if msg[10] != ord(crc8):
+            self.badCRC += 1
+            self.log.warning("Msg contains bad CRC:%s.", "".join(" 0x%02x" % b for b in msg))
+        else:
+            opp_inp = self.matrixInpAddrDict[chain_serial + '-' + str(msg[0])]
+            opp_inp.oldState[0] = (msg[2] << 24) | (msg[3] << 16) | (msg[4] << 8) | msg[5]
+            opp_inp.oldState[1] = (msg[6] << 24) | (msg[7] << 16) | (msg[8] << 8) | msg[9]
+
+    def read_matrix_inp_resp(self, chain_serial, msg):
+        """Read matrix switch changes.
+
+        Args:
+            chain_serial: Serial of the chain which received the message.
+            msg: Message to parse.
+        """
+        # Single read gen2 input response.  Receive function breaks them down
+
+        # Verify the CRC8 is correct
+        if len(msg) < 11:
+            self.log.warning("Msg too short: %s.", "".join(" 0x%02x" % b for b in msg))
+            self.opp_connection[chain_serial].lost_synch()
+            return
+
+        crc8 = OppRs232Intf.calc_crc8_part_msg(msg, 0, 10)
+        if msg[10] != ord(crc8):
+            self.badCRC += 1
+            self.log.warning("Msg contains bad CRC:%s.", "".join(" 0x%02x" % b for b in msg))
+        else:
+            opp_inp = self.matrixInpAddrDict[chain_serial + '-' + str(msg[0])]
+            new_state = [(msg[2] << 24) | (msg[3] << 16) | (msg[4] << 8) | msg[5], \
+                (msg[6] << 24) | (msg[7] << 16) | (msg[8] << 8) | msg[9]]
+
+            # Using a bank so 32 bit python works properly
+            for bank in range(0, 2):
+                changes = opp_inp.oldState[bank] ^ new_state[bank]
+                if changes != 0:
+                    curr_bit = 1
+                    for index in range(0, 32):
+                        if (curr_bit & changes) != 0:
+                            if (curr_bit & new_state[bank]) == 0:
+                                self.machine.switch_controller.process_switch_by_num(
+                                    state=1,
+                                    num=opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index),
+                                    platform=self)
+                            else:
+                                self.machine.switch_controller.process_switch_by_num(
+                                    state=0,
+                                    num=opp_inp.chain_serial + '-' + opp_inp.cardNum + '-' + str(index),
+                                    platform=self)
+                        curr_bit <<= 1
+                opp_inp.oldState[bank] = new_state[bank]
+            
     def reconfigure_driver(self, driver, use_hold: bool):
         """Reconfigure a driver.
 
@@ -461,15 +561,19 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
             if not hold:
                 raise AssertionError("Hold may not be 0")
             if hold >= 16:
-                hold = 15
                 if self.minVersion >= 0x00020000:
-                    # set flag for full power
+                    # set flag for full power, hold is not used
                     cmd += ord(OppRs232Intf.CFG_SOL_ON_OFF)
+                    hold = 0
+                else:
+                    hold = 15
 
-        # TODO: implement separate hold power (0-f) and minimum off time (0-7)
         minimum_off = self.get_minimum_off_time(driver)
 
-        if driver.hw_driver.use_switch:
+        # Before version 0.2.0.0 set solenoid input wasn't available.
+        # CFG_SOL_USE_SWITCH was used to enable/disable a solenoid.  This
+        # will work as long as switches are added using _add_switch_coil_mapping
+        if (self.minVersion < 0x00020000) and driver.hw_driver.use_switch:
             cmd += ord(OppRs232Intf.CFG_SOL_USE_SWITCH)
 
         _, solenoid = driver.config['number'].split('-')
@@ -538,11 +642,8 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         hold = self.get_hold_value(opp_sol)
         self.reconfigure_driver(ConfiguredHwDriver(opp_sol, {}), hold != 0)
 
-        _, _, coil_num = number.split("-")
-        coil_num = int(coil_num)
-        # calculate the default input and remove it by default
-        switch_num = int(coil_num - (coil_num % 4)) * 2 + (coil_num % 4)
-        self._remove_switch_coil_mapping(switch_num, opp_sol)
+        # Removing the default input is not necessary since the
+        # CFG_SOL_USE_SWITCH is not being set
 
         return opp_sol
 
@@ -629,7 +730,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
             for chain_serial in self.read_input_msg:
                 self.send_to_processor(chain_serial, self.read_input_msg[chain_serial])
                 yield from self.opp_connection[chain_serial].writer.drain()
-                # the line above saturates the link and seems to overhelm the hardware. limit it to 100Hz
+                # the line above saturates the link and seems to overwhelm the hardware. limit it to 100Hz
                 yield from asyncio.sleep(1 / self.config['poll_hz'], loop=self.machine.clock.loop)
 
     @asyncio.coroutine
@@ -645,16 +746,16 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
     def _verify_coil_and_switch_fit(self, switch, coil):
         chain_serial, card, solenoid = coil.hw_driver.number.split('-')
         sw_chain_serial, sw_card, sw_num = switch.hw_switch.number.split('-')
-        matching_sw = ((int(solenoid) & 0x0c) << 1) | (int(solenoid) & 0x03)
         if self.minVersion >= 0x00020000:
             if chain_serial != sw_chain_serial or card != sw_card:
                 raise AssertionError('Invalid switch being configured for driver. Driver = %s '
-                                     'Switch = %s. For Firmware 2.0+ driver and switch have to be on the same board.'
+                                     'Switch = %s. For Firmware 0.2.0+ driver and switch have to be on the same board.'
                                      % (coil.hw_driver.number, switch.hw_switch.number))
         else:
+            matching_sw = ((int(solenoid) & 0x0c) << 1) | (int(solenoid) & 0x03)
             if chain_serial != sw_chain_serial or card != sw_card or matching_sw != int(sw_num):
                 raise AssertionError('Invalid switch being configured for driver. Driver = %s '
-                                     'Switch = %s. For Firmware <2.0 they have to be on the same board and have the '
+                                     'Switch = %s. For Firmware < 0.2.0 they have to be on the same board and have the '
                                      'same number' % (coil.hw_driver.number, switch.hw_switch.number))
 
     def set_pulse_on_hit_rule(self, enable_switch, coil):
@@ -721,6 +822,8 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         if not coil.config['recycle']:
             return 0
         elif coil.config['recycle_factor']:
+            if coil.config['recycle_factor'] > 7:
+                raise AssertionError("Maximum recycle_factor allowed is 7")
             return coil.config['recycle_factor']
         else:
             # default to two times pulse_ms
@@ -748,6 +851,9 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         switch_num = int(switch_num)
         self._add_switch_coil_mapping(switch_num, driver_obj.hw_driver)
 
+        # Technically not necessary unless the solenoid parameters are
+        # changing.  MPF may not know when initial kick and hold values
+        # are changed, so this might need to be called each time.
         self.reconfigure_driver(driver_obj, use_hold)
 
     def _remove_switch_coil_mapping(self, switch_num, driver):
@@ -804,6 +910,9 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
             self._remove_switch_coil_mapping(switch_num, coil.hw_driver)
 
         # disable rule if there are no more switches
+        # Technically not necessary unless the solenoid parameters are
+        # changing.  MPF may not know when initial kick and hold values
+        # are changed, so this might need to be called each time.
         if not coil.hw_driver.switches:
             coil.hw_driver.use_switch = False
             self.reconfigure_driver(coil, not coil.hw_driver.can_be_pulsed)
@@ -867,7 +976,7 @@ class OPPSerialCommunicator(BaseSerialCommunicator):
         self.send_get_gen2_cfg_cmd()
         resp = yield from self.readuntil(b'\xff', 6)
 
-        # resp will contain the gen2 cfg reponses.  That will end up creating all the
+        # resp will contain the gen2 cfg responses.  That will end up creating all the
         # correct objects.
         self.platform.process_received_message(self.chain_serial, resp)
 
@@ -919,7 +1028,7 @@ class OPPSerialCommunicator(BaseSerialCommunicator):
         for card_addr in self.platform.gen2AddrArr[self.chain_serial]:
             msg = bytearray()
             msg.append(card_addr)
-            msg.extend(OppRs232Intf.GET_GET_VERS_CMD)
+            msg.extend(OppRs232Intf.GET_VERS_CMD)
             msg.append(0)
             msg.append(0)
             msg.append(0)
@@ -945,7 +1054,7 @@ class OPPSerialCommunicator(BaseSerialCommunicator):
     def _parse_msg(self, msg):
         self.partMsg += msg
         strlen = len(self.partMsg)
-        messaged_found = 0
+        message_found = 0
         # Split into individual responses
         while strlen >= 7:
             if self._lost_synch:
@@ -961,12 +1070,18 @@ class OPPSerialCommunicator(BaseSerialCommunicator):
 
             # Check if this is a gen2 card address
             if (self.partMsg[0] & 0xe0) == 0x20:
-                # Only command expect to receive back is
+                # Check if read input
                 if self.partMsg[1] == ord(OppRs232Intf.READ_GEN2_INP_CMD):
                     self.platform.process_received_message(self.chain_serial, self.partMsg[:7])
-                    messaged_found += 1
+                    message_found += 1
                     self.partMsg = self.partMsg[7:]
                     strlen -= 7
+                # Check if read matrix input
+                elif self.partMsg[1] == ord(OppRs232Intf.READ_MATRIX_INP):
+                    self.platform.process_received_message(self.chain_serial, self.partMsg[:11])
+                    message_found += 1
+                    self.partMsg = self.partMsg[11:]
+                    strlen -= 11
                 else:
                     # Lost synch
                     self.partMsg = self.partMsg[2:]
@@ -982,4 +1097,4 @@ class OPPSerialCommunicator(BaseSerialCommunicator):
                 strlen -= 1
                 self._lost_synch = True
 
-        return messaged_found
+        return message_found

--- a/mpf/platforms/opp/opp_coil.py
+++ b/mpf/platforms/opp/opp_coil.py
@@ -92,7 +92,7 @@ class OPPSolenoidCard(object):
 
     # pylint: disable-msg=too-many-arguments
     def __init__(self, chain_serial, addr, mask, sol_dict, platform):
-        """Initialise OPP solennoid card."""
+        """Initialise OPP solenoid card."""
         self.log = logging.getLogger('OPPSolenoid')
         self.chain_serial = chain_serial
         self.addr = addr

--- a/mpf/platforms/opp/opp_rs232_intf.py
+++ b/mpf/platforms/opp/opp_rs232_intf.py
@@ -7,8 +7,8 @@ class OppRs232Intf:
 
     GET_SER_NUM_CMD = b'\x00'
     GET_PROD_ID_CMD = b'\x01'
-    GET_GET_VERS_CMD = b'\x02'
-    GET_SET_SER_NUM_CMD = b'\x03'
+    GET_VERS_CMD = b'\x02'
+    SET_SER_NUM_CMD = b'\x03'
     RESET_CMD = b'\x04'
     GO_BOOT_CMD = b'\x05'
     CFG_SOL_CMD = b'\x06'
@@ -28,14 +28,14 @@ class OppRs232Intf:
     CFG_IND_INP_CMD = b'\x15'
     SET_IND_NEO_CMD = b'\x16'
     SET_SOL_INP_CMD = b'\x17'
+    UPGRADE_OTHER_BRD = b'\x18'
+    READ_MATRIX_INP = b'\x19'
 
     INV_CMD = b'\xf0'
     ILLEGAL_CMD = b'\xfe'
     EOM_CMD = b'\xff'
 
     CARD_ID_TYPE_MASK = b'\xf0'
-    CARD_ID_SOL_CARD = b'\x00'
-    CARD_ID_INP_CARD = b'\x10'
     CARD_ID_GEN2_CARD = b'\x20'
 
     NUM_G2_WING_PER_BRD = 4
@@ -45,16 +45,25 @@ class OppRs232Intf:
     WING_SW_MATRIX_OUT = b'\x04'
     WING_SW_MATRIX_IN = b'\x05'
     WING_NEO = b'\x06'
+    WING_HI_SIDE_INCAND = b'\x07'
 
     NUM_G2_INP_PER_BRD = 32
     CFG_INP_STATE = b'\x00'
     CFG_INP_FALL_EDGE = b'\x01'
     CFG_INP_RISE_EDGE = b'\x02'
 
+    # Solenoid configuration constants
+    CFG_BYTES_PER_SOL = 3
+    INIT_KICK_OFFSET = 1
+    DUTY_CYCLE_OFFSET = 2
     NUM_G2_SOL_PER_BRD = 16
+    
+    CFG_SOL_DISABLE = b'\x00'
     CFG_SOL_USE_SWITCH = b'\x01'
     CFG_SOL_AUTO_CLR = b'\x02'
     CFG_SOL_ON_OFF = b'\x04'
+    CFG_SOL_DLY_KICK = b'\x08'
+    CFG_SOL_USE_MTRX_INP = b'\x10'
 
     CFG_SOL_INP_REMOVE = b'\x80'
 
@@ -74,14 +83,6 @@ class OppRs232Intf:
     INCAND_SET_ON = b'\x01'
     INCAND_SET_BLINK_SLOW = b'\x02'
     INCAND_SET_BLINK_FAST = b'\x04'
-
-    # Solenoid configuration constants
-    CFG_BYTES_PER_SOL = 3
-    INIT_KICK_OFFSET = 1
-    DUTY_CYCLE_OFFSET = 2
-    # CFG_SOL_USE_SWITCH  = '\x01'
-    # CFG_SOL_AUTO_CLR    = '\x02'
-    CFG_SOL_DISABLE = b'\x00'
 
     CRC8_LOOKUP = [
         0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15, 0x38, 0x3f, 0x36, 0x31, 0x24, 0x23, 0x2a, 0x2d,

--- a/mpf/platforms/opp/opp_switch.py
+++ b/mpf/platforms/opp/opp_switch.py
@@ -16,6 +16,7 @@ class OPPInputCard(object):
         self.log = logging.getLogger('OPPInputCard')
         self.chain_serial = chain_serial
         self.addr = addr
+        self.isMatrix = False
         self.oldState = 0
         self.mask = mask
         self.cardNum = str(addr - ord(OppRs232Intf.CARD_ID_GEN2_CARD))
@@ -28,6 +29,28 @@ class OPPInputCard(object):
                 inp_dict[self.chain_serial + "-" + self.cardNum + '-' + str(index)] =\
                     OPPSwitch(self, self.chain_serial + "-" + self.cardNum + '-' + str(index))
 
+class OPPMatrixCard(object):
+
+    """OPP matrix input card."""
+
+    # pylint: disable-msg=too-many-arguments
+    def __init__(self, chain_serial, addr, inp_dict, inp_addr_dict):
+        """Initialise OPP matrix input card."""
+        self.log = logging.getLogger('OPPMatrixCard')
+        self.chain_serial = chain_serial
+        self.addr = addr
+        self.isMatrix = True
+        self.oldState = [0, 0]
+        self.cardNum = str(addr - ord(OppRs232Intf.CARD_ID_GEN2_CARD))
+
+        self.log.debug("Creating OPP Matrix Input at hardware address: 0x%02x", addr)
+
+        inp_addr_dict[chain_serial + '-' + str(addr)] = self
+        
+        # Matrix inputs are inputs 32 - 95 (OPP only supports 8x8 input switch matrices)
+        for index in range(32, 96):
+            inp_dict[self.chain_serial + "-" + self.cardNum + '-' + str(index)] =\
+                OPPSwitch(self, self.chain_serial + "-" + self.cardNum + '-' + str(index))
 
 class OPPSwitch(SwitchPlatformInterface):
 

--- a/mpf/tests/machine_files/opp/config/config2.yaml
+++ b/mpf/tests/machine_files/opp/config/config2.yaml
@@ -1,0 +1,88 @@
+#config_version=4
+
+hardware:
+    platform: opp
+    driverboards: gen2
+
+opp:
+    ports: com1
+    baud: 115200
+    debug: True
+
+switches:
+    s_test:
+        number: 0-0
+    s_test_no_debounce:
+        number: 0-1
+        debounce: quick
+    s_test_nc:
+        number: 0-2
+        type: 'NC'
+    s_flipper:
+        number: 0-3
+    s_test_card2:
+        number: 0-8
+    s_matrix_test:
+        number: 3-48
+
+coils:
+    c_test:
+        number: 0-0
+        pulse_ms: 23
+    c_test_allow_enable:
+        number: 0-1
+        pulse_ms: 23
+        recycle_factor: 3
+        allow_enable: true
+    c_flipper_hold:
+        number: 0-2
+        allow_enable: true
+    c_flipper_main:
+        number: 0-3
+        pulse_ms: 10
+        hold_power: 3
+    c_holdpower_16:
+        number: 1-12
+        hold_power16: 1
+    c_matrix_test:
+        number: 3-0
+        pulse_ms: 42
+
+matrix_lights:
+  test_light1:
+    number: 0-16
+  test_light2:
+    number: 0-17
+
+leds:
+  test_led1:
+    number: 1-0
+  test_led2:
+    number: 1-1
+
+autofire_coils:
+    ac_slingshot_test:
+        coil: c_test
+        switch: s_test
+
+    ac_slingshot_test2:
+        coil: c_test_allow_enable
+        switch: s_test_no_debounce
+
+    ac_matrix_slingshot_test:
+        coil: c_matrix_test
+        switch: s_matrix_test
+        
+flippers:
+    f_test_single:
+        debug: true
+        #main_coil_overwrite:
+        #    pulse_ms: 11
+        main_coil: c_flipper_main
+        activation_switch: s_flipper
+
+    f_test_hold:
+        debug: true
+        main_coil: c_flipper_main
+        hold_coil: c_flipper_hold
+        activation_switch: s_flipper


### PR DESCRIPTION
OPPMatrixCard and support for READ_MATRIX_INP command.  Small amounts of code cleanup so processing is similar in all cases.  Insure msgs contain enough bytes for crc8 before verifying crc8 is correct.  Removed use of CFG_SOL_USE_SWITCH since using SET_SOL_INP_CMD.  Added config2.yaml for
some additional unit tests.