### PR TITLE
Restart shots and shot groups

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1018,6 +1018,7 @@ shots:
     enable_events: event_handler|str:ms|None
     disable_events: event_handler|str:ms|None
     reset_events: event_handler|str:ms|None
+    restart_events: event_handler|str:ms|None
     advance_events: event_handler|str:ms|None
     hit_events: event_handler|str:ms|None
     show_tokens: dict|str:str|None
@@ -1030,6 +1031,7 @@ shot_groups:
     enable_events: event_handler|str:ms|None
     disable_events: event_handler|str:ms|None
     reset_events: event_handler|str:ms|None
+    restart_events: event_handler|str:ms|None
     enable_rotation_events: event_handler|str:ms|None
     disable_rotation_events: event_handler|str:ms|None
 shot_profiles:

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -391,6 +391,16 @@ class Shot(EnableDisableMixin, ModeDevice):
 
         self.jump(state=0)
 
+    @event_handler(2)
+    def restart(self, **kwargs):
+        """Restart the shot profile by calling reset() and enable().
+
+        Automatically called when one fo the restart_events is called.
+        """
+        del kwargs
+        self.reset()
+        self.enable()
+
     def _enable(self):
         super()._enable()
         self._register_switch_handlers()

--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -106,6 +106,11 @@ class ShotGroup(ModeDevice):
         for shot in self.config['shots']:
             shot.reset(**kwargs)
 
+    def restart(self, **kwargs):
+        """Restart all member shots."""
+        for shot in self.config['shots']:
+            shot.restart(**kwargs)
+
     def _hit(self, advancing, **kwargs):
         """One of the member shots in this shot group was hit.
 

--- a/mpf/tests/machine_files/shots/modes/base/config/base.yaml
+++ b/mpf/tests/machine_files/shots/modes/base/config/base.yaml
@@ -177,6 +177,7 @@ shot_groups:
     enable_events: group32_enable
     disable_events: group32_disable
     reset_events: group32_reset
+    restart_events: group32_restart
     rotate_left_events: group32_rotate_left
     rotate_right_events: group32_rotate_right
     enable_rotation_events: group32_enable_rotation

--- a/mpf/tests/machine_files/shots/modes/base2/config/base2.yaml
+++ b/mpf/tests/machine_files/shots/modes/base2/config/base2.yaml
@@ -82,6 +82,7 @@ shots:
     reset_events: custom_reset_16
     hit_events: custom_hit_16
     advance_events: custom_advance_16
+    restart_events: custom_restart_16
   shot_17:
     switch: switch_17
     profile: profile_17

--- a/mpf/tests/test_ShotGroups.py
+++ b/mpf/tests/test_ShotGroups.py
@@ -225,6 +225,24 @@ class TestShotGroups(MpfFakeGameTestCase):
         self.assertLightColor("led_32", 'off')
         self.assertLightColor("led_33", 'off')
 
+        # test restart
+        # first advance and disable
+        shot32.advance()
+        shot33.advance()
+        shot32.disable()
+        shot33.disable()
+        self.assertFalse(shot32.enabled)
+        self.assertFalse(shot33.enabled)
+        self.assertEqual(shot32.state_name, 'red')
+        self.assertEqual(shot33.state_name, 'red')
+        # ensure all shots are enabled and at the first state
+        self.machine.events.post('group32_restart')
+        self.advance_time_and_run()
+        self.assertTrue(shot32.enabled)
+        self.assertTrue(shot33.enabled)
+        self.assertEqual(shot32.state_name, 'unlit')
+        self.assertEqual(shot33.state_name, 'unlit')
+
     def test_rotation_pattern(self):
         shot40 = self.machine.shots.shot_40
         shot41 = self.machine.shots.shot_41

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -552,6 +552,17 @@ class TestShots(MpfTestCase):
         self.assertEqual(2, self._events["shot_16_hit"])
         self.assertEqual(shot16.state_name, 'lit')
 
+        # test restart event
+        self.machine.events.post('custom_disable_16')
+        self.advance_time_and_run()
+        # make sure we are disabled and advanced in the profile
+        self.assertEqual(shot16.state_name, 'lit')
+        self.assertFalse(self.machine.shots.shot_16.enabled)
+        self.machine.events.post('custom_restart_16')
+        self.advance_time_and_run()
+        self.assertEqual(shot16.state_name, 'unlit')
+        self.assertTrue(self.machine.shots.shot_16.enabled)
+
         # mode1 is not active, so make sure none of the events from
         # mode1_shot_17
 


### PR DESCRIPTION
This PR adds a new event handler to _shots_ and _shot_groups_ called `restart_events`.

Replicating the behavior found in _timers_, _logicblocks_, and elsewhere, a `restart` event is a simultaneous `reset()` and `enable()` call. Restarting a shot enables it at the initial profile state, and restarting a shot group restarts all shots in that group.

Documentation update to follow this PR.