### PR TITLE
Added getter for x/y/z on supported devices

### DIFF
--- a/mpf/devices/device_mixins.py
+++ b/mpf/devices/device_mixins.py
@@ -1,0 +1,12 @@
+class DevicePositionMixin():
+    @property
+    def x(self):
+        return self.config.get('x', None)
+
+    @property
+    def y(self):
+        return self.config.get('y', None)
+
+    @property
+    def z(self):
+        return self.config.get('z', None)

--- a/mpf/devices/device_mixins.py
+++ b/mpf/devices/device_mixins.py
@@ -1,12 +1,35 @@
+"""Device Mixins."""
+
+
 class DevicePositionMixin():
+
+    """Adds x/y/z getters to a device.
+
+    For devices that have x/y/z config in the yaml this
+    mixin will add getters to allow the use of device.x
+    device.y and device.z instead of device.config['x']
+    """
+
     @property
     def x(self):
+        """Get the X value from the config.
+
+        Returns the devices x position from config
+        """
         return self.config.get('x', None)
 
     @property
     def y(self):
+        """Get the Y value from the config.
+
+        Returns the devices y position from config
+        """
         return self.config.get('y', None)
 
     @property
     def z(self):
+        """Get the Z value from the config.
+
+        Returns the devices z position from config
+        """
         return self.config.get('z', None)

--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -13,6 +13,7 @@ from mpf.core.machine import MachineController
 from mpf.core.rgb_color import RGBColor
 from mpf.core.system_wide_device import SystemWideDevice
 from mpf.platforms.interfaces.light_platform_interface import LightPlatformSoftwareFade
+from mpf.devices.device_mixins import DevicePositionMixin
 
 
 class DriverLight(LightPlatformSoftwareFade):
@@ -37,7 +38,7 @@ class DriverLight(LightPlatformSoftwareFade):
 
 
 @DeviceMonitor(_color="color")
-class Light(SystemWideDevice):
+class Light(SystemWideDevice, DevicePositionMixin):
 
     """A light in a pinball machine."""
 

--- a/mpf/devices/switch.py
+++ b/mpf/devices/switch.py
@@ -6,6 +6,7 @@ from mpf.core.machine import MachineController
 from mpf.core.system_wide_device import SystemWideDevice
 from mpf.core.utility_functions import Util
 from mpf.core.platform import SwitchConfig
+from mpf.devices.device_mixins import DevicePositionMixin
 
 MYPY = False
 if MYPY:   # pragma: no cover
@@ -14,7 +15,7 @@ if MYPY:   # pragma: no cover
 
 
 @DeviceMonitor("state", "recycle_jitter_count")
-class Switch(SystemWideDevice):
+class Switch(SystemWideDevice, DevicePositionMixin):
 
     """A switch in a pinball machine."""
 

--- a/mpf/tests/machine_files/light/config/light.yaml
+++ b/mpf/tests/machine_files/light/config/light.yaml
@@ -16,6 +16,9 @@ lights:
     number: 1
     default_on_color: red
     debug: True
+    x: 0.4
+    y: 0.5
+    z: 0
   led2:
     channels:
       red:
@@ -25,6 +28,8 @@ lights:
       blue:
         number: 2
     debug: True
+    x: 0.6
+    y: 0.7
   led_bgr_2:
     type: bgr
     number: 42

--- a/mpf/tests/machine_files/switch_player/config/config.yaml
+++ b/mpf/tests/machine_files/switch_player/config/config.yaml
@@ -3,8 +3,13 @@
 switches:
     s_test1:
         number:
+        x: 0.4
+        y: 0.5
+        z: 0
     s_test2:
         number:
+        x: 0.6
+        y: 0.7
     s_test3:
         number:
 

--- a/mpf/tests/test_LightPositions.py
+++ b/mpf/tests/test_LightPositions.py
@@ -1,0 +1,30 @@
+"""Test Light Position Mixin."""
+from mpf.core.rgb_color import RGBColor
+from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
+
+
+class TestLightPositions(MpfFakeGameTestCase):
+
+    def getConfigFile(self):
+        return 'light.yaml'
+
+    def getMachinePath(self):
+        return 'tests/machine_files/light/'
+
+    def test_light_positions(self):
+        led1 = self.machine.lights.led1
+        led2 = self.machine.lights.led2
+        led3 = self.machine.lights.led3
+
+        self.assertEqual(led1.x, 0.4)
+        self.assertEqual(led1.y, 0.5)
+        self.assertEqual(led1.z, 0)
+
+        self.assertEqual(led2.x, 0.6)
+        self.assertEqual(led2.y, 0.7)
+        self.assertEqual(led2.z, None)
+        
+        self.assertEqual(led3.x, None)
+        self.assertEqual(led3.y, None)
+        self.assertEqual(led3.z, None)
+        

--- a/mpf/tests/test_SwitchPositions.py
+++ b/mpf/tests/test_SwitchPositions.py
@@ -1,0 +1,29 @@
+"""Test Switch Position Mixin."""
+from mpf.core.rgb_color import RGBColor
+from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
+
+
+class TestSwitchPositions(MpfFakeGameTestCase):
+
+    def getConfigFile(self):
+        return 'config.yaml'
+
+    def getMachinePath(self):
+        return 'tests/machine_files/switch_player/'
+
+    def test_switch_positions(self):
+        switch1 = self.machine.switches.s_test1
+        switch2 = self.machine.switches.s_test2
+        switch3 = self.machine.switches.s_test3
+
+        self.assertEqual(switch1.x, 0.4)
+        self.assertEqual(switch1.y, 0.5)
+        self.assertEqual(switch1.z, 0)
+
+        self.assertEqual(switch2.x, 0.6)
+        self.assertEqual(switch2.y, 0.7)
+        self.assertEqual(switch2.z, None)
+        
+        self.assertEqual(switch3.x, None)
+        self.assertEqual(switch3.y, None)
+        self.assertEqual(switch3.z, None)


### PR DESCRIPTION
This commit adds a mixin which adds getters to a device for x/y/z config
it purely is for cleaner looking code when working with positions of
devices.