### PR TITLE
Allow list of flashers as light value

### DIFF
--- a/mpf/config_players/flasher_player.py
+++ b/mpf/config_players/flasher_player.py
@@ -1,6 +1,7 @@
 """Flasher config player."""
 from mpf.config_players.device_config_player import DeviceConfigPlayer
 from mpf.core.delays import DelayManager
+from mpf.core.utility_functions import Util
 
 
 class FlasherPlayer(DeviceConfigPlayer):
@@ -23,9 +24,11 @@ class FlasherPlayer(DeviceConfigPlayer):
 
         for flasher, s in settings.items():
             if isinstance(flasher, str):
-                self._flash(self.machine.lights[flasher],
-                            duration_ms=s['ms'],
-                            key=context)
+                flasher_names = Util.string_to_list(flasher)
+                for flasher_name in flasher_names:
+                    self._flash(self.machine.lights[flasher_name],
+                                duration_ms=s['ms'],
+                                key=context)
             else:
                 self._flash(flasher, duration_ms=s['ms'], key=context)
 


### PR DESCRIPTION
This PR adds functionality to `flasher_player` to support a list of lights as the target. The iteration was copied directly from `light_player` and brings the two players to parity.

Without this fix, using a list of lights in `flasher_player` (or as show tokens for it) throws a KeyError. This is presumed to be a bug, since the expectation is that `flasher_player` will behave like other players.