### PR TITLE
select AC relay handling

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1232,6 +1232,8 @@ snux:
     platform: single|str|None
     console_log: single|enum(none,basic,full)|none
     file_log: single|enum(none,basic,full)|basic
+    prefer_a_side_event: single|str|game_ended
+    prefer_c_side_event: single|str|game_will_start
 smartmatrix:
     __valid_in__: machine
     port: single|str|

--- a/mpf/tests/test_Snux.py
+++ b/mpf/tests/test_Snux.py
@@ -1,10 +1,9 @@
 """Test snux platform."""
+from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase, MagicMock
 from mpf.platforms.interfaces.driver_platform_interface import PulseSettings, HoldSettings
 
-from mpf.tests.MpfTestCase import MpfTestCase, MagicMock
 
-
-class TestSnux(MpfTestCase):
+class TestSnux(MpfFakeGameTestCase):
     def getConfigFile(self):
         return 'config.yaml'
 
@@ -29,6 +28,22 @@ class TestSnux(MpfTestCase):
             if driver.number + "c" == coil.hw_driver.number:
                 return driver
         return False
+
+    def test_ac_relay_default(self):
+        # outside game it should be default off
+        c_ac_relay = self.machine.coils["c_ac_relay"]
+        self.assertEqual("disabled", c_ac_relay.hw_driver.state)
+
+        self.start_game()
+        # during a game it should be default on to allow fast flashers
+        self.assertEqual("enabled", c_ac_relay.hw_driver.state)
+
+        # after the game ended it should turn back to default off
+        self.drain_all_balls()
+        self.drain_all_balls()
+        self.drain_all_balls()
+        self.assertGameIsNotRunning()
+        self.assertEqual("disabled", c_ac_relay.hw_driver.state)
 
     def test_ac_switch_and_pulse(self):
         # test diag led flashing. otherwise snux is not running


### PR DESCRIPTION
fix #1288 (apply changes from snux)

test by myself. AC relay should be off outside of a game and on during the game to allow fast flashers