### PR TITLE
config_spec: allow reusable widgets

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1505,6 +1505,7 @@ widgets:
         adjust_right: single|int|0
         expire: single|secs|None
         key: single|str|None
+        widget: single|str|None
     animations:
         property: list|str|
         value: list|str|


### PR DESCRIPTION
This PR corresponds to https://github.com/missionpinball/mpf-mc/pull/353 for MC, which adds a `widget:` setting to including reusable widgets in slides.