### PR TITLE
Allow multiple "eject_coil_enable_time" values

### DIFF
--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -118,7 +118,7 @@ ball_devices:
     eject_coil_retry_pulse: single|ms|None
     eject_coil_reorder_pulse: single|ms|None
     eject_coil_max_wait_ms: single|ms|200ms
-    eject_coil_enable_time: single|ms|None
+    eject_coil_enable_time: list|ms|None
     retries_before_increasing_pulse: single|int|4
     hold_coil: single|machine(coils)|None
     hold_coil_release_time: single|ms|1s

--- a/mpf/devices/ball_device/enable_coil_ejector.py
+++ b/mpf/devices/ball_device/enable_coil_ejector.py
@@ -24,14 +24,21 @@ class EnableCoilEjector(PulseCoilEjector):
         """Enable eject coil."""
         del is_jammed
         del eject_try
+
+        # If multiple eject_coil_enable_time values, they correspond to the # of balls
+        if self.ball_device.balls <= len(self.ball_device.config['eject_coil_enable_time']):
+            eject_time = self.ball_device.config['eject_coil_enable_time'][self.ball_device.balls - 1]
+        else:
+            eject_time = self.ball_device.config['eject_coil_enable_time'][-1]
+
         # default pulse
         self.ball_device.debug_log("Enabling eject coil for %sms, Current balls: %s.",
-                                   self.ball_device.config['eject_coil_enable_time'],
+                                   eject_time,
                                    self.ball_device.balls)
 
         self.ball_device.config['eject_coil'].enable()
         self.delay.reset(name="disable", callback=self._disable_coil,
-                         ms=self.ball_device.config['eject_coil_enable_time'])
+                         ms=eject_time)
 
     def _disable_coil(self):
         """Disable the coil."""
@@ -43,5 +50,5 @@ class EnableCoilEjector(PulseCoilEjector):
         else:
             self.ball_device.config['eject_coil'].enable()
             self.delay.reset(name="disable", callback=self._disable_coil,
-                             ms=self.ball_device.config['eject_coil_enable_time'])
+                             ms=self.ball_device.config['eject_coil_enable_time'][0])
         return True

--- a/mpf/tests/machine_files/ball_device/config/test_enable_coil_multiple.yaml
+++ b/mpf/tests/machine_files/ball_device/config/test_enable_coil_multiple.yaml
@@ -1,0 +1,26 @@
+#config_version=5
+
+playfields:
+    playfield:
+        default_source_device: test
+        tags: default
+
+coils:
+    eject_coil:
+        default_hold_power: 0.25
+        default_pulse_ms: 20
+        number:
+
+switches:
+    s_ball1:
+        number:
+    s_ball2:
+        number:
+
+ball_devices:
+    test:
+        eject_coil: eject_coil
+        eject_coil_enable_time: 600ms, 200ms
+        ball_switches: s_ball1, s_ball2
+        tags: home, trough
+        debug: true

--- a/mpf/tests/test_BallDeviceEnableCoil.py
+++ b/mpf/tests/test_BallDeviceEnableCoil.py
@@ -27,3 +27,43 @@ class TestBallDevicesEnableCoil(MpfTestCase):
         self.advance_time_and_run(10)
 
         self.assertEqual("idle", self.machine.ball_devices.test.state)
+
+class TestBallDevicesEnableCoilMultiple(MpfTestCase):
+    def getConfigFile(self):
+        return 'test_enable_coil_multiple.yaml'
+
+    def getMachinePath(self):
+        return 'tests/machine_files/ball_device/'
+
+    def test_enable_coil_eject_times(self):
+        self.hit_switch_and_run("s_ball1", 0)
+        self.hit_switch_and_run("s_ball2", 5)
+        self.assertEqual("idle", self.machine.ball_devices.test.state)
+
+        self.machine.playfield.add_ball()
+        self.advance_time_and_run(.1)
+
+        self.assertEqual("enabled", self.machine.coils.eject_coil.hw_driver.state)
+        self.advance_time_and_run(.2)
+        self.assertEqual("disabled", self.machine.coils.eject_coil.hw_driver.state)
+
+        self.release_switch_and_run("s_ball2", 1)
+
+        self.assertEqual("ball_left", self.machine.ball_devices.test.state)
+        self.advance_time_and_run(10)
+
+        self.assertEqual("idle", self.machine.ball_devices.test.state)   
+
+        self.machine.playfield.add_ball()
+        self.advance_time_and_run(.1)
+        self.assertEqual("enabled", self.machine.coils.eject_coil.hw_driver.state)
+        self.advance_time_and_run(.4)
+        self.assertEqual("enabled", self.machine.coils.eject_coil.hw_driver.state)
+        self.advance_time_and_run(.2)
+        self.assertEqual("disabled", self.machine.coils.eject_coil.hw_driver.state)
+     
+        self.release_switch_and_run("s_ball1", 1)
+        self.assertEqual("ball_left", self.machine.ball_devices.test.state)
+        self.advance_time_and_run(10)
+
+        self.assertEqual("idle", self.machine.ball_devices.test.state)


### PR DESCRIPTION
In the continuing work for supporting ball devices that physically lock multiple balls, this PR extends the `eject_coil_enable_time` setting to (optionally) support multiple time values.

The reasoning here is that eject-coil-enable devices, by definition, rely on gravity to pull the ejecting ball from the device. When multiple balls are stacked in the device it is critical to time the coil to release only one ball: too short and the ejecting ball will jam, too long and a second ball will attempt to escape.

However the exact timing of the coil depends on how many balls are in the device, as the added weight of a second or third ball will "push" the ejecting ball out faster. As a result, an eject-coil-enable ball device will need shorter and shorter enable times as the number of held balls increases.

This change only affects machines when explicitly specified. Config settings that have only a single `eject_coil_enable_time` value will continue to behave as they currently do.