### PR TITLE
Autofire timeout

### DIFF
--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -100,9 +100,9 @@ autofire_coils:
     ball_search_order: single|int|100
     playfield: single|machine(playfields)|playfield
     enable_timeouts: single|bool|False
-    timeout_watch_time: single|s|0
+    timeout_watch_time: single|ms|0
     timeout_max_hits: single|int|0
-    timeout_disable_time: single|s|0
+    timeout_disable_time: single|ms|0
 coil_overwrites:
     __valid_in__: machine
     recycle: single|bool|None

--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -99,6 +99,10 @@ autofire_coils:
     switch_overwrite: dict|str:str|None
     ball_search_order: single|int|100
     playfield: single|machine(playfields)|playfield
+    enable_timeouts: single|bool|False
+    timeout_watch_time: single|s|0
+    timeout_max_hits: single|int|0
+    timeout_disable_time: single|s|0
 coil_overwrites:
     __valid_in__: machine
     recycle: single|bool|None

--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -583,6 +583,10 @@ kickbacks:
     switch_overwrite: dict|str:str|None
     ball_search_order: single|int|100
     playfield: single|machine(playfields)|playfield
+    enable_timeouts: single|bool|False
+    timeout_watch_time: single|ms|0
+    timeout_max_hits: single|int|0
+    timeout_disable_time: single|ms|0
 kivy_config:
     __valid_in__: machine                           # todo add to validator
 led_player:

--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -99,7 +99,6 @@ autofire_coils:
     switch_overwrite: dict|str:str|None
     ball_search_order: single|int|100
     playfield: single|machine(playfields)|playfield
-    enable_timeouts: single|bool|False
     timeout_watch_time: single|ms|0
     timeout_max_hits: single|int|0
     timeout_disable_time: single|ms|0
@@ -583,7 +582,6 @@ kickbacks:
     switch_overwrite: dict|str:str|None
     ball_search_order: single|int|100
     playfield: single|machine(playfields)|playfield
-    enable_timeouts: single|bool|False
     timeout_watch_time: single|ms|0
     timeout_max_hits: single|int|0
     timeout_disable_time: single|ms|0

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -61,6 +61,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.shot_group import ShotGroup
     from mpf.devices.shot import Shot
     from logging import Logger  # noqa
+    from mpf.devices.autofire import AutofireCoil
 
 
 # pylint: disable-msg=too-many-instance-attributes
@@ -129,6 +130,7 @@ class MachineController(LogMixin):
             self.tui = None                             # type: TextUi
 
             # devices
+            self.autofires = None                       # type: DeviceCollectionType[str, AutofireCoil]
             self.shows = None                           # type: DeviceCollectionType[str, Show]
             self.shots = None                           # type: DeviceCollectionType[str, Shot]
             self.shot_groups = None                     # type: DeviceCollectionType[str, ShotGroup]

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -48,9 +48,9 @@ class AutofireCoil(SystemWideDevice):
         # pulse is handled via rule but add a handler so that we take notice anyway
         self.config['switch'].add_handler(self._hit)
         if self.config['enable_timeouts']:
-            self._timeout_watch_time = self.config['timeout_watch_time']
+            self._timeout_watch_time = self.config['timeout_watch_time']/1000
             self._timeout_max_hits = self.config['timeout_max_hits']
-            self._timeout_disable_time = self.config['timeout_disable_time']
+            self._timeout_disable_time = self.config['timeout_disable_time']/1000
             self._timeout_hits = []
             from time import time as _time
             from threading import Timer as _Timer

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -42,11 +42,6 @@ class AutofireCoil(SystemWideDevice):
         super().__init__(machine, name)
         self.delay = DelayManager(self.machine.delayRegistry)
         self._ball_search_in_progress = False
-        if self.config['enable_timeouts']:
-            self._timeout_watch_time = self.config['timeout_watch_time'] / 1000
-            self._timeout_max_hits = self.config['timeout_max_hits']
-            self._timeout_disable_time = self.config['timeout_disable_time']
-            self._timeout_hits = []
 
     def _initialize(self) -> None:
         if self.config['ball_search_order']:
@@ -54,6 +49,11 @@ class AutofireCoil(SystemWideDevice):
                 self.config['ball_search_order'], self._ball_search, self.name)
         # pulse is handled via rule but add a handler so that we take notice anyway
         self.config['switch'].add_handler(self._hit)
+        if self.config['enable_timeouts']:
+            self._timeout_watch_time = self.config['timeout_watch_time'] / 1000
+            self._timeout_max_hits = self.config['timeout_max_hits']
+            self._timeout_disable_time = self.config['timeout_disable_time']
+            self._timeout_hits = []
 
     @event_handler(10)
     def enable(self, **kwargs):

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -6,6 +6,8 @@ from mpf.core.platform_controller import SwitchRuleSettings, DriverRuleSettings,
 
 from mpf.core.system_wide_device import SystemWideDevice
 
+from time import time as _time
+
 MYPY = False
 if MYPY:   # pragma: no cover
     from mpf.core.machine import MachineController
@@ -50,10 +52,8 @@ class AutofireCoil(SystemWideDevice):
         if self.config['enable_timeouts']:
             self._timeout_watch_time = self.config['timeout_watch_time']/1000
             self._timeout_max_hits = self.config['timeout_max_hits']
-            self._timeout_disable_time = self.config['timeout_disable_time']/1000
+            self._timeout_disable_time = self.config['timeout_disable_time']
             self._timeout_hits = []
-            from time import time as _time
-            from threading import Timer as _Timer
 
     @event_handler(10)
     def enable(self, **kwargs):
@@ -105,6 +105,8 @@ class AutofireCoil(SystemWideDevice):
 
         """
         del kwargs
+        
+        self.delay.remove("_timeout_enable_delay")
 
         if not self._enabled:
             return
@@ -126,8 +128,7 @@ class AutofireCoil(SystemWideDevice):
                     break
             if len(self._timeout_hits)>self._timeout_max_hits:
                 self.disable()
-                _timeout_timer=_Timer(self._timeout_disable_time,self.enable)
-                _timeout_timer.start()
+                self.delay.add(self._timeout_disable_time,self.enable,"_timeout_enable_delay")
 
     def _ball_search(self, phase, iteration):
         del phase

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -1,6 +1,4 @@
 """Contains the base class for autofire coil devices."""
-from time import time as _time
-
 from mpf.core.delays import DelayManager
 from mpf.core.device_monitor import DeviceMonitor
 from mpf.core.events import event_handler
@@ -123,13 +121,11 @@ class AutofireCoil(SystemWideDevice):
         if not self._ball_search_in_progress:
             self.config['playfield'].mark_playfield_active_from_device_action()
         if self._timeout_watch_time:
-            self._timeout_hits.append(_time())
-            while True:
-                if self._timeout_hits[-1] - self._timeout_hits[0] > self._timeout_watch_time:
-                    self._timeout_hits.pop(0)
-                else:
-                    break
-            if len(self._timeout_hits) > self._timeout_max_hits:
+            current_time = self.machine.clock.get_time()
+            self._timeout_hits = [t for t in self._timeout_hits if t > current_time - self._timeout_watch_time / 1000.0]
+            self._timeout_hits.append(current_time)
+
+            if len(self._timeout_hits) >= self._timeout_max_hits:
                 self.disable()
                 self.delay.add(self._timeout_disable_time, self.enable, "_timeout_enable_delay")
 

--- a/mpf/tests/machine_files/autofire/config/config.yaml
+++ b/mpf/tests/machine_files/autofire/config/config.yaml
@@ -20,10 +20,13 @@ autofire_coils:
     ac_test:
         coil: c_test
         switch: s_test
+        enable_timeouts: False
     ac_test_inverted:
         coil: c_test2
         switch: s_test_nc
+        enable_timeouts: False
     ac_test_inverted2:
         coil: c_test2
         switch: s_test
         reverse_switch: True
+        enable_timeouts: False

--- a/mpf/tests/machine_files/autofire/config/config.yaml
+++ b/mpf/tests/machine_files/autofire/config/config.yaml
@@ -20,13 +20,10 @@ autofire_coils:
     ac_test:
         coil: c_test
         switch: s_test
-        enable_timeouts: False
     ac_test_inverted:
         coil: c_test2
         switch: s_test_nc
-        enable_timeouts: False
     ac_test_inverted2:
         coil: c_test2
         switch: s_test
         reverse_switch: True
-        enable_timeouts: False

--- a/mpf/tests/machine_files/autofire/config/config.yaml
+++ b/mpf/tests/machine_files/autofire/config/config.yaml
@@ -27,3 +27,9 @@ autofire_coils:
         coil: c_test2
         switch: s_test
         reverse_switch: True
+    ac_test_timeout:
+        coil: c_test
+        switch: s_test
+        timeout_watch_time: 1s
+        timeout_max_hits: 10
+        timeout_disable_time: 500ms

--- a/mpf/tests/machine_files/autofire/config/config.yaml
+++ b/mpf/tests/machine_files/autofire/config/config.yaml
@@ -20,10 +20,13 @@ autofire_coils:
     ac_test:
         coil: c_test
         switch: s_test
+        enable_timeout: False
     ac_test_inverted:
         coil: c_test2
         switch: s_test_nc
+        enable_timout: False
     ac_test_inverted2:
         coil: c_test2
         switch: s_test
         reverse_switch: True
+        enable_timeout: False

--- a/mpf/tests/machine_files/autofire/config/config.yaml
+++ b/mpf/tests/machine_files/autofire/config/config.yaml
@@ -20,13 +20,10 @@ autofire_coils:
     ac_test:
         coil: c_test
         switch: s_test
-        enable_timeout: False
     ac_test_inverted:
         coil: c_test2
         switch: s_test_nc
-        enable_timout: False
     ac_test_inverted2:
         coil: c_test2
         switch: s_test
         reverse_switch: True
-        enable_timeout: False


### PR DESCRIPTION
More of a request to test than to merge. I am currently unable to do any tests myself. I was wondering if someone could look over this. It *should* work but I'm not confident in it. What it's supposed to do is add the ability for autofire devices to automatically disable themselves for X amount of seconds if they are triggered Y times in Z seconds. X, Y, and Z are options in the config file. There's also an option to disable the timeout entirely. Basically, when disabled it shouldn't change anything. Sorry for anything I did wrong. I'm new to GitHub and okay-ish at Python. Thanks in advance.