### PR TITLE
multiball_lock.balls_to_replace and multiball.replace_balls_in_play

### DIFF
--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -777,6 +777,7 @@ multiballs:
     __valid_in__: machine, mode
     ball_count: single|template_int|
     ball_count_type: single|enum(add,total)|total
+    replace_balls_in_play: single|bool|false
     source_playfield: single|machine(ball_devices)|playfield
     shoot_again: single|ms|10s
     ball_locks: list|machine(ball_devices)|None
@@ -790,6 +791,7 @@ multiballs:
 multiball_locks:
     __valid_in__: mode
     balls_to_lock: single|int|
+    balls_to_replace: single|int|-1
     lock_devices: list|machine(ball_devices)|
     source_playfield: single|machine(ball_devices)|playfield
     enable_events: dict|str:ms|None

--- a/mpf/core/player.py
+++ b/mpf/core/player.py
@@ -170,7 +170,7 @@ class Player(object):
         """
         self.machine.events.post('player_' + name,
                                  value=value,
-                                 prev_value=value,
+                                 prev_value=prev_value,
                                  change=change,
                                  player_num=player_num)
         '''event: player_(var_name)

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -273,11 +273,11 @@ class MultiballLock(ModeDevice):
         # schedule eject of new balls for all physically locked balls
         if self.config['balls_to_replace'] == -1 or self.locked_balls <= self.config['balls_to_replace']:
             self.debug_log("{} locked balls and {} to replace, requesting {} new balls"
-                .format(self.locked_balls, self.config['balls_to_replace'], balls_to_lock_physically))
+                           .format(self.locked_balls, self.config['balls_to_replace'], balls_to_lock_physically))
             self._request_new_balls(balls_to_lock_physically)
         else:
             self.debug_log("{} locked balls exceeds {} to replace, not requesting any balls"
-                .format(self.locked_balls, self.config['balls_to_replace']))
+                           .format(self.locked_balls, self.config['balls_to_replace']))
 
         self.debug_log("Locked %s balls virtually and %s balls physically", balls_to_lock, balls_to_lock_physically)
 

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -271,7 +271,13 @@ class MultiballLock(ModeDevice):
         '''
 
         # schedule eject of new balls for all physically locked balls
-        self._request_new_balls(balls_to_lock_physically)
+        if self.config['balls_to_replace'] == -1 or self.locked_balls <= self.config['balls_to_replace']:
+            self.debug_log("{} locked balls and {} to replace, requesting {} new balls"
+                .format(self.locked_balls, self.config['balls_to_replace'], balls_to_lock_physically))
+            self._request_new_balls(balls_to_lock_physically)
+        else:
+            self.debug_log("{} locked balls exceeds {} to replace, not requesting any balls"
+                .format(self.locked_balls, self.config['balls_to_replace']))
 
         self.debug_log("Locked %s balls virtually and %s balls physically", balls_to_lock, balls_to_lock_physically)
 


### PR DESCRIPTION
Pursuant to https://github.com/missionpinball/mpf/issues/1083, this PR adds configuration settings to `multiballs` and `multiball_locks` to overwrite the default ball replacement and multiball counting strategies.

These changes are specific to machines that physically lock multiple balls, and have been documented via https://github.com/missionpinball/mpf-docs/pull/134. A future change to implement relay/queue events and initiate conversation directly between a multiball and a multiball_lock could supercede these configuration settings. 

This PR also fixes two bugs, one where the "prev_value" of a player variable event was passing the new value, and one where a "balls_live_target" log was passing the `balls_added_live` value instead of the `balls_live_target` value.

There are lots of debug logs related to this behavior, I'm happy to trim them down if advised.