### PR TITLE
#1189 Prevent spaces in event names

### DIFF
--- a/mpf/core/events.py
+++ b/mpf/core/events.py
@@ -146,6 +146,10 @@ class EventManager(MpfController):
                              'accidentally add parenthesis to the end of the '
                              'handler you passed?'.format(handler, event))
 
+        if " " in event:
+            raise ValueError('Cannot handle events with spaces in the event name, '
+                             'please remedy "{}"'.format(event))
+
         sig = inspect.signature(handler)
         if 'kwargs' not in sig.parameters:
             raise AssertionError("Handler {} for event '{}' is missing **kwargs. Actual signature: {}".format(

--- a/mpf/core/events.py
+++ b/mpf/core/events.py
@@ -146,7 +146,7 @@ class EventManager(MpfController):
                              'accidentally add parenthesis to the end of the '
                              'handler you passed?'.format(handler, event))
 
-        if " " in event:
+        if " " in event.split("{")[0]:
             raise ValueError('Cannot handle events with spaces in the event name, '
                              'please remedy "{}"'.format(event))
 


### PR DESCRIPTION
This PR addresses issue #1189 by adding a catch in `events.add_handler` that prevents spaces in the event name. 

I opted to add the catch to `add_handler()` rather than `post()` to reduce the number of times it has to be evaluated. An event without a handler doesn't do anything, so we should really only care about handled events not working, right?