### PR TITLE
evaluate all events in MPF instead of in MC

### DIFF
--- a/mpf/config_players/plugin_player.py
+++ b/mpf/config_players/plugin_player.py
@@ -63,6 +63,9 @@ class PluginPlayer(DeviceConfigPlayer):
 
     def play(self, settings, context, calling_context, priority=0, **kwargs):
         """Trigger remote player via BCP."""
+        if "_from_bcp" in kwargs:
+            del kwargs["_from_bcp"]
+
         self.machine.bcp.interface.bcp_trigger(
             name='{}_play'.format(self.show_section),
             settings=settings, context=context,

--- a/mpf/config_players/plugin_player.py
+++ b/mpf/config_players/plugin_player.py
@@ -54,31 +54,19 @@ class PluginPlayer(DeviceConfigPlayer):
             return event_list
 
         self.bcp_client = self._get_bcp_client(config)
-
-        for event in config:
-            event_name, _ = self.machine.events.get_event_and_condition_from_string(event)
-            self.machine.bcp.interface.add_registered_trigger_event_for_client(
-                self.bcp_client, event_name)
-            event_list.append(event_name)
-
         self.machine.bcp.interface.add_registered_trigger_event_for_client(
             self.bcp_client, '{}_play'.format(self.show_section))
         self.machine.bcp.interface.add_registered_trigger_event_for_client(
             self.bcp_client, '{}_clear'.format(self.show_section))
 
-        return event_list
-
-    def unload_player_events(self, key_list):
-        """Unload player events via BCP."""
-        for event in key_list:
-            self.machine.bcp.interface.remove_registered_trigger_event_for_client(self.bcp_client, event)
+        return super().register_player_events(config, mode, priority)
 
     def play(self, settings, context, calling_context, priority=0, **kwargs):
         """Trigger remote player via BCP."""
         self.machine.bcp.interface.bcp_trigger(
             name='{}_play'.format(self.show_section),
             settings=settings, context=context,
-            priority=priority)
+            priority=priority, **kwargs)
 
     def clear_context(self, context):
         """Clear the context at remote player via BCP."""


### PR DESCRIPTION
This would move all event handlers to the MPF side to fix all problems with conditional events. Currently this breaks a lot of tests in MC. Need to run them as integration tests. Also this would break most configs which rely on the "mc_ready" because that happens in MC before MPF is connected. Another downside would be that you can not add any MC asset loading slides. Maybe we could connect to MPF before loading all assets?

What do you think? Should we move in that direction?