### PR TITLE
Support conditional event handlers for score and show players

### DIFF
--- a/mpf/config_players/score_player.py
+++ b/mpf/config_players/score_player.py
@@ -33,6 +33,9 @@ class ScorePlayer(ConfigPlayer):
             if var == "block":
                 raise AssertionError('Do not use "block" as variable name in score_player.')
 
+            if s['condition'] and not s['condition'].evaluate(kwargs):
+                continue
+
             block_item = var + ":" + calling_context
             if self._is_blocked(block_item, context, priority):
                 continue
@@ -102,7 +105,10 @@ class ScorePlayer(ConfigPlayer):
             raise AssertionError("Settings of score_player {} should "
                                  "be a dict. But are: {}".format(name, settings))
         for var, s in settings.items():
-            config[var] = self._parse_config(s, name)
+            var_dict = self.machine.placeholder_manager.parse_conditional_template(var)
+            score_dict = self._parse_config(s, name)
+            score_dict["condition"] = var_dict["condition"]
+            config[var_dict["name"]] = score_dict
         return config
 
     def get_express_config(self, value: Any) -> dict:

--- a/mpf/config_players/show_player.py
+++ b/mpf/config_players/show_player.py
@@ -18,6 +18,11 @@ class ShowPlayer(DeviceConfigPlayer):
         if not start_time:
             start_time = self.machine.clock.get_time()
         for show, show_settings in settings.items():
+            # Look for a conditional event in the show name
+            show_dict = self.machine.placeholder_manager.parse_conditional_template(show)
+            if show_dict['condition'] and not show_dict['condition'].evaluate(kwargs):
+                continue
+
             show_settings = dict(show_settings)
             if 'hold' in show_settings and show_settings['hold'] is not None:
                 raise AssertionError(
@@ -26,10 +31,9 @@ class ShowPlayer(DeviceConfigPlayer):
                 show_settings['priority'] += priority
             except KeyError:
                 show_settings['priority'] = priority
-
             # todo need to add this key back to the config player
 
-            self._update_show(show, show_settings, context, queue, start_time)
+            self._update_show(show_dict["name"], show_settings, context, queue, start_time)
 
     def handle_subscription_change(self, value, settings, priority, context):
         """Handle subscriptions."""


### PR DESCRIPTION
In my never-ending quest to swap conditional events for conditional event handlers, here's a PR that extends conditional handlers to `score_player` and `show_player`.

With these changes, fun things like this are possible:
```
scoring:
  mode_recruitzaeed_started:
    zaeed_path_renegade:
      action: set
      score: 0
  # If the right orbit is the first orbit hit, set path to renegade
  zaeed_right_orbit_hit{device.counters.zaeed_orbits_counter.value==0}:
    zaeed_path_renegade:
      score: 1

show_player:
  mode_field_started:
    missions_available_show{current_player.available_missions>0}:
      action: play
  player_available_missions{value>0}:
    missions_available_show:
      action: play
  # All of the following are to flash the colored shields for available missions
  enable_recruit_shots:
    recruits_lit_show{current_player.status_garrus==3}:
      action: play
      key: recruits_lit_show_garrus
      show_tokens:
        leds: color_shield_blue
    recruits_lit_show{current_player.status_grunt==3}:
      action: play
      key: recruits_lit_show_grunt
      show_tokens:
        leds: color_shield_orange
    recruits_lit_show{current_player.status_jack==3}:
      action: play
      key: recruits_lit_show_jack
      show_tokens:
        leds: color_shield_purple
    recruits_lit_show{current_player.status_kasumi==3}:
      action: play
      key: recruits_lit_show_kasumi
      show_tokens:
        leds: color_shield_yellow
```