### PR TITLE
Config spec support for multiple widget styles

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1498,7 +1498,7 @@ widgets:
         animations: ignore
         reset_animations_events: event_handler|str:ms|None
         color: single|kivycolor|ffffffff
-        style: single|str|None
+        style: list|str|None
         adjust_top: single|int|0
         adjust_bottom: single|int|0
         adjust_left: single|int|0


### PR DESCRIPTION
This PR updates `config_spec` to process a widget's `styles:` setting as a list instead of a string. This is the companion commit to the MPF-MC update to support multiple widget styles.

See the MPF-MC change here: https://github.com/missionpinball/mpf-mc/pull/349