### PR TITLE
#1086 Support Servo Speed and Acceleration

### DIFF
--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -974,6 +974,8 @@ servos:
     servo_max: single|float|1.0
     ball_search_min: single|float|0.0
     ball_search_max: single|float|1.0
+    speed: single|float|0.0
+    acceleration: single|float|0.0
     ball_search_wait: single|ms|5s
     include_in_ball_search: single|bool|True
     reset_position: single|float|0.5

--- a/mpf/core/config_spec.py
+++ b/mpf/core/config_spec.py
@@ -974,8 +974,8 @@ servos:
     servo_max: single|float|1.0
     ball_search_min: single|float|0.0
     ball_search_max: single|float|1.0
-    speed: single|float|0.0
-    acceleration: single|float|0.0
+    speed_limit: single|float|-1.0
+    acceleration_limit: single|float|-1.0
     ball_search_wait: single|ms|5s
     include_in_ball_search: single|bool|True
     reset_position: single|float|0.5

--- a/mpf/devices/servo.py
+++ b/mpf/devices/servo.py
@@ -24,6 +24,8 @@ class Servo(SystemWideDevice):
         self.hw_servo = None
         self.platform = None        # type: ServoPlatform
         self._position = None
+        self.speed = None
+        self.acceleration = None
         self._ball_search_started = False
         self.delay = DelayManager(machine.delayRegistry)
         super().__init__(machine, name)
@@ -38,12 +40,17 @@ class Servo(SystemWideDevice):
 
         self.hw_servo = self.platform.configure_servo(self.config['number'])
         self._position = self.config['reset_position']
+        self.speed = self.config['speed']
+        self.acceleration = self.config['acceleration']
 
         if self.config['include_in_ball_search']:
             self.machine.events.add_handler("ball_search_started",
                                             self._ball_search_start)
             self.machine.events.add_handler("ball_search_stopped",
                                             self._ball_search_stop)
+
+        self.set_speed(self.speed)
+        self.set_acceleration(self.acceleration)
 
     @event_handler(1)
     def reset(self, **kwargs):
@@ -70,6 +77,12 @@ class Servo(SystemWideDevice):
 
         # call platform with calculated position
         self.hw_servo.go_to_position(position)
+
+    def set_speed(self, speed):
+        self.hw_servo.set_speed(speed)
+
+    def set_acceleration(self, acceleration):
+        self.hw_servo.set_acceleration(acceleration)
 
     def _ball_search_start(self, **kwargs):
         del kwargs

--- a/mpf/devices/servo.py
+++ b/mpf/devices/servo.py
@@ -79,9 +79,11 @@ class Servo(SystemWideDevice):
         self.hw_servo.go_to_position(position)
 
     def set_speed(self, speed):
+        """Set speed parameter"""
         self.hw_servo.set_speed(speed)
 
     def set_acceleration(self, acceleration):
+        """Set acceleration parameter"""
         self.hw_servo.set_acceleration(acceleration)
 
     def _ball_search_start(self, **kwargs):

--- a/mpf/devices/servo.py
+++ b/mpf/devices/servo.py
@@ -79,11 +79,11 @@ class Servo(SystemWideDevice):
         self.hw_servo.go_to_position(position)
 
     def set_speed(self, speed):
-        """Set speed parameter"""
+        """Set speed parameter."""
         self.hw_servo.set_speed(speed)
 
     def set_acceleration(self, acceleration):
-        """Set acceleration parameter"""
+        """Set acceleration parameter."""
         self.hw_servo.set_acceleration(acceleration)
 
     def _ball_search_start(self, **kwargs):

--- a/mpf/devices/servo.py
+++ b/mpf/devices/servo.py
@@ -24,8 +24,8 @@ class Servo(SystemWideDevice):
         self.hw_servo = None
         self.platform = None        # type: ServoPlatform
         self._position = None
-        self.speed = None
-        self.acceleration = None
+        self.speed_limit = None
+        self.acceleration_limit = None
         self._ball_search_started = False
         self.delay = DelayManager(machine.delayRegistry)
         super().__init__(machine, name)
@@ -40,8 +40,8 @@ class Servo(SystemWideDevice):
 
         self.hw_servo = self.platform.configure_servo(self.config['number'])
         self._position = self.config['reset_position']
-        self.speed = self.config['speed']
-        self.acceleration = self.config['acceleration']
+        self.speed_limit = self.config['speed_limit']
+        self.acceleration_limit = self.config['acceleration_limit']
 
         if self.config['include_in_ball_search']:
             self.machine.events.add_handler("ball_search_started",
@@ -49,8 +49,8 @@ class Servo(SystemWideDevice):
             self.machine.events.add_handler("ball_search_stopped",
                                             self._ball_search_stop)
 
-        self.set_speed(self.speed)
-        self.set_acceleration(self.acceleration)
+        self.set_speed_limit(self.speed_limit)
+        self.set_acceleration_limit(self.acceleration_limit)
 
     @event_handler(1)
     def reset(self, **kwargs):
@@ -78,13 +78,13 @@ class Servo(SystemWideDevice):
         # call platform with calculated position
         self.hw_servo.go_to_position(position)
 
-    def set_speed(self, speed):
+    def set_speed_limit(self, speed_limit):
         """Set speed parameter."""
-        self.hw_servo.set_speed(speed)
+        self.hw_servo.set_speed_limit(speed_limit)
 
-    def set_acceleration(self, acceleration):
+    def set_acceleration_limit(self, acceleration_limit):
         """Set acceleration parameter."""
-        self.hw_servo.set_acceleration(acceleration)
+        self.hw_servo.set_acceleration_limit(acceleration_limit)
 
     def _ball_search_start(self, **kwargs):
         del kwargs

--- a/mpf/platforms/fast/fast_servo.py
+++ b/mpf/platforms/fast/fast_servo.py
@@ -27,11 +27,11 @@ class FastServo(ServoPlatformInterface):
         self.net_connection.send(cmd)
 
     @classmethod
-    def set_speed(self, speed):
+    def set_speed_limit(cls, speed_limit):
         """Todo emulate speed parameter."""
         pass
 
     @classmethod
-    def set_acceleration(self, accel):
+    def set_acceleration_limit(cls, acceleration_limit):
         """Todo emulate acceleration parameter."""
         pass

--- a/mpf/platforms/fast/fast_servo.py
+++ b/mpf/platforms/fast/fast_servo.py
@@ -26,12 +26,12 @@ class FastServo(ServoPlatformInterface):
 
         self.net_connection.send(cmd)
 
-    @staticmethod
+    @classmethod
     def set_speed(self, speed):
-        """todo emulate speed parameter"""
+        """Todo emulate speed parameter."""
         pass
 
-    @staticmethod
+    @classmethod
     def set_acceleration(self, accel):
-        """todo emulate acceleration parameter"""
+        """Todo emulate acceleration parameter."""
         pass

--- a/mpf/platforms/fast/fast_servo.py
+++ b/mpf/platforms/fast/fast_servo.py
@@ -26,8 +26,12 @@ class FastServo(ServoPlatformInterface):
 
         self.net_connection.send(cmd)
 
+    @staticmethod
     def set_speed(self, speed):
-        return
+        """todo emulate speed parameter"""
+        pass
 
+    @staticmethod
     def set_acceleration(self, accel):
-        return
+        """todo emulate acceleration parameter"""
+        pass

--- a/mpf/platforms/fast/fast_servo.py
+++ b/mpf/platforms/fast/fast_servo.py
@@ -25,3 +25,9 @@ class FastServo(ServoPlatformInterface):
             Util.int_to_hex_string(position_numeric))
 
         self.net_connection.send(cmd)
+
+    def set_speed(self, speed):
+        return
+
+    def set_acceleration(self, accel):
+        return

--- a/mpf/platforms/i2c_servo_controller.py
+++ b/mpf/platforms/i2c_servo_controller.py
@@ -102,12 +102,12 @@ class I2cServo(ServoPlatformInterface):
         self.platform.i2c_write8(self.config['address'], 0x09 + self.number * 4,
                                  value >> 8)
 
-    @staticmethod
+    @classmethod
     def set_speed(self, speed):
-        """todo emulate speed parameter"""
+        """Todo emulate speed parameter."""
         pass
 
-    @staticmethod
+    @classmethod
     def set_acceleration(self, accel):
-        """todo emulate acceleration parameter"""
+        """Todo emulate acceleration parameter."""
         pass

--- a/mpf/platforms/i2c_servo_controller.py
+++ b/mpf/platforms/i2c_servo_controller.py
@@ -103,11 +103,11 @@ class I2cServo(ServoPlatformInterface):
                                  value >> 8)
 
     @classmethod
-    def set_speed(self, speed):
+    def set_speed_limit(cls, speed_limit):
         """Todo emulate speed parameter."""
         pass
 
     @classmethod
-    def set_acceleration(self, accel):
+    def set_acceleration_limit(cls, acceleration_limit):
         """Todo emulate acceleration parameter."""
         pass

--- a/mpf/platforms/i2c_servo_controller.py
+++ b/mpf/platforms/i2c_servo_controller.py
@@ -102,8 +102,12 @@ class I2cServo(ServoPlatformInterface):
         self.platform.i2c_write8(self.config['address'], 0x09 + self.number * 4,
                                  value >> 8)
 
+    @staticmethod
     def set_speed(self, speed):
-        return
+        """todo emulate speed parameter"""
+        pass
 
+    @staticmethod
     def set_acceleration(self, accel):
-        return
+        """todo emulate acceleration parameter"""
+        pass

--- a/mpf/platforms/i2c_servo_controller.py
+++ b/mpf/platforms/i2c_servo_controller.py
@@ -101,3 +101,9 @@ class I2cServo(ServoPlatformInterface):
                                  value & 0xFF)
         self.platform.i2c_write8(self.config['address'], 0x09 + self.number * 4,
                                  value >> 8)
+
+    def set_speed(self, speed):
+        return
+
+    def set_acceleration(self, accel):
+        return

--- a/mpf/platforms/pololu_maestro.py
+++ b/mpf/platforms/pololu_maestro.py
@@ -115,6 +115,7 @@ class PololuServo(ServoPlatformInterface):
             speed: speed to set
 
         """
+        speed = int(speed * 100)  # change normalized values for maestro
         lsb = speed & 0x7f  # 7 bits for least significant byte
         msb = (speed >> 7) & 0x7f  # shift 7 and take next 7 bits for msb
         cmd = self.cmd_header + bytes([0x07, self.number, lsb, msb])
@@ -130,6 +131,7 @@ class PololuServo(ServoPlatformInterface):
         A value of 1 will take the servo about 3s to move between 1ms to 2ms
         range.
         """
+        accel = int(accel * 255)  # change normalized values for maestro
         lsb = accel & 0x7f  # 7 bits for least significant byte
         msb = (accel >> 7) & 0x7f  # shift 7 and take next 7 bits for msb
         cmd = self.cmd_header + bytes([0x09, self.number, lsb, msb])

--- a/mpf/platforms/pololu_maestro.py
+++ b/mpf/platforms/pololu_maestro.py
@@ -1,8 +1,8 @@
 """Pololu Maestro servo controller platform."""
+import math
 import asyncio
 import logging
 import serial
-import math
 from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
 
 from mpf.core.platform import ServoPlatform
@@ -146,8 +146,8 @@ class PololuServo(ServoPlatformInterface):
             maestro_acceleration_normalized = 1  # minimum acceleration setting
         else:
             max_speed_change_per_second = math.sqrt(acceleration_limit * self.config['servo_max'])
-            maestro_acceleration_limit = self.calculate_maestro_acceleration_limit(max_speed_change_per_second)
-            max_limit_value = self.calculate_maestro_acceleration_limit(math.sqrt(1.0 * self.config['servo_max']))
+            maestro_acceleration_limit = calculate_maestro_acceleration(max_speed_change_per_second)
+            max_limit_value = calculate_maestro_acceleration(math.sqrt(1.0 * self.config['servo_max']))
             maestro_acceleration_normalized = int(255 / max_limit_value * maestro_acceleration_limit)
 
         lsb = maestro_acceleration_normalized & 0x7f  # 7 bits for least significant byte
@@ -155,6 +155,8 @@ class PololuServo(ServoPlatformInterface):
         cmd = self.cmd_header + bytes([0x09, self.number, lsb, msb])
         self.serial.write(cmd)
 
-    def calculate_maestro_acceleration_limit(self, normalized_limit):
-        """Calculate acceleration limit for the maestro based on the formula 0.25microseconds/10milliseconds/80milliseconds."""
-        return normalized_limit / 1000 / 0.25 / 80
+
+def calculate_maestro_acceleration(normalized_limit):
+    """Calculate acceleration limit for the maestro
+     based on the formula 0.25microseconds/10milliseconds/80milliseconds."""
+    return normalized_limit / 1000 / 0.25 / 80

--- a/mpf/platforms/pololu_maestro.py
+++ b/mpf/platforms/pololu_maestro.py
@@ -157,6 +157,5 @@ class PololuServo(ServoPlatformInterface):
 
 
 def calculate_maestro_acceleration(normalized_limit):
-    """Calculate acceleration limit for the maestro
-     based on the formula 0.25microseconds/10milliseconds/80milliseconds."""
+    """Calculate acceleration limit for the maestro."""
     return normalized_limit / 1000 / 0.25 / 80

--- a/mpf/platforms/rpi/rpi.py
+++ b/mpf/platforms/rpi/rpi.py
@@ -87,6 +87,12 @@ class RpiServo(ServoPlatformInterface):
         position_translated = 1000 + position * 1000
         self.platform.send_command(self.platform.pi.set_servo_pulsewidth(self.gpio, position_translated))
 
+    def set_speed(self, speed):
+        return
+
+    def set_acceleration(self, accel):
+        return
+
 
 class RaspberryPiHardwarePlatform(SwitchPlatform, DriverPlatform, ServoPlatform, I2cPlatform):
 

--- a/mpf/platforms/rpi/rpi.py
+++ b/mpf/platforms/rpi/rpi.py
@@ -88,12 +88,12 @@ class RpiServo(ServoPlatformInterface):
         self.platform.send_command(self.platform.pi.set_servo_pulsewidth(self.gpio, position_translated))
 
     @classmethod
-    def set_speed(self, speed):
+    def set_speed_limit(cls, speed_limit):
         """Todo emulate speed parameter."""
         pass
 
     @classmethod
-    def set_acceleration(self, accel):
+    def set_acceleration_limit(cls, acceleration_limit):
         """Todo emulate acceleration parameter."""
         pass
 

--- a/mpf/platforms/rpi/rpi.py
+++ b/mpf/platforms/rpi/rpi.py
@@ -87,11 +87,15 @@ class RpiServo(ServoPlatformInterface):
         position_translated = 1000 + position * 1000
         self.platform.send_command(self.platform.pi.set_servo_pulsewidth(self.gpio, position_translated))
 
+    @staticmethod
     def set_speed(self, speed):
-        return
+        """todo emulate speed parameter"""
+        pass
 
+    @staticmethod
     def set_acceleration(self, accel):
-        return
+        """todo emulate acceleration parameter"""
+        pass
 
 
 class RaspberryPiHardwarePlatform(SwitchPlatform, DriverPlatform, ServoPlatform, I2cPlatform):

--- a/mpf/platforms/rpi/rpi.py
+++ b/mpf/platforms/rpi/rpi.py
@@ -87,14 +87,14 @@ class RpiServo(ServoPlatformInterface):
         position_translated = 1000 + position * 1000
         self.platform.send_command(self.platform.pi.set_servo_pulsewidth(self.gpio, position_translated))
 
-    @staticmethod
+    @classmethod
     def set_speed(self, speed):
-        """todo emulate speed parameter"""
+        """Todo emulate speed parameter."""
         pass
 
-    @staticmethod
+    @classmethod
     def set_acceleration(self, accel):
-        """todo emulate acceleration parameter"""
+        """Todo emulate acceleration parameter."""
         pass
 
 

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -353,14 +353,14 @@ class VirtualServo(ServoPlatformInterface):
         """Go to position."""
         self.current_position = position
 
-    @staticmethod
+    @classmethod
     def set_speed(self, speed):
-        """todo emulate speed parameter"""
+        """Todo emulate speed parameter."""
         pass
 
-    @staticmethod
+    @classmethod
     def set_acceleration(self, accel):
-        """todo emulate acceleration parameter"""
+        """Todo emulate acceleration parameter."""
         pass
 
 

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -354,12 +354,12 @@ class VirtualServo(ServoPlatformInterface):
         self.current_position = position
 
     @classmethod
-    def set_speed(self, speed):
+    def set_speed_limit(cls, speed_limit):
         """Todo emulate speed parameter."""
         pass
 
     @classmethod
-    def set_acceleration(self, accel):
+    def set_acceleration_limit(cls, acceleration_limit):
         """Todo emulate acceleration parameter."""
         pass
 

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -346,11 +346,18 @@ class VirtualServo(ServoPlatformInterface):
         self.log = logging.getLogger('VirtualServo')
         self.number = number
         self.current_position = None
+        self.speed = None
+        self.acceleration = None
 
     def go_to_position(self, position):
         """Go to position."""
         self.current_position = position
 
+    def set_speed(self, speed):
+        self.speed = speed
+
+    def set_acceleration(self, acceleration):
+        self.acceleration = acceleration
 
 class VirtualStepper(StepperPlatformInterface):
 

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -353,11 +353,16 @@ class VirtualServo(ServoPlatformInterface):
         """Go to position."""
         self.current_position = position
 
+    @staticmethod
     def set_speed(self, speed):
-        self.speed = speed
+        """todo emulate speed parameter"""
+        pass
 
-    def set_acceleration(self, acceleration):
-        self.acceleration = acceleration
+    @staticmethod
+    def set_acceleration(self, accel):
+        """todo emulate acceleration parameter"""
+        pass
+
 
 class VirtualStepper(StepperPlatformInterface):
 

--- a/mpf/tests/machine_files/pololu_maestro/config/pololu_maestro.yaml
+++ b/mpf/tests/machine_files/pololu_maestro/config/pololu_maestro.yaml
@@ -15,6 +15,8 @@ servos:
     servo_min: 0.0
     servo_max: 1.0
     reset_position: 0.5
+    speed: 0.5
+    acceleration: 0.5
     reset_events: reset_servo1
     number: 1
   servo2:

--- a/mpf/tests/machine_files/pololu_maestro/config/pololu_maestro.yaml
+++ b/mpf/tests/machine_files/pololu_maestro/config/pololu_maestro.yaml
@@ -15,8 +15,8 @@ servos:
     servo_min: 0.0
     servo_max: 1.0
     reset_position: 0.5
-    speed: 0.5
-    acceleration: 0.5
+    speed_limit: 0.5
+    acceleration_limit: 0.5
     reset_events: reset_servo1
     number: 1
   servo2:

--- a/mpf/tests/test_PololuMaestro.py
+++ b/mpf/tests/test_PololuMaestro.py
@@ -53,27 +53,30 @@ class TestPololuMaestro(MpfTestCase):
 
     def test_servo_set_speed(self):
         # test setting speed in config
-        self.assertEqual(0.5, self.machine.servos.servo1.speed)
+        self.assertEqual(0.5, self.machine.servos.servo1.speed_limit)
         # test standard value
-        self.assertEqual(0.0, self.machine.servos.servo2.speed)
+        self.assertEqual(-1.0, self.machine.servos.servo2.speed_limit)
 
-        self.machine.servos.servo1.set_speed(0.0)
+        self.machine.servos.servo1.set_speed_limit(-1.0)
         self.serial.write.assert_called_with(self._build_message(0x07, 1, 0))
-        self.machine.servos.servo1.set_speed(0.5)
-        self.serial.write.assert_called_with(self._build_message(0x07, 1, 50))
-        self.machine.servos.servo1.set_speed(2.0)
-        self.serial.write.assert_called_with(self._build_message(0x07, 1, 200))
+        self.machine.servos.servo1.set_speed_limit(0.0)
+        self.serial.write.assert_called_with(self._build_message(0x07, 1, 1))
+        self.machine.servos.servo1.set_speed_limit(0.5)
+        self.serial.write.assert_called_with(self._build_message(0x07, 1, 18))
+        self.machine.servos.servo1.set_speed_limit(1.0)
 
     def test_servo_set_acceleration(self):
         # test setting acceleration in config
-        self.assertEqual(0.5, self.machine.servos.servo1.acceleration)
+        self.assertEqual(0.5, self.machine.servos.servo1.acceleration_limit)
         # test standard value
-        self.assertEqual(0.0, self.machine.servos.servo2.acceleration)
+        self.assertEqual(-1.0, self.machine.servos.servo2.acceleration_limit)
 
-        self.machine.servos.servo1.set_acceleration(0.0)
-        self.serial.write.assert_called_with(self._build_message(0x09, 1, 0))
-        self.machine.servos.servo1.set_acceleration(0.5)
-        self.serial.write.assert_called_with(self._build_message(0x09, 1, 127))
-        self.machine.servos.servo1.set_acceleration(1.0)
+        self.machine.servos.servo1.set_speed_limit(-1.0)
+        self.serial.write.assert_called_with(self._build_message(0x07, 1, 0))
+        self.machine.servos.servo1.set_speed_limit(0.0)
+        self.serial.write.assert_called_with(self._build_message(0x07, 1, 1))
+        self.machine.servos.servo1.set_acceleration_limit(0.5)
+        self.serial.write.assert_called_with(self._build_message(0x09, 1, 180))
+        self.machine.servos.servo1.set_acceleration_limit(1.0)
         self.serial.write.assert_called_with(self._build_message(0x09, 1, 255))
 

--- a/mpf/tests/test_PololuMaestro.py
+++ b/mpf/tests/test_PololuMaestro.py
@@ -20,33 +20,60 @@ class TestPololuMaestro(MpfTestCase):
         mpf.platforms.pololu_maestro.serial.Serial.return_value = self.serial
         super().setUp()
 
-    def _build_message(self, number, value):
+    def _build_message(self, command, number, value):
         lsb = value & 0x7f  # 7 bits for least significant byte
         msb = (value >> 7) & 0x7f  # shift 7 and take next 7 bits for msb
         # Send Pololu intro, device number, command, channel, and target
         # lsb/msb
-        return bytes([0xaa, 0xc, 0x04, number, lsb, msb])
+        return bytes([0xaa, 0xc, command, number, lsb, msb])
 
     def test_servo_go_to_position(self):
         # go to position 1.0 (on of the ends)
         self.machine.servos.servo1.go_to_position(1.0)
         # assert that platform got called
-        self.serial.write.assert_called_with(self._build_message(1, 9000))
+        self.serial.write.assert_called_with(self._build_message(0x04, 1, 9000))
         # go to position 0.0 (other end)
         self.machine.servos.servo1.go_to_position(0.0)
         # assert that platform got called
-        self.serial.write.assert_called_with(self._build_message(1, 3000))
+        self.serial.write.assert_called_with(self._build_message(0x04, 1, 3000))
 
         self.serial.reset_mock()
         # go to position 1.0 (on of the ends)
         self.machine.servos.servo2.go_to_position(1.0)
         # assert that platform got called
-        self.serial.write.assert_called_with(self._build_message(2, 7800))
+        self.serial.write.assert_called_with(self._build_message(0x04, 2, 7800))
         # go to position 0.0 (other end)
         self.machine.servos.servo2.go_to_position(0.0)
         # assert that platform got called
-        self.serial.write.assert_called_with(self._build_message(2, 4200))
+        self.serial.write.assert_called_with(self._build_message(0x04, 2, 4200))
         # go to position 0.0 (middle)
         self.machine.servos.servo2.go_to_position(0.5)
         # assert that platform got called
-        self.serial.write.assert_called_with(self._build_message(2, 6000))
+        self.serial.write.assert_called_with(self._build_message(0x04, 2, 6000))
+
+    def test_servo_set_speed(self):
+        # test setting speed in config
+        self.assertEqual(0.5, self.machine.servos.servo1.speed)
+        # test standard value
+        self.assertEqual(0.0, self.machine.servos.servo2.speed)
+
+        self.machine.servos.servo1.set_speed(0.0)
+        self.serial.write.assert_called_with(self._build_message(0x07, 1, 0))
+        self.machine.servos.servo1.set_speed(0.5)
+        self.serial.write.assert_called_with(self._build_message(0x07, 1, 50))
+        self.machine.servos.servo1.set_speed(2.0)
+        self.serial.write.assert_called_with(self._build_message(0x07, 1, 200))
+
+    def test_servo_set_acceleration(self):
+        # test setting acceleration in config
+        self.assertEqual(0.5, self.machine.servos.servo1.acceleration)
+        # test standard value
+        self.assertEqual(0.0, self.machine.servos.servo2.acceleration)
+
+        self.machine.servos.servo1.set_acceleration(0.0)
+        self.serial.write.assert_called_with(self._build_message(0x09, 1, 0))
+        self.machine.servos.servo1.set_acceleration(0.5)
+        self.serial.write.assert_called_with(self._build_message(0x09, 1, 127))
+        self.machine.servos.servo1.set_acceleration(1.0)
+        self.serial.write.assert_called_with(self._build_message(0x09, 1, 255))
+


### PR DESCRIPTION
Hi, there are some things I am a bit unsure about:
* the general implementation: Since it's only implemented in the Maestro the set_speed/acceleration methods are currently not implemented for the other platforms. As discussed in #1086 this should be emulated for the other platforms (new issue)
* the default values for speed and acceleration (both are 0 currently)

Just let me know if any of this or something else needs fixing.