### PR TITLE
Improve FAST behaviour during MPF init

### DIFF
--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -161,8 +161,6 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, DmdPlatform,
 
         yield from self._connect_to_hardware()
 
-        self.machine.clock.schedule_interval(self._update_watchdog, self.config['watchdog'] / 2000)
-
     def stop(self):
         """Stop platform and close connections."""
         for connection in self.serial_connections:
@@ -173,7 +171,9 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, DmdPlatform,
 
     @asyncio.coroutine
     def start(self):
-        """Start listening for commands."""
+        """Start listening for commands and schedule watchdog."""
+        self.machine.clock.schedule_interval(self._update_watchdog, self.config['watchdog'] / 2000)
+
         for connection in self.serial_connections:
             yield from connection.start_read_loop()
 

--- a/mpf/platforms/fast/fast_serial_communicator.py
+++ b/mpf/platforms/fast/fast_serial_communicator.py
@@ -309,7 +309,7 @@ class FastSerialCommunicator(BaseSerialCommunicator):
             if msg[:2] not in self.ignored_messages_in_flight:
 
                 self.messages_in_flight -= 1
-                if self.messages_in_flight <= self.max_messages_in_flight:
+                if self.messages_in_flight <= self.max_messages_in_flight or not self.read_task:
                     self.send_ready.set()
                 if self.messages_in_flight < 0:
                     self.log.warning("Port %s received more messages than "


### PR DESCRIPTION
- do not send watchdog messaged during init for FAST
- do not throttle NET during init for FAST