### PR TITLE
Move all INFO logs to level >20 and DEBUG <20

### DIFF
--- a/mpf/core/logging.py
+++ b/mpf/core/logging.py
@@ -24,10 +24,10 @@ class LogMixin(object):
         self._info_to_file = False
         self._debug_to_file = False
 
-        logging.addLevelName(11, "INFO")
-        logging.addLevelName(12, "DEBUG")
         logging.addLevelName(21, "INFO")
-        logging.addLevelName(22, "DEBUG")
+        logging.addLevelName(11, "DEBUG")
+        logging.addLevelName(22, "INFO")
+        logging.addLevelName(12, "DEBUG")
 
     def configure_logging(self, logger: str, console_level: str = 'basic',
                           file_level: str = 'basic'):
@@ -72,9 +72,9 @@ class LogMixin(object):
             self._logging_not_configured()
 
         if self._debug_to_console:
-            self.log.log(22, msg, *args, **kwargs)
-        elif self._debug_to_file:
             self.log.log(12, msg, *args, **kwargs)
+        elif self._debug_to_file:
+            self.log.log(11, msg, *args, **kwargs)
 
     def info_log(self, msg: str, *args, context=None, **kwargs) -> None:
         """Log a message at the info level.
@@ -87,9 +87,9 @@ class LogMixin(object):
 
         code = None
         if self._info_to_console or self._debug_to_console:
-            code = 21
+            code = 22
         elif self._info_to_file or self._debug_to_file:
-            code = 11
+            code = 21
 
         if context:
             self.log.log(code, msg + " context: " + context, *args, **kwargs)


### PR DESCRIPTION
This PR fixes a logging behavior bug wherein some logs listed at INFO are only logged when the level is DEBUG. The logger calculates INFO as >= 20 and DEBUG as >= 10, so this PR changes the file info level to 21 and the file debug level to 11, aligned with the console info level of 22 and the console debug level of 12.

See #1184 for discussion.