### PR TITLE
Allow dict keys as valid attrs in _eval_attribute() lookups

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,5 +17,6 @@ their spare time, unpaid, for the love of pinball!
  * Adina Shanholtz <ashanhol@gmail.com>
  * Andres Rosales <meepman32@gmail.com>
  * Fabian Gand <gandfabian@gmail.com>
+ * Anthony van Winkle <mpf@anthonyvanwinkle.com>
 
 Want to contribute to MPF? Get started here: http://docs.missionpinball.org/en/latest/about/contributing_to_mpf.html

--- a/mpf/core/placeholder_manager.py
+++ b/mpf/core/placeholder_manager.py
@@ -521,7 +521,10 @@ class BasePlaceholderManager(MpfController):
 
     def _eval_attribute(self, node, variables, subscribe):
         slice_value, subscription = self._eval(node.value, variables, subscribe)
-        ret_value = getattr(slice_value, node.attr)
+        if isinstance(slice_value, dict) and node.attr in slice_value:
+            ret_value = slice_value[node.attr]
+        else:
+            ret_value = getattr(slice_value, node.attr)
         if subscribe:
             return ret_value, subscription + [slice_value.subscribe_attribute(node.attr)]
         else:


### PR DESCRIPTION
### Summary:
This PR expands the lookup of `_eval_attribute()` for situations when the object being queried is a native `dict` type rather than a proper `object`. In particular, this is useful for conditional events based on the state of an achievement.


### New Behavior:
With this change, the following conditional events are valid:
```
event_player:
  mode_base_started{device.achievements.savetheworld.state!="complete"}:
    - start_mode_bettergetgoing
  mode_base_started{device.achievements.savetheworld.state=="complete"}:
    - start_mode_youreahero
```


### Current Behavior:
Unlike other conditional lookups that store values as attributes, a `device.achievements.<achievementname>` object is a Python dictionary and has no user-defined attributes. In the current behavior, the above conditional events will crash as follows:
```
Traceback (most recent call last):
  File ".../mpf/mpf/core/placeholder_manager.py", line 66, in evaluate
    result = self.placeholder_manager.evaluate_template(self.template, parameters)
  File ".../mpf/mpf/core/placeholder_manager.py", line 588, in evaluate_template
    return self._eval(template, parameters, False)[0]
  File ".../mpf/mpf/core/placeholder_manager.py", line 560, in _eval
    return self._eval_methods[type(node)](node, variables, subscribe)
  File ".../mpf/mpf/core/placeholder_manager.py", line 504, in _eval_compare
    left_value, left_subscription = self._eval(node.left, variables, subscribe)
  File ".../mpf/mpf/core/placeholder_manager.py", line 560, in _eval
    return self._eval_methods[type(node)](node, variables, subscribe)
  File ".../mpf/mpf/core/placeholder_manager.py", line 524, in _eval_attribute
    ret_value = getattr(slice_value, node.attr)
AttributeError: 'dict' object has no attribute 'state'
```


### Other Notes:
This is my first PR for Mission Pinball! I've parsed all the code/documentation I could find on how else to create an achievement-based conditional event, but came up with nothing. If I just missed it and this PR is unnecessary, please let me know! Also, any other feedback would be much appreciated. 😄 