### PR TITLE
Bug fix: prevent achievements from enabling after restoring state

### DIFF
--- a/mpf/devices/achievement.py
+++ b/mpf/devices/achievement.py
@@ -220,6 +220,15 @@ class Achievement(ModeDevice):
             self._show.stop()
             self._show = None
 
+    def add_control_events_in_mode(self, mode: Mode) -> None:
+        """Override the default mode device behavior of automatically enabling devices
+        that don't explicitly define enable_events.
+
+        Achievements use sophisticated logic to handle their mode-starting states
+        during device_loaded_in_mode(). Therefore no default enabling is required.
+        """
+        pass
+
     def add_to_group(self, group):
         """Add this achievement to an achievement group.
 

--- a/mpf/devices/achievement.py
+++ b/mpf/devices/achievement.py
@@ -221,8 +221,7 @@ class Achievement(ModeDevice):
             self._show = None
 
     def add_control_events_in_mode(self, mode: Mode) -> None:
-        """Override the default mode device behavior of automatically enabling devices
-        that don't explicitly define enable_events.
+        """Override the default mode device behavior.
 
         Achievements use sophisticated logic to handle their mode-starting states
         during device_loaded_in_mode(). Therefore no default enabling is required.

--- a/mpf/tests/test_Achievement.py
+++ b/mpf/tests/test_Achievement.py
@@ -186,6 +186,22 @@ class TestAchievement(MpfFakeGameTestCase):
         self.assertEqual("stopped", achievement._state)
         self.assertLightColor('led1', 'off')
 
+    def test_control_events_in_mode(self):
+        baseMode = self.machine.modes.base
+        ach = self.machine.achievements['achievement7']
+        group = self.machine.achievement_groups['group1']
+
+        # The custom behavior is unique to mode devices _without_ enable_events
+        self.assertFalse(ach.config['enable_events'])
+        self.assertFalse(group.config['enable_events'])
+        # Assert that the achievement does not add mode event handlers
+        self.assertEqual(baseMode.event_handlers, set())
+        ach.add_control_events_in_mode(mode=baseMode)
+        self.assertEqual(baseMode.event_handlers, set())
+        # Assert that achievement groups do add event handlers
+        group.add_control_events_in_mode(mode=baseMode)
+        self.assertEqual(len(baseMode.event_handlers), 1)
+
     def test_group_select(self):
 
         a4 = self.machine.achievements['achievement4']


### PR DESCRIPTION
This PR addresses a bug in Achievement behavior wherein achievements without `enable_events` inherit behavior from `mode_device.add_control_events_in_mode()` and automatically enable themselves when their modes start.

This inherited behavior is contradictory to the achievement's `device_loaded_in_mode()` behavior, which to calls `_reset()` or `_restore_state()` and uses sophisticated logic to determine the desired state of the achievement (including automatically enabling achievements without `enable_events` defined).

Unfortunately `add_control_events_in_mode()` creates a callback which is called _after_ `device_loaded_in_mode()`, so any achievement without `enable_events` will subsequently have its restored state changed to "enabled".

This PR overwrites the `add_control_events_in_mode()` behavior for Achievements to do nothing. The expected result is that `_restore_state()` will handle all of the desired behavior.