### PR TITLE
Unify how we call config players via BCP

### DIFF
--- a/mpf/config_players/plugin_player.py
+++ b/mpf/config_players/plugin_player.py
@@ -48,37 +48,26 @@ class PluginPlayer(DeviceConfigPlayer):
         config_player events to send the trigger via BCP instead of calling
         the local play() method.
         """
-        event_list = list()
+        events = super().register_player_events(config, mode, priority)
         # when bcp is disabled do not register plugin_player
         if not self.machine.options['bcp']:
-            return event_list
+            return events
 
         self.bcp_client = self._get_bcp_client(config)
-
-        for event in config:
-            event_name, _ = self.machine.events.get_event_and_condition_from_string(event)
-            self.machine.bcp.interface.add_registered_trigger_event_for_client(
-                self.bcp_client, event_name)
-            event_list.append(event_name)
 
         self.machine.bcp.interface.add_registered_trigger_event_for_client(
             self.bcp_client, '{}_play'.format(self.show_section))
         self.machine.bcp.interface.add_registered_trigger_event_for_client(
             self.bcp_client, '{}_clear'.format(self.show_section))
 
-        return event_list
-
-    def unload_player_events(self, key_list):
-        """Unload player events via BCP."""
-        for event in key_list:
-            self.machine.bcp.interface.remove_registered_trigger_event_for_client(self.bcp_client, event)
+        return events
 
     def play(self, settings, context, calling_context, priority=0, **kwargs):
         """Trigger remote player via BCP."""
         self.machine.bcp.interface.bcp_trigger(
             name='{}_play'.format(self.show_section),
-            settings=settings, context=context,
-            priority=priority)
+            settings=settings, context=context, calling_context=calling_context,
+            priority=priority, **kwargs)
 
     def clear_context(self, context):
         """Clear the context at remote player via BCP."""

--- a/mpf/core/bcp/bcp_socket_client.py
+++ b/mpf/core/bcp/bcp_socket_client.py
@@ -19,7 +19,7 @@ class MpfJSONEncoder(json.JSONEncoder):
 
 
 def decode_command_string(bcp_string):
-    """Decode a BCP command string into separate command and paramter parts.
+    """Decode a BCP command string into separate command and parameter parts.
 
     Args:
         bcp_string: The incoming UTF-8, URL encoded BCP command string.
@@ -40,7 +40,7 @@ def decode_command_string(bcp_string):
 
     if bcp_command.query[0:5] == "json=":
         kwargs = json.loads(bcp_command.query[5:])
-        return bcp_command.path.lower(), kwargs
+        return bcp_command.path, kwargs
 
     try:
         kwargs = parse_qs(bcp_command.query, keep_blank_values=True)
@@ -64,8 +64,8 @@ def decode_command_string(bcp_string):
 
             kwargs[k] = v
 
-    return (bcp_command.path.lower(),
-            dict((k.lower(), v[0]) for k, v in kwargs.items()))
+    return (bcp_command.path,
+            dict((k, v[0]) for k, v in kwargs.items()))
 
 
 def encode_command_string(bcp_command, **kwargs):
@@ -109,7 +109,7 @@ def encode_command_string(bcp_command, **kwargs):
         else:  # cast anything else as a string
             value = str(value)
 
-        kwarg_string += '{}={}&'.format(quote(k.lower(), ''),
+        kwarg_string += '{}={}&'.format(quote(k, ''),
                                         value)
 
     kwarg_string = kwarg_string[:-1]
@@ -117,7 +117,7 @@ def encode_command_string(bcp_command, **kwargs):
     if json_needed:
         kwarg_string = 'json={}'.format(json.dumps(kwargs, cls=MpfJSONEncoder))
 
-    return str(urlunparse(('', '', bcp_command.lower(), '', kwarg_string, '')))
+    return str(urlunparse(('', '', bcp_command, '', kwarg_string, '')))
 
 
 class AsyncioBcpClientSocket():

--- a/mpf/core/config_player.py
+++ b/mpf/core/config_player.py
@@ -143,6 +143,7 @@ class ConfigPlayer(LogMixin, metaclass=abc.ABCMeta):
 
     def _get_instance_dict(self, context):
         if context not in self.instances or self.config_file_section not in self.instances[context]:
+            self.warning_log("Config player {} is missing context {}".format(self.config_file_section, context))
             return {}
         return self.instances[context][self.config_file_section]
 


### PR DESCRIPTION
Should also allow conditional events everywhere