### PR TITLE
Restore "(shot_group)_(profile)_(state)_hit" event

### DIFF
--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -110,9 +110,11 @@ class ShotGroup(ModeDevice):
         """One of the member shots in this shot group was hit.
 
         Args:
-            kwarg: unused
+            kwarg: {
+                profile: the current profile of the member shot that was hit
+                state: the current state of the member shot that was hit
+            }
         """
-        del kwargs
         if advancing:
             self._check_for_complete()
 
@@ -120,6 +122,11 @@ class ShotGroup(ModeDevice):
         '''event: (shot_group)_hit
         desc: A member shots in the shot group called (shot_group)
         has been hit.
+        '''
+        self.machine.events.post("{}_{}_{}_hit".format(self.name, kwargs['profile'], kwargs['state']))
+        '''event: (shot_group)_(state)_hit
+        desc: A member shot with profile (profile) and state (state)
+        in the shot group (shot_group) has been hit.
         '''
 
     @event_handler(9)

--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -113,6 +113,7 @@ class ShotGroup(ModeDevice):
             kwarg: {
                 profile: the current profile of the member shot that was hit
                 state: the current state of the member shot that was hit
+                advancing: boolean of whether the state is advancing
             }
         """
         if advancing:
@@ -123,10 +124,10 @@ class ShotGroup(ModeDevice):
         desc: A member shots in the shot group called (shot_group)
         has been hit.
         '''
-        self.machine.events.post("{}_{}_{}_hit".format(self.name, kwargs['profile'], kwargs['state']))
+        self.machine.events.post("{}_{}_hit".format(self.name, kwargs['state']))
         '''event: (shot_group)_(state)_hit
-        desc: A member shot with profile (profile) and state (state)
-        in the shot group (shot_group) has been hit.
+        desc: A member shot with state (state) in the shot group (shot_group)
+        has been hit.
         '''
 
     @event_handler(9)


### PR DESCRIPTION
This PR reverts one change from https://github.com/missionpinball/mpf/pull/1033, specifically [refactor Shots and ShotGroups](https://github.com/missionpinball/mpf/commit/c90b0d73f88375c069b87c30a9b01e228bc4bd5c).

The changes above simplified and streamlined the shot_group logic, but in the process eliminated the profile-specific events.

**Events posted before refactor:**
* `(shot_group)_hit Args={profile: profile, state: state}`
* `(shot_group)_(profile)_hit Args={profile: profile, state: state}`
* `(shot_group)_(profile)_(state)_hit Args={profile: profile, state: state}`

**Events posted after refactor:**
* `(shot_group)_hit Args={}`

**Use Case:**
The use case affected is a collection of shots in a group with one or more shots in various states. The shot group provides a means to rotate which of the shots are in which states, and when a player hits a shot in the group it is desired to have event handlers based on the state of the shot hit. Examples: a "chase" mode, an elimination mode, or a random shot mode.

Currently, an event handler must be attached for every shot in the group in order to capture events based on state. This PR restores one event to the shot group that includes the profile and state: `(shot_group)_(profile)_(state)`

I'm open to other ideas and suggestions on how to handle the above use cases, if shot_groups are not ideal or if passing arguments is preferred. Thanks!
