### PR TITLE
Check duplicate lights on Spike by including node in address uniqueness

### DIFF
--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -97,7 +97,8 @@ class Light(SystemWideDevice):
         check_set = set()
         for light in machine.lights:
             for driver in light.hw_drivers.values():
-                key = (light.platform, driver.number, type(driver))
+                # Spike platforms identify unique addresses by node + number, so include node if available
+                key = (light.platform, getattr(driver, "node", None), driver.number, type(driver))
                 if key in check_set:
                     raise AssertionError(
                         "Duplicate light number {} {} for light {}".format(


### PR DESCRIPTION
The recent update to check for duplicate light addresses triggered a false positive on Spike platforms, which use `device.node` plus `device.number` to identify a unique address. During the duplicate light check, a light with address `10-14` would fail as duplicating a light with address `8-14`.

This PR checks for the presence of `device.node` and includes the value when creating the unique key for a light, thereby ensuring that lights of the same number on different nodes are not considered duplicates.