### PR TITLE
Dont send smartmatrix brightness for old setups

### DIFF
--- a/mpf/platforms/smartmatrix.py
+++ b/mpf/platforms/smartmatrix.py
@@ -115,7 +115,8 @@ class SmartMatrixDevice(DmdPlatformInterface):
         """Set brightness."""
         if brightness < 0.0 or brightness > 1.0:
             raise AssertionError("Brightness has to be between 0 and 1.")
-        self.control_data_queue.insert(0, bytearray([0xBA, 0x11, 0x00, 0x03, 20, int(brightness * 255), 00, 00]))
+        if not self.config['old_cookie']:
+            self.control_data_queue.insert(0, bytearray([0xBA, 0x11, 0x00, 0x03, 20, int(brightness * 255), 00, 00]))
 
     def stop(self):
         """Stop platform."""

--- a/mpf/tests/test_SmartMatrix.py
+++ b/mpf/tests/test_SmartMatrix.py
@@ -60,13 +60,13 @@ class TestSmartMatrix(MpfTestCase):
             call(b'\xba\x11\x00\x03\x04\x00\x00\x00\x00\x01\x02\x03')   # frame
             ])
 
+        #test old cookie
         self.machine.rgb_dmds.smartmatrix_2.update([0x00, 0x01, 0x02, 0x03])
         self.advance_time_and_run(.1)
         start = time.time()
         while self.serial_mocks["com5"].write.call_count < 2 and time.time() < start + 10:
             time.sleep(.001)
         self.serial_mocks["com5"].write.assert_has_calls([
-            call(b'\xba\x11\x00\x03\x14\x7f\x00\x00'),                  # brightness
             call(b'\x01\x00\x01\x02\x03')                               # frame
             ])
 


### PR DESCRIPTION
Don't send the brightness packet for old smartmatrix/teensy setups, if someone is using the old_cookie = true, that means that they are probably using an older setup and the brightness packet will lock up their teensy.