### PR TITLE
1085 - Avoid duplicate handlers for shot sequence event duplicates

### DIFF
--- a/mpf/devices/sequence_shot.py
+++ b/mpf/devices/sequence_shot.py
@@ -64,7 +64,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
             self._sequence_events.append(self.machine.switch_controller.get_active_event_for_switch(switch.name))
 
     def _register_handlers(self):
-        for event in self._sequence_events:
+        for event in set(self._sequence_events):
             self.machine.events.add_handler(event, self._sequence_advance, event_name=event)
 
         for switch in self.config['cancel_switches']:

--- a/mpf/tests/machine_files/sequence_shot/config/config.yaml
+++ b/mpf/tests/machine_files/sequence_shot/config/config.yaml
@@ -37,3 +37,10 @@ sequence_shots:
     sequence3:
         event_sequence:
             - event3_1
+    sequence_with_dupes:
+        event_sequence:
+            - event_1
+            - event_2
+            - event_1
+            - event_3
+            - event_1

--- a/mpf/tests/test_SequenceShot.py
+++ b/mpf/tests/test_SequenceShot.py
@@ -119,6 +119,11 @@ class TestShots(MpfTestCase):
         self.machine_run()
         self.assertEventCalled("sequence3_hit")
 
+    def test_sequence_with_duplicates(self):
+        self.assertEqual(1, len(self.machine.events.registered_handlers["event_1"]))
+        self.assertEqual(1, len(self.machine.events.registered_handlers["event_2"]))
+        self.assertEqual(1, len(self.machine.events.registered_handlers["event_3"]))
+
     def test_interleaved_sequences(self):
         """"Two balls pass through the sequence."""
         self.mock_event("sequence1_hit")


### PR DESCRIPTION
This PR addresses issue #1085 by restricting the creation of event handlers for `sequence_shots` events.

Previously, each item in the list of switches/events for a sequence shot was given an event handler. With this change, that list is reduced to a non-duplicate set prior to the event handler creation, ensuring only one handler is created per unique switch/event name.