### PR TITLE
Issue 1112: Allow setting x,y,z location to switch

### DIFF
--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -1309,6 +1309,9 @@ switches:
     events_when_deactivated: list|str|None
     platform: single|str|None
     platform_settings: single|dict|None
+    x: single|float|None
+    y: single|float|None
+    z: single|float|None
 fast_switches:
     debounce_open: single|str|None
     debounce_close: single|str|None


### PR DESCRIPTION
I would like to set the location (copy from mpg-monitor) the location of switches. This can then be used in code to react to switch events and drive lightshows based on switch location.

Currently I get "Your config contains a value for the setting "switches:s_start:x", but this is not a valid setting name."

I will raise a PR that will allow this setting in switches config.