### PR TITLE
Anchor rounding centered widgets

### DIFF
--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -319,6 +319,8 @@ displays:
     height: single|int|600
     default: single|bool|False
     fps: single|int|0
+    round_anchor_x: single|str|center
+    round_anchor_y: single|str|middle
 display_light_player:
     __valid_in__: machine, mode, show
     action: single|enum(play,stop)|play
@@ -1406,6 +1408,8 @@ widgets:
         y: single|str|None
         anchor_x: single|str|center
         anchor_y: single|str|center
+        round_anchor_x: single|str|None
+        round_anchor_y: single|str|None
         opacity: single|float|1.0
         z: single|int|0
         animations: ignore


### PR DESCRIPTION
This PR updates the *config_spec* to allow `round_anchor_x` and `round_anchor_y` on `displays:` and `widgets:` config blocks.

This is to enable the anchor pixel rounding functionality of PR https://github.com/missionpinball/mpf-mc/pull/294