### PR TITLE
Fix multiball_lock event unregister and duplicates

### DIFF
--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -168,6 +168,7 @@ class MultiballLock(ModeDevice):
     def _unregister_handlers(self):
         # unregister ball_enter handlers
         self.machine.events.remove_handler(self._lock_ball)
+        self.machine.events.remove_handler(self._post_events)
 
     @property
     def is_virtually_full(self):
@@ -284,6 +285,7 @@ class MultiballLock(ModeDevice):
         del kwargs
         for event in self._events[device]:
             self.machine.events.post(**event)
+        self._events[device] = []
 
     def _request_new_balls(self, balls):
         """Request new ball to playfield."""


### PR DESCRIPTION
This PR fixes two minor bugs in `multiball_lock` behavior events.

1. When enabled, a multiball lock registers two event handlers `_lock_ball` and `_post_events`, but when the lock is disabled only `_lock_ball` is removed. This PR includes the removal of `_post_events` when unregistering.

2. When posting events, a multiball lock creates an array of events and then iterates posting them. This array is never cleared, so each new event posting (e.g. `total_balls=2` includes all previous events e.g. `total_balls=1`). This PR clears the array of events after they have been posted.