### PR TITLE
Enable ‘casing’ as config setting for Text Widget

### DIFF
--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -1520,6 +1520,7 @@ widgets:
         valign: single|str|middle
         rotation: single|int|0
         scale: single|float|1.0
+        casing: single|str|None
         # outline_color: single|kivycolor|ffffffff
         # outline_width: single|int|0
         # text_size: single|int|None  # sets width of bounding box, not font


### PR DESCRIPTION
This PR is the companion to the MPF-MC PR https://github.com/missionpinball/mpf-mc/pull/305 for the new Text Widget config setting "casing".

This PR just adds "casing" as a valid setting name in `config_spec.py`.