### PR TITLE
Support for ‘—no-sound’ argument (required for corresponding MC update)

### DIFF
--- a/mpf/commands/game.py
+++ b/mpf/commands/game.py
@@ -144,6 +144,9 @@ class Command(object):
                             metavar='mc_file_name',
                             default=None, help=argparse.SUPPRESS)
 
+        parser.add_argument("--no-sound",
+                            action="store_true", dest="no_sound", default=False)
+
         self.args = parser.parse_args(args)
         self.args.configfile = Util.string_to_list(self.args.configfile)
 


### PR DESCRIPTION
This is the sibling PR for https://github.com/missionpinball/mpf-mc/pull/340 to allow `--no-sound` as a command line argument.

This exists because of the dependency on arguments when using `mpf both`, but only MC actually cares about the new arg.