### PR TITLE
Support kwargs in event handler conditions

### DIFF
--- a/mpf/config_players/event_player.py
+++ b/mpf/config_players/event_player.py
@@ -19,12 +19,11 @@ class EventPlayer(FlatConfigPlayer):
 
     def play(self, settings, context, calling_context, priority=0, **kwargs):
         """Post (delayed) events."""
-        del kwargs
         for event, s in settings.items():
             s = deepcopy(s)
             event_dict = self.machine.placeholder_manager.parse_conditional_template(event)
 
-            if event_dict['condition'] and not event_dict['condition'].evaluate([]):
+            if event_dict['condition'] and not event_dict['condition'].evaluate(kwargs):
                 continue
 
             if event_dict['number']:


### PR DESCRIPTION
This PR is an update to https://github.com/missionpinball/mpf/pull/1067 that allows event kwargs to be used in the conditions of event handlers.

The original feature was built and tested using only machine/player variables, but this fix is needed to evaluate a condition based on the `Args` of the event that triggered the handler.

I know `delete kwargs` is commonly used to prevent propagation and distinguish between regular and relay events. I removed the deletion line for the `play` method but don't believe it should have any behavioral impacts, since there are no other calls that reference/relay it. Right?