### PR TITLE
Issue #1075: mpf both crashes with termios.error

### DIFF
--- a/mpf/commands/both.py
+++ b/mpf/commands/both.py
@@ -21,11 +21,8 @@ class Command(object):
     def __init__(self, mpf_path, machine_path, args):
         """Run game and mc."""
         multiprocessing.set_start_method('spawn')
-        mpf = multiprocessing.Process(target=_start_mpf,
-                                      args=(mpf_path, machine_path, args))
         mc = multiprocessing.Process(target=_start_mc,
                                      args=(mpf_path, machine_path, args))
-        mpf.start()
         mc.start()
-        mpf.join()
+        _start_mpf(mpf_path, machine_path, args)
         mc.join()


### PR DESCRIPTION
Changing both.py to run MC in mutliprocessing and leave MPF running in the main thread should sidestep the issue with termios unable to access the tty stdin.