### PR TITLE
Added OPP support for processing switch matrices.  This includes adding

### DIFF
--- a/mpf/core/platform_controller.py
+++ b/mpf/core/platform_controller.py
@@ -67,6 +67,10 @@ class PlatformController(MpfController):
         pulse_duration = driver.driver.get_and_verify_pulse_ms(pulse_setting.duration if pulse_setting else None)
         pulse_power = driver.driver.get_and_verify_pulse_power(pulse_setting.power if pulse_setting else None)
         hold_power = driver.driver.get_and_verify_hold_power(hold_settings.power if hold_settings else None)
+
+        if hold_power == 0.0:
+            raise AssertionError("Cannot enable driver with hold_power 0.0")
+
         return DriverSettings(
             hw_driver=driver.driver.hw_driver,
             pulse_settings=PulseSettings(duration=pulse_duration, power=pulse_power),

--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -7,6 +7,8 @@ boards.
 import logging
 import asyncio
 
+from mpf.platforms.interfaces.driver_platform_interface import PulseSettings, HoldSettings
+
 from mpf.platforms.base_serial_communicator import BaseSerialCommunicator
 
 from mpf.platforms.opp.opp_coil import OPPSolenoidCard
@@ -601,12 +603,12 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         opp_sol.config = config
         opp_sol.platform_settings = platform_settings
         self.log.debug("Configure driver %s", number)
+        default_pulse = PulseSettings(config.default_pulse_power, config.default_pulse_ms)
+        default_hold = HoldSettings(config.default_hold_power)
+        opp_sol.reconfigure_driver(default_pulse, default_hold)
 
-        _, _, coil_num_str = number.split("-")
-        coil_num = int(coil_num_str)
-        # calculate the default input and remove it by default
-        switch_num = int(coil_num - (coil_num % 4)) * 2 + (coil_num % 4)
-        self._remove_switch_coil_mapping(switch_num, opp_sol)
+        # Removing the default input is not necessary since the
+        # CFG_SOL_USE_SWITCH is not being set
 
         return opp_sol
 

--- a/mpf/platforms/opp/opp_rs232_intf.py
+++ b/mpf/platforms/opp/opp_rs232_intf.py
@@ -7,8 +7,8 @@ class OppRs232Intf:
 
     GET_SER_NUM_CMD = b'\x00'
     GET_PROD_ID_CMD = b'\x01'
-    GET_GET_VERS_CMD = b'\x02'
-    GET_SET_SER_NUM_CMD = b'\x03'
+    GET_VERS_CMD = b'\x02'
+    SET_SER_NUM_CMD = b'\x03'
     RESET_CMD = b'\x04'
     GO_BOOT_CMD = b'\x05'
     CFG_SOL_CMD = b'\x06'
@@ -28,14 +28,14 @@ class OppRs232Intf:
     CFG_IND_INP_CMD = b'\x15'
     SET_IND_NEO_CMD = b'\x16'
     SET_SOL_INP_CMD = b'\x17'
+    UPGRADE_OTHER_BRD = b'\x18'
+    READ_MATRIX_INP = b'\x19'
 
     INV_CMD = b'\xf0'
     ILLEGAL_CMD = b'\xfe'
     EOM_CMD = b'\xff'
 
     CARD_ID_TYPE_MASK = b'\xf0'
-    CARD_ID_SOL_CARD = b'\x00'
-    CARD_ID_INP_CARD = b'\x10'
     CARD_ID_GEN2_CARD = b'\x20'
 
     NUM_G2_WING_PER_BRD = 4
@@ -45,16 +45,25 @@ class OppRs232Intf:
     WING_SW_MATRIX_OUT = b'\x04'
     WING_SW_MATRIX_IN = b'\x05'
     WING_NEO = b'\x06'
+    WING_HI_SIDE_INCAND = b'\x07'
 
     NUM_G2_INP_PER_BRD = 32
     CFG_INP_STATE = b'\x00'
     CFG_INP_FALL_EDGE = b'\x01'
     CFG_INP_RISE_EDGE = b'\x02'
 
+    # Solenoid configuration constants
+    CFG_BYTES_PER_SOL = 3
+    INIT_KICK_OFFSET = 1
+    DUTY_CYCLE_OFFSET = 2
     NUM_G2_SOL_PER_BRD = 16
+    
+    CFG_SOL_DISABLE = b'\x00'
     CFG_SOL_USE_SWITCH = b'\x01'
     CFG_SOL_AUTO_CLR = b'\x02'
     CFG_SOL_ON_OFF = b'\x04'
+    CFG_SOL_DLY_KICK = b'\x08'
+    CFG_SOL_USE_MTRX_INP = b'\x10'
 
     CFG_SOL_INP_REMOVE = b'\x80'
 
@@ -74,14 +83,6 @@ class OppRs232Intf:
     INCAND_SET_ON = b'\x01'
     INCAND_SET_BLINK_SLOW = b'\x02'
     INCAND_SET_BLINK_FAST = b'\x04'
-
-    # Solenoid configuration constants
-    CFG_BYTES_PER_SOL = 3
-    INIT_KICK_OFFSET = 1
-    DUTY_CYCLE_OFFSET = 2
-    # CFG_SOL_USE_SWITCH  = '\x01'
-    # CFG_SOL_AUTO_CLR    = '\x02'
-    CFG_SOL_DISABLE = b'\x00'
 
     CRC8_LOOKUP = [
         0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15, 0x38, 0x3f, 0x36, 0x31, 0x24, 0x23, 0x2a, 0x2d,

--- a/mpf/platforms/opp/opp_switch.py
+++ b/mpf/platforms/opp/opp_switch.py
@@ -16,6 +16,7 @@ class OPPInputCard(object):
         self.log = logging.getLogger('OPPInputCard')
         self.chain_serial = chain_serial
         self.addr = addr
+        self.isMatrix = False
         self.oldState = 0
         self.mask = mask
         self.cardNum = str(addr - ord(OppRs232Intf.CARD_ID_GEN2_CARD))
@@ -28,6 +29,28 @@ class OPPInputCard(object):
                 inp_dict[self.chain_serial + "-" + self.cardNum + '-' + str(index)] =\
                     OPPSwitch(self, self.chain_serial + "-" + self.cardNum + '-' + str(index))
 
+class OPPMatrixCard(object):
+
+    """OPP matrix input card."""
+
+    # pylint: disable-msg=too-many-arguments
+    def __init__(self, chain_serial, addr, inp_dict, inp_addr_dict):
+        """Initialise OPP matrix input card."""
+        self.log = logging.getLogger('OPPMatrixCard')
+        self.chain_serial = chain_serial
+        self.addr = addr
+        self.isMatrix = True
+        self.oldState = [0, 0]
+        self.cardNum = str(addr - ord(OppRs232Intf.CARD_ID_GEN2_CARD))
+
+        self.log.debug("Creating OPP Matrix Input at hardware address: 0x%02x", addr)
+
+        inp_addr_dict[chain_serial + '-' + str(addr)] = self
+        
+        # Matrix inputs are inputs 32 - 95 (OPP only supports 8x8 input switch matrices)
+        for index in range(32, 96):
+            inp_dict[self.chain_serial + "-" + self.cardNum + '-' + str(index)] =\
+                OPPSwitch(self, self.chain_serial + "-" + self.cardNum + '-' + str(index))
 
 class OPPSwitch(SwitchPlatformInterface):
 

--- a/mpf/tests/machine_files/opp/config/config2.yaml
+++ b/mpf/tests/machine_files/opp/config/config2.yaml
@@ -1,0 +1,87 @@
+#config_version=5
+
+hardware:
+    platform: opp
+    driverboards: gen2
+
+opp:
+    ports: com1
+    baud: 115200
+    debug: True
+
+switches:
+    s_test:
+        number: 0-0
+    s_test_no_debounce:
+        number: 0-1
+        debounce: quick
+    s_test_nc:
+        number: 0-2
+        type: 'NC'
+    s_flipper:
+        number: 0-3
+    s_test_card2:
+        number: 0-8
+    s_matrix_test:
+        number: 3-48
+
+coils:
+    c_test:
+        number: 0-0
+        default_pulse_ms: 23
+    c_test_allow_enable:
+        number: 0-1
+        default_pulse_ms: 23
+        platform_settings:
+            recycle_factor: 3
+        default_hold_power: 1.0
+    c_flipper_hold:
+        number: 0-2
+        default_hold_power: 1.0
+    c_flipper_main:
+        number: 0-3
+        default_pulse_ms: 10
+        default_hold_power: 0.375
+    c_holdpower_16:
+        number: 1-12
+        default_hold_power: 0.0625
+    c_matrix_test:
+        number: 3-0
+        default_pulse_ms: 42
+
+lights:
+  test_light1:
+    number: 0-16
+    subtype: matrix
+  test_light2:
+    number: 0-17
+    subtype: matrix
+  test_led1:
+    number: 1-0
+  test_led2:
+    number: 1-1
+
+autofire_coils:
+    ac_slingshot_test:
+        coil: c_test
+        switch: s_test
+
+    ac_slingshot_test2:
+        coil: c_test_allow_enable
+        switch: s_test_no_debounce
+
+    ac_matrix_slingshot_test:
+        coil: c_matrix_test
+        switch: s_matrix_test
+        
+flippers:
+    f_test_single:
+        debug: true
+        main_coil: c_flipper_main
+        activation_switch: s_flipper
+
+    f_test_hold:
+        debug: true
+        main_coil: c_flipper_main
+        hold_coil: c_flipper_hold
+        activation_switch: s_flipper


### PR DESCRIPTION
OPPMatrixCard and support for READ_MATRIX_INP command.  Small amounts of
code cleanup so processing is similar in all cases.  Insure msgs contain
enough bytes for crc8 before verifying crc8 is correct.  Removed use of
CFG_SOL_USE_SWITCH since using SET_SOL_INP_CMD.  Added config2.yaml for
some additional unit tests.