### PR TITLE
Bugfix: timer "pause" delay passed in secs when expecting ms

### DIFF
--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -299,7 +299,7 @@ class Timer(ModeDevice):
 
         self.running = False
 
-        pause_secs = timer_value
+        pause_ms = timer_value * 1000 # delays happen in ms
 
         self._remove_system_timer()
         self.machine.events.post('timer_' + self.name + '_paused',
@@ -314,8 +314,8 @@ class Timer(ModeDevice):
             ticks_remaining: The number of ticks in this timer remaining.
         '''
 
-        if pause_secs > 0:
-            self.delay.add(name='pause', ms=pause_secs, callback=self.start)
+        if pause_ms > 0:
+            self.delay.add(name='pause', ms=pause_ms, callback=self.start)
 
     def timer_complete(self, **kwargs):
         """Automatically called when this timer completes.

--- a/mpf/tests/test_Timer.py
+++ b/mpf/tests/test_Timer.py
@@ -91,7 +91,16 @@ class TestTimer(MpfFakeGameTestCase):
         self.assertEqual(3, self.tick)
         self.assertEqual(3, timer.ticks)
         self.post_event("pause_timer_down")
+        self.advance_time_and_run(0.5)
+        self.assertEqual(3, self.tick)
+        self.assertEqual(3, timer.ticks)
         self.advance_time_and_run(1)
+        self.assertEqual(3, self.tick)
+        self.assertEqual(3, timer.ticks)
+        self.advance_time_and_run(1)
+        # Resuming the paused timer re-ticks at the last number,
+        # so self.ticks increases but timer.ticks does not
+        self.assertEqual(4, self.tick)
         self.assertEqual(3, timer.ticks)
         self.advance_time_and_run(1)
         self.assertEqual(5, self.tick)


### PR DESCRIPTION
This PR fixes a bug where the `Timer.pause()` method handles pause duration in seconds but `DelayManager.add()` expects an argument in milliseconds. The result is that pauses are uselessly brief.

This PR takes the timer argument and multiplies by 1000 before passing the delay. Verified working via log event timestamps.