### PR TITLE
Initital Add for supporting Pololu TIC stepper drivers

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -979,6 +979,9 @@ pololu_maestro:
     console_log: single|enum(none,basic,full)|none
     file_log: single|enum(none,basic,full)|basic
     debug: single|bool|False
+pololu_tic:
+    __valid_in__: machine
+    debug: single|bool|False
 random_event_player:
     __valid_in__: machine, mode, show
     events: ignore
@@ -1408,6 +1411,7 @@ steppers:
     homing_mode: single|enum(hardware,switch)|hardware
     homing_switch: single|machine(switches)|None
     homing_direction: single|enum(clockwise,counterclockwise)|clockwise
+    homing_set_zero: single|bool|False
     pos_min: single|int|0
     pos_max: single|int|1000
     ball_search_min: single|int|0
@@ -1467,6 +1471,14 @@ system11:
     ac_relay_driver: single|machine(coils)|
 text_strings:
     __valid_in__: machine, mode                 # todo add to validator
+tic_stepper_settings:
+    max_speed: single|int|2000000
+    starting_speed: single|int|0
+    max_acceleration: single|int|40000
+    max_deceleration: single|int|40000
+    step_mode: single|int|1
+    poll_ms: single|ms|100ms
+    current_limit: single|int|192
 tilt:
     __valid_in__: machine, mode
     tilt_slam_tilt_events: event_handler|str:ms|None

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -144,7 +144,7 @@ class Stepper(SystemWideDevice):
             yield from self.machine.switch_controller.wait_for_switch(self.config['homing_switch'].name,
                                                                       only_on_change=False)
             self.hw_stepper.stop()
-            if self.config['homing_set_zero'] == True:
+            if self.config['homing_set_zero']:
                 self.hw_stepper.set_position(0)
 
         self._is_homed = True

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -11,7 +11,7 @@ from mpf.core.events import event_handler
 from mpf.core.system_wide_device import SystemWideDevice
 
 
-@DeviceMonitor(_current_position="position", _target_position="target_position", _is_home="is_homed")
+@DeviceMonitor(_current_position="position", _target_position="target_position", _is_homed="is_homed")
 class Stepper(SystemWideDevice):
 
     """Represents an stepper motor based axis in a pinball machine.
@@ -144,6 +144,8 @@ class Stepper(SystemWideDevice):
             yield from self.machine.switch_controller.wait_for_switch(self.config['homing_switch'].name,
                                                                       only_on_change=False)
             self.hw_stepper.stop()
+            if self.config['homing_set_zero'] == True:
+                self.hw_stepper.set_position(0)
 
         self._is_homed = True
         self._is_moving.clear()

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -112,6 +112,7 @@ mpf:
         virtual: mpf.platforms.virtual.VirtualHardwarePlatform
         spike: mpf.platforms.spike.spike.SpikePlatform
         trinamics_steprocker: mpf.platforms.trinamics_steprocker.TrinamicsStepRocker
+        pololu_tic: mpf.platforms.pololu_tic.PololuTICHardwarePlatform
         smbus2: mpf.platforms.smbus2.Smbus2
         mma8451: mpf.platforms.mma8451.MMA8451Platform
         virtual_pinball: mpf.platforms.virtual_pinball.virtual_pinball.VirtualPinballPlatform

--- a/mpf/platforms/pololu/PololuTIC.py
+++ b/mpf/platforms/pololu/PololuTIC.py
@@ -3,11 +3,13 @@ import subprocess
 import logging
 import asyncio
 from threading import Timer, Thread, Event
-import ruamel.yaml as yaml
+import ruamel.yaml
 
 
 class TICError(Exception):
+
     """A Pololu TIC Error."""
+
     pass
 
 
@@ -16,7 +18,7 @@ class PololuTICDevice():
     """A Pololu TIC Device."""
 
     def __init__(self, serial_number, machine, debug=True):
-        """Returns the current status of the TIC device.
+        """Return the current status of the TIC device.
 
         Args:
             serial_number (number): The serial number of the TIC to control
@@ -49,7 +51,7 @@ class PololuTICDevice():
             self._commandrunning = False
             return output
         except subprocess.CalledProcessError as e:
-            self.log.debug("Exception: {}".format(str(e.output)))
+            self.log.debug("Exception: {}".format(e.output))
             raise TICError(e.output)
 
     def currentstatus(self, refresh=True):

--- a/mpf/platforms/pololu/PololuTIC.py
+++ b/mpf/platforms/pololu/PololuTIC.py
@@ -10,7 +10,8 @@ class TICError(Exception):
 
 
 class PololuTICDevice(object):
-        """A Pololu TIC Device"""
+
+    """A Pololu TIC Device"""
 
     def __init__(self, serial_number, machine, debug=True):
         self._debug = debug

--- a/mpf/platforms/pololu/PololuTIC.py
+++ b/mpf/platforms/pololu/PololuTIC.py
@@ -51,7 +51,7 @@ class PololuTICDevice():
             self._commandrunning = False
             return output
         except subprocess.CalledProcessError as e:
-            self.log.debug("Exception: {}".format(e.output))
+            self.log.debug("Exception: %s", str(e.output))
             raise TICError(e.output)
 
     def currentstatus(self, refresh=True):
@@ -66,7 +66,7 @@ class PololuTICDevice():
 
     def _getstatus(self):
         cmd_return = self._ticcmd('-s', '--full')
-        self._status = yaml.load(cmd_return)
+        self._status = ruamel.yaml.load(cmd_return)
         self.currentposition = self._status['Current position']
 
     def haltandhold(self):

--- a/mpf/platforms/pololu/PololuTIC.py
+++ b/mpf/platforms/pololu/PololuTIC.py
@@ -1,13 +1,16 @@
-import ruamel.yaml as yaml
 import subprocess
 import logging
 import asyncio
 from threading import Timer, Thread, Event
+import ruamel.yaml as yaml
+
 
 class TICError(Exception):
     pass
 
+
 class PololuTICDevice(object):
+        """A Pololu TIC Device"""
 
     def __init__(self, serial_number, machine, debug=True):
         self._debug = debug
@@ -21,10 +24,10 @@ class PololuTICDevice(object):
         self._getstatus()
 
     def _ticcmd(self, *args):
-        #this is my cheat to control threading, because self._commandrunning appears to
-        #be shared memory between the threads, I can use it to prevent collisions with
-        #ticcmd but potentially risk deadlock.  if someone knows a more proper way to do
-        #this in python, feel free
+        # this is my cheat to control threading, because self._commandrunning appears to
+        # be shared memory between the threads, I can use it to prevent collisions with
+        # ticcmd but potentially risk deadlock.  if someone knows a more proper way to do
+        # this in python, feel free
         while self._commandrunning:
             asyncio.sleep(0.005)
         self._commandrunning = True
@@ -36,10 +39,15 @@ class PololuTICDevice(object):
             self._commandrunning = False
             return output
         except subprocess.CalledProcessError as e:
-            self.log.debug("Exception: " + str(e.output))
+            self.log.debug("Exception: {}".format(str(e.output)))
             raise TICError(e.output)
 
     def currentstatus(self, refresh=True):
+        """Returns the current status of the TIC device.
+
+        Args:
+            refresh (boolean): Refresh the cached status by asking the TIC
+        """
         if refresh:
             self._getstatus()
         return self._status
@@ -50,41 +58,86 @@ class PololuTICDevice(object):
         self.currentposition = self._status['Current position']
 
     def haltandhold(self):
+        """Stops the motor abruptly without respecting the deceleration limit."""
         self._ticcmd('--halt-and-hold')
 
     def haltandsetposition(self, position):
+        """Stops the motor abruptly without respecting the deceleration limit and sets the current position."""
         self._ticcmd('--halt-and-set-position', str(position))
 
     def rotate_to_position(self, position):
+        """Tells the TIC to move the stepper to the target position
+
+        Args:
+            position (number): The desired position in microsteps
+        """
         self.targetposition = position
         self._ticcmd('--position', str(position))
 
     def rotate_by_velocity(self, velocity):
+        """Tells the TIC to move the stepper continuously at the specified velocity
+
+        Args:
+            velocity (number): The desired speed in microsteps per 10,000 s
+        """
         self._ticcmd('--velocity', str(velocity))
 
     def reset_command_timeout(self):
+        """Tells the TIC to reset the internal command timeout."""
         self._ticcmd('--reset-command-timeout')
 
     def exit_safe_start(self):
+        """Tells the TIC to exit the safe start mode."""
         self._ticcmd('--exit-safe-start')
 
     def set_step_mode(self, mode):
+        """Sets the Step Mode of the stepper
+
+        Args:
+            mode (number): One of 1, 2, 4, 8, 16, 32, the number of microsteps per step
+        """
         self._ticcmd('--step-mode', str(mode))
 
     def set_max_speed(self, speed):
+        """Sets the max speed of the stepper
+
+        Args:
+            speed (number): The maximum speed of the stepper in microsteps per 10,000s
+        """
         self._ticcmd('--max-speed', str(speed))
 
     def set_starting_speed(self, speed):
+        """Sets the starting speed of the stepper
+
+        Args:
+            speed (number): The starting speed of the stepper in microsteps per 10,000s
+        """
         self._ticcmd('--starting-speed', str(speed))
 
     def set_max_acceleration(self, acceleration):
+        """Sets the max acceleration of the stepper
+
+        Args:
+            acceleration (number): The maximum acceleration of the stepper in microsteps per 100 s^2
+        """
         self._ticcmd('--max-accel', str(acceleration))
 
     def set_max_deceleration(self, deceleration):
+        """Sets the max deceleration of the stepper
+
+        Args:
+            deceleration (number): The maximum deceleration of the stepper in microsteps per 100 s^2
+        """
         self._ticcmd('--max-decel', str(deceleration))
 
     def set_current_limit(self, current):
+        """Sets the max current of the stepper driver
+
+        Args:
+            current (number): The maximum current of the stepper in milliamps
+        """
         self._ticcmd('--current', str(current))
 
     def energize(self):
+        """Energizes the Stepper"""
         self._ticcmd('--energize')

--- a/mpf/platforms/pololu/PololuTIC.py
+++ b/mpf/platforms/pololu/PololuTIC.py
@@ -1,0 +1,90 @@
+import ruamel.yaml as yaml
+import subprocess
+import logging
+import asyncio
+from threading import Timer, Thread, Event
+
+class TICError(Exception):
+    pass
+
+class PololuTICDevice(object):
+
+    def __init__(self, serial_number, machine, debug=True):
+        self._debug = debug
+        self.log = logging.getLogger('TIC Stepper')
+        self._serial_number = serial_number
+        self._machine = machine
+        self._status = None
+        self._commandrunning = False
+        self.currentposition = None
+        self.targetposition = None
+        self._getstatus()
+
+    def _ticcmd(self, *args):
+        #this is my cheat to control threading, because self._commandrunning appears to
+        #be shared memory between the threads, I can use it to prevent collisions with
+        #ticcmd but potentially risk deadlock.  if someone knows a more proper way to do
+        #this in python, feel free
+        while self._commandrunning:
+            asyncio.sleep(0.005)
+        self._commandrunning = True
+        args = list(args)
+        args.append('-d')
+        args.append(str(self._serial_number))
+        try:
+            output = subprocess.check_output(['ticcmd'] + args, stderr=subprocess.STDOUT)
+            self._commandrunning = False
+            return output
+        except subprocess.CalledProcessError as e:
+            self.log.debug("Exception: " + str(e.output))
+            raise TICError(e.output)
+
+    def currentstatus(self, refresh=True):
+        if refresh:
+            self._getstatus()
+        return self._status
+
+    def _getstatus(self):
+        cmd_return = self._ticcmd('-s', '--full')
+        self._status = yaml.load(cmd_return)
+        self.currentposition = self._status['Current position']
+
+    def haltandhold(self):
+        self._ticcmd('--halt-and-hold')
+
+    def haltandsetposition(self, position):
+        self._ticcmd('--halt-and-set-position', str(position))
+
+    def rotate_to_position(self, position):
+        self.targetposition = position
+        self._ticcmd('--position', str(position))
+
+    def rotate_by_velocity(self, velocity):
+        self._ticcmd('--velocity', str(velocity))
+
+    def reset_command_timeout(self):
+        self._ticcmd('--reset-command-timeout')
+
+    def exit_safe_start(self):
+        self._ticcmd('--exit-safe-start')
+
+    def set_step_mode(self, mode):
+        self._ticcmd('--step-mode', str(mode))
+
+    def set_max_speed(self, speed):
+        self._ticcmd('--max-speed', str(speed))
+
+    def set_starting_speed(self, speed):
+        self._ticcmd('--starting-speed', str(speed))
+
+    def set_max_acceleration(self, acceleration):
+        self._ticcmd('--max-accel', str(acceleration))
+
+    def set_max_deceleration(self, deceleration):
+        self._ticcmd('--max-decel', str(deceleration))
+
+    def set_current_limit(self, current):
+        self._ticcmd('--current', str(current))
+
+    def energize(self):
+        self._ticcmd('--energize')

--- a/mpf/platforms/pololu/PololuTIC.py
+++ b/mpf/platforms/pololu/PololuTIC.py
@@ -1,3 +1,4 @@
+"""Pololu TIC Device."""
 import subprocess
 import logging
 import asyncio
@@ -6,14 +7,22 @@ import ruamel.yaml as yaml
 
 
 class TICError(Exception):
+    """A Pololu TIC Error."""
     pass
 
 
-class PololuTICDevice(object):
+class PololuTICDevice():
 
-    """A Pololu TIC Device"""
+    """A Pololu TIC Device."""
 
     def __init__(self, serial_number, machine, debug=True):
+        """Returns the current status of the TIC device.
+
+        Args:
+            serial_number (number): The serial number of the TIC to control
+            machine (object): The machine object
+            debug (boolean): Turn on debugging or not
+        """
         self._debug = debug
         self.log = logging.getLogger('TIC Stepper')
         self._serial_number = serial_number
@@ -44,7 +53,7 @@ class PololuTICDevice(object):
             raise TICError(e.output)
 
     def currentstatus(self, refresh=True):
-        """Returns the current status of the TIC device.
+        """Return the current status of the TIC device.
 
         Args:
             refresh (boolean): Refresh the cached status by asking the TIC
@@ -59,15 +68,15 @@ class PololuTICDevice(object):
         self.currentposition = self._status['Current position']
 
     def haltandhold(self):
-        """Stops the motor abruptly without respecting the deceleration limit."""
+        """Stop the motor abruptly without respecting the deceleration limit."""
         self._ticcmd('--halt-and-hold')
 
     def haltandsetposition(self, position):
-        """Stops the motor abruptly without respecting the deceleration limit and sets the current position."""
+        """Stop the motor abruptly without respecting the deceleration limit and sets the current position."""
         self._ticcmd('--halt-and-set-position', str(position))
 
     def rotate_to_position(self, position):
-        """Tells the TIC to move the stepper to the target position
+        """Tells the TIC to move the stepper to the target position.
 
         Args:
             position (number): The desired position in microsteps
@@ -76,7 +85,7 @@ class PololuTICDevice(object):
         self._ticcmd('--position', str(position))
 
     def rotate_by_velocity(self, velocity):
-        """Tells the TIC to move the stepper continuously at the specified velocity
+        """Tells the TIC to move the stepper continuously at the specified velocity.
 
         Args:
             velocity (number): The desired speed in microsteps per 10,000 s
@@ -92,7 +101,7 @@ class PololuTICDevice(object):
         self._ticcmd('--exit-safe-start')
 
     def set_step_mode(self, mode):
-        """Sets the Step Mode of the stepper
+        """Set the Step Mode of the stepper.
 
         Args:
             mode (number): One of 1, 2, 4, 8, 16, 32, the number of microsteps per step
@@ -100,7 +109,7 @@ class PololuTICDevice(object):
         self._ticcmd('--step-mode', str(mode))
 
     def set_max_speed(self, speed):
-        """Sets the max speed of the stepper
+        """Set the max speed of the stepper.
 
         Args:
             speed (number): The maximum speed of the stepper in microsteps per 10,000s
@@ -108,7 +117,7 @@ class PololuTICDevice(object):
         self._ticcmd('--max-speed', str(speed))
 
     def set_starting_speed(self, speed):
-        """Sets the starting speed of the stepper
+        """Set the starting speed of the stepper.
 
         Args:
             speed (number): The starting speed of the stepper in microsteps per 10,000s
@@ -116,7 +125,7 @@ class PololuTICDevice(object):
         self._ticcmd('--starting-speed', str(speed))
 
     def set_max_acceleration(self, acceleration):
-        """Sets the max acceleration of the stepper
+        """Set the max acceleration of the stepper.
 
         Args:
             acceleration (number): The maximum acceleration of the stepper in microsteps per 100 s^2
@@ -124,7 +133,7 @@ class PololuTICDevice(object):
         self._ticcmd('--max-accel', str(acceleration))
 
     def set_max_deceleration(self, deceleration):
-        """Sets the max deceleration of the stepper
+        """Set the max deceleration of the stepper.
 
         Args:
             deceleration (number): The maximum deceleration of the stepper in microsteps per 100 s^2
@@ -132,7 +141,7 @@ class PololuTICDevice(object):
         self._ticcmd('--max-decel', str(deceleration))
 
     def set_current_limit(self, current):
-        """Sets the max current of the stepper driver
+        """Set the max current of the stepper driver.
 
         Args:
             current (number): The maximum current of the stepper in milliamps
@@ -140,5 +149,5 @@ class PololuTICDevice(object):
         self._ticcmd('--current', str(current))
 
     def energize(self):
-        """Energizes the Stepper"""
+        """Energize the Stepper."""
         self._ticcmd('--energize')

--- a/mpf/platforms/pololu/__init__.py
+++ b/mpf/platforms/pololu/__init__.py
@@ -1,0 +1,1 @@
+"""Pololu TIC Library."""

--- a/mpf/platforms/pololu_tic.py
+++ b/mpf/platforms/pololu_tic.py
@@ -89,7 +89,7 @@ class PololuTICStepper(StepperPlatformInterface):
         if self.config['max_speed'] > 500000000:
             raise ConfigFileError("max_speed must be less than or equal to 500,000,000", 3, self.log.name)
 
-        self.log.debug("Looking for TIC Device with serial number " + str(self.serial_number) + ".")
+        self.log.debug("Looking for TIC Device with serial number {}.".format(str(self.serial_number)))
         self.TIC = PololuTICDevice(self.serial_number, False)
 
         if "Low VIN" in self.TIC.currentstatus(False)['Errors currently stopping the motor']:
@@ -116,7 +116,7 @@ class PololuTICStepper(StepperPlatformInterface):
     def resetCommandTimeout(self):
         """Reset the command timeout."""
         self.TIC.reset_command_timeout()
-    
+
     def home(self, direction):
         """Home an axis, resetting 0 position."""
         self.TIC.haltandhold() #stop the stepper in case its moving
@@ -145,7 +145,7 @@ class PololuTICStepper(StepperPlatformInterface):
             self.TIC.haltandhold()     # motor stop
         else:
             calculatedvelocity = velocity * self.config['max_speed']
-            self.log.debug("Rotating By Velocity (velocity * max_speed): {}".format(str(calculatedvelocity)))
+            self.log.debug("Rotating By Velocity (velocity * max_speed): {}".format(calculatedvelocity))
             self.TIC.rotate_by_velocity(calculatedvelocity)
 
     def set_position(self, position):
@@ -171,32 +171,34 @@ class PololuTICStepper(StepperPlatformInterface):
         """Return true if move is complete."""
         self.TIC.currentstatus(True)
         self.log.debug("Target Position: {} Current Position: {}".format( \
-            str(self.TIC.targetposition),str(self.TIC.currentposition)))
+            str(self.TIC.targetposition), str(self.TIC.currentposition)))
         complete = bool(self.TIC.targetposition == self.TIC.currentposition)
         return complete
 
 class pololuCommandTimer():
+
     """A timer wrapper for the command refresh."""
 
     def __init__(self, t, hFunction):
+        """Initialize the object."""
         self.t = t
         self.hFunction = hFunction
         self.thread = Timer(self.t, self.handle_function)
 
     def handle_function(self):
-        """Handles the assigned function upon timer trigger."""
+        """Handle the assigned function upon timer trigger."""
         self.hFunction()
         self.thread = Timer(self.t, self.handle_function)
         self.thread.start()
 
     def start(self):
-        """Starts the timer thread."""
+        """Start the timer thread."""
         self.thread.start()
 
     def cancel(self):
-        """Cancels the timer thread."""
+        """Cancel the timer thread."""
         self.thread.cancel()
 
     def is_alive(self):
-        """Checks to see if the timer thread is alive."""
+        """Check to see if the timer thread is alive."""
         return self.is_alive()

--- a/mpf/platforms/pololu_tic.py
+++ b/mpf/platforms/pololu_tic.py
@@ -129,12 +129,12 @@ class PololuTICStepper(StepperPlatformInterface):
 
     def move_abs_pos(self, position):
         """Move axis to a certain absolute position."""
-        self.log.debug("Moving To Absolute Position: {}".format(str(position)))
+        self.log.debug("Moving To Absolute Position: %s", str(position))
         self.TIC.rotate_to_position(position)
 
     def move_rel_pos(self, position):
         """Move axis to a relative position."""
-        self.log.debug("Moving To Relative Position: {}".format(str(position)))
+        self.log.debug("Moving To Relative Position: %s", str(position))
         _newposition = int(position) - int(self.TIC.currentstatus(True)['Current position'])
         self.TIC.rotate_to_position(_newposition)
 
@@ -145,7 +145,7 @@ class PololuTICStepper(StepperPlatformInterface):
             self.TIC.haltandhold()     # motor stop
         else:
             calculatedvelocity = velocity * self.config['max_speed']
-            self.log.debug("Rotating By Velocity (velocity * max_speed): {}".format(calculatedvelocity))
+            self.log.debug("Rotating By Velocity (velocity * max_speed): %s", calculatedvelocity)
             self.TIC.rotate_by_velocity(calculatedvelocity)
 
     def set_position(self, position):
@@ -154,7 +154,7 @@ class PololuTICStepper(StepperPlatformInterface):
         Args:
             position (number): The position to set
         """
-        self.log.debug("Setting Position To {}".format(str(position)))
+        self.log.debug("Setting Position To %s", str(position))
         self.TIC.haltandsetposition(position)
 
     def current_position(self):
@@ -175,8 +175,8 @@ class PololuTICStepper(StepperPlatformInterface):
     def is_move_complete(self) -> bool:
         """Return true if move is complete."""
         self.TIC.currentstatus(True)
-        self.log.debug("Target Position: {} Current Position: {}".format( \
-            str(self.TIC.targetposition), str(self.TIC.currentposition)))
+        self.log.debug("Target Position: %s Current Position: %s", \
+            str(self.TIC.targetposition), str(self.TIC.currentposition))
         complete = bool(self.TIC.targetposition == self.TIC.currentposition)
         return complete
 

--- a/mpf/platforms/pololu_tic.py
+++ b/mpf/platforms/pololu_tic.py
@@ -89,7 +89,7 @@ class PololuTICStepper(StepperPlatformInterface):
         if self.config['max_speed'] > 500000000:
             raise ConfigFileError("max_speed must be less than or equal to 500,000,000", 3, self.log.name)
 
-        self.log.debug("Looking for TIC Device with serial number {}.".format(str(self.serial_number)))
+        self.log.debug("Looking for TIC Device with serial number {}.".format(self.serial_number))
         self.TIC = PololuTICDevice(self.serial_number, False)
 
         if "Low VIN" in self.TIC.currentstatus(False)['Errors currently stopping the motor']:
@@ -149,6 +149,11 @@ class PololuTICStepper(StepperPlatformInterface):
             self.TIC.rotate_by_velocity(calculatedvelocity)
 
     def set_position(self, position):
+        """Set the current position of the stepper.
+
+        Args:
+            position (number): The position to set
+        """
         self.log.debug("Setting Position To {}".format(str(position)))
         self.TIC.haltandsetposition(position)
 

--- a/mpf/platforms/pololu_tic.py
+++ b/mpf/platforms/pololu_tic.py
@@ -170,12 +170,13 @@ class PololuTICStepper(StepperPlatformInterface):
     def is_move_complete(self) -> bool:
         """Return true if move is complete."""
         self.TIC.currentstatus(True)
-        self.log.debug("Target Position: {} Current Position: {}".format(
-            str(self.TIC.targetposition),str(self.TIC.currentposition))
-        return bool(self.TIC.targetposition == self.TIC.currentposition)
+        self.log.debug("Target Position: {} Current Position: {}".format( \
+            str(self.TIC.targetposition),str(self.TIC.currentposition)))
+        complete = bool(self.TIC.targetposition == self.TIC.currentposition)
+        return complete
 
 class pololuCommandTimer():
-"""A timer wrapper for the command refresh."""
+    """A timer wrapper for the command refresh."""
 
     def __init__(self, t, hFunction):
         self.t = t
@@ -183,19 +184,19 @@ class pololuCommandTimer():
         self.thread = Timer(self.t, self.handle_function)
 
     def handle_function(self):
-    """Handles the assigned function upon timer trigger."""
+        """Handles the assigned function upon timer trigger."""
         self.hFunction()
         self.thread = Timer(self.t, self.handle_function)
         self.thread.start()
 
     def start(self):
-    """Starts the timer thread."""
+        """Starts the timer thread."""
         self.thread.start()
 
     def cancel(self):
-    """Cancels the timer thread."""
+        """Cancels the timer thread."""
         self.thread.cancel()
 
     def is_alive(self):
-    """Checks to see if the timer thread is alive."""
+        """Checks to see if the timer thread is alive."""
         return self.is_alive()

--- a/mpf/platforms/pololu_tic.py
+++ b/mpf/platforms/pololu_tic.py
@@ -1,0 +1,199 @@
+"""Pololu TIC controller platform."""
+import asyncio
+import logging
+import subprocess
+
+from threading import Timer, Thread, Event
+
+from mpf.platforms.pololu import PololuTIC
+
+from mpf.platforms.pololu.PololuTIC import PololuTICDevice
+
+from mpf.platforms.interfaces.stepper_platform_interface import StepperPlatformInterface
+
+from mpf.core.platform import StepperPlatform
+
+from mpf.exceptions.ConfigFileError import ConfigFileError
+
+class PololuTICHardwarePlatform(StepperPlatform):
+
+    """Supports the Pololu TIC stepper drivers via ticcmd command line."""
+
+    def __init__(self, machine):
+        """Initialise TIC platform."""
+        super().__init__(machine)
+        self.log = logging.getLogger("Pololu TIC")
+        self.log.debug("Configuring template hardware interface.")
+        self.config = self.machine.config['pololu_tic']
+        self.platform = None
+        self.features['tickless'] = True
+        self.TIC = None
+
+    def __repr__(self):
+        """Return string representation."""
+        return '<Platform.PololuTICHardwarePlatform>'
+
+    @asyncio.coroutine
+    def initialize(self):
+        """Initialise TIC platform."""
+        yield from super().initialize()
+
+        # validate our config (has to be in initialize since config_processor
+        # is not read in __init__)
+        self.config = self.machine.config_validator.validate_config("pololu_tic", self.config)
+
+    def stop(self):
+        """De-energize the stepper and stop sending the command timeout refresh."""
+        #self.TMCL.stop()
+    
+    def configure_stepper(self, number: str, config: dict) -> "PololuTICStepper":
+        """Configure a smart stepper device in platform.
+
+        Args:
+            config (dict): Configuration of device
+        """
+        return PololuTICStepper(number, config, self.TIC, self.machine)
+
+    @classmethod
+    def get_stepper_config_section(cls):
+        """Return config validator name."""
+        return "tic_stepper_settings"
+
+
+# pylint: disable-msg=too-many-instance-attributes
+class PololuTICStepper(StepperPlatformInterface):
+
+    """A stepper on a pololu TIC."""
+
+    def __init__(self, number, config, tic_device, machine):
+        """Initialise stepper."""
+        self.config = config
+        self.log = logging.getLogger('TIC Stepper')
+        self.log.debug("Configuring Stepper Parameters.")
+        self.serial_number = number
+        self.TIC = PololuTICDevice(self.serial_number, machine, False)
+        self.max_speed = self.config['max_speed']
+        self.starting_speed = self.config['starting_speed']
+        self.max_acceleration = self.config['max_acceleration']
+        self.max_deceleration = self.config['max_deceleration']
+        self.current_limit = self.config['current_limit']
+        self.step_mode = self.config['step_mode']
+        self.machine = machine
+        self.commandTimer = None
+        
+        if self.config['step_mode'] not in [1, 2, 4, 8, 16, 32]:
+            raise ConfigFileError("step_mode must be one of (1, 2, 4, 8, 16, or 32)", 1, self.log.name)
+
+        if self.config['max_speed'] <= 0:
+            raise ConfigFileError("max_speed must be greater than 0", 2, self.log.name)
+
+        if self.config['max_speed'] > 500000000:
+            raise ConfigFileError("max_speed must be less than or equal to 500,000,000", 3, self.log.name)
+
+        self.log.debug("Looking for TIC Device with serial number " + str(self.serial_number) + ".")
+        self.TIC = PololuTICDevice(self.serial_number, False)
+
+        if "Low VIN" in self.TIC.currentstatus(False)['Errors currently stopping the motor']:
+            self.log.debug("WARNING: Reporting Low VIN")
+        
+        self.log.debug("TIC Status: ")
+        self.log.debug(self.TIC.currentstatus(True))
+        
+        #start the thread that continuously resets the command timeout
+        self.commandTimer = pololuCommandTimer(0.5, self.resetCommandTimeout)
+        self.commandTimer.start()
+        
+        self.TIC.set_step_mode(self.step_mode)
+        self.TIC.set_max_speed(self.max_speed)
+        self.TIC.set_starting_speed(self.starting_speed)
+        self.TIC.set_max_acceleration(self.max_acceleration)
+        self.TIC.set_max_deceleration(self.max_deceleration)
+        self.TIC.set_current_limit(self.current_limit)
+        
+        self.TIC.exit_safe_start()
+        self.TIC.energize()
+
+    # Public Stepper Platform Interface
+    def resetCommandTimeout(self):
+        #self.log.debug("Requested command timeout reset")
+        self.TIC.reset_command_timeout()
+    
+    def home(self, direction):
+        """Home an axis, resetting 0 position."""
+        self.TIC.haltandhold() #stop the stepper in case its moving
+        if direction == 'clockwise':
+            self.log.debug("Homing clockwise")
+            self.TIC.rotate_to_position(2147483647)
+        elif direction == 'counterclockwise':
+            self.log.debug("Homing counterclockwise")
+            self.TIC.rotate_to_position(-2147483647)
+
+    def move_abs_pos(self, position):
+        """Move axis to a certain absolute position."""
+        self.log.debug("Moving To Absolute Position: " + str(position))
+        self.TIC.rotate_to_position(position)
+
+    def move_rel_pos(self, position):
+        """Move axis to a relative position."""
+        self.log.debug("Moving To Relative Position: " + str(position))
+        _newposition = int(position) - int(self.TIC.currentstatus(True)['Current position'])
+        self.TIC.rotate_to_position(_newposition)
+
+    def move_vel_mode(self, velocity):
+        """Move at a specific velocity and direction (pos = clockwise, neg = counterclockwise)."""
+        if velocity == 0:
+            self.log.debug("Stopping Due To Velocity Set To 0")
+            self.TIC.haltandhold()     # motor stop
+        else:
+            calculatedvelocity = velocity * self.config['max_speed']
+            self.log.debug("Rotating By Velocity (velocity * max_speed): " + str(calculatedvelocity))
+            self.TIC.rotate_by_velocity(calculatedvelocity)
+
+    def set_position(self, position):
+        self.log.debug("Setting Position To " + str(position))
+        self.TIC.haltandsetposition(position)
+
+    def current_position(self):
+        """Return current position."""
+        return int(self.log.debug(self.TIC.currentstatus(True)['Current position']))
+
+    def stop(self) -> None:
+        """Stop stepper."""
+        self.log.debug("Commanded To Stop")
+        self.TIC.haltandhold()
+
+    @asyncio.coroutine
+    def wait_for_move_completed(self):
+        """Wait until move completed."""
+        while not self.is_move_complete():
+            yield from asyncio.sleep(1 / self.config['poll_ms'], loop=self.machine.clock.loop)
+
+    def is_move_complete(self) -> bool:
+        """Return true if move is complete."""
+        _currentstatus = self.TIC.currentstatus(True)
+        self.log.debug("Target Position: " + str(self.TIC.targetposition) + " Current Position: " + str(self.TIC.currentposition))
+        if self.TIC.targetposition == self.TIC.currentposition:
+            return True
+        else:
+            return False
+
+class pololuCommandTimer():
+
+    def __init__(self, t, hFunction):
+        self.t = t
+        self.hFunction = hFunction
+        self.thread = Timer(self.t, self.handle_function)
+
+    def handle_function(self):
+        self.hFunction()
+        self.thread = Timer(self.t, self.handle_function)
+        self.thread.start()
+
+    def start(self):
+        self.thread.start()
+
+    def cancel(self):
+        self.thread.cancel()
+
+    def is_alive(self):
+        return self.is_alive()

--- a/mpf/platforms/pololu_tic.py
+++ b/mpf/platforms/pololu_tic.py
@@ -89,7 +89,7 @@ class PololuTICStepper(StepperPlatformInterface):
         if self.config['max_speed'] > 500000000:
             raise ConfigFileError("max_speed must be less than or equal to 500,000,000", 3, self.log.name)
 
-        self.log.debug("Looking for TIC Device with serial number {}.".format(self.serial_number))
+        self.log.debug("Looking for TIC Device with serial number %s.", self.serial_number)
         self.TIC = PololuTICDevice(self.serial_number, False)
 
         if "Low VIN" in self.TIC.currentstatus(False)['Errors currently stopping the motor']:

--- a/mpf/platforms/pololu_tic.py
+++ b/mpf/platforms/pololu_tic.py
@@ -171,7 +171,8 @@ class PololuTICStepper(StepperPlatformInterface):
     def is_move_complete(self) -> bool:
         """Return true if move is complete."""
         _currentstatus = self.TIC.currentstatus(True)
-        self.log.debug("Target Position: " + str(self.TIC.targetposition) + " Current Position: " + str(self.TIC.currentposition))
+        self.log.debug("Target Position: " + str(self.TIC.targetposition) + \
+            " Current Position: " + str(self.TIC.currentposition))
         if self.TIC.targetposition == self.TIC.currentposition:
             return True
         else:


### PR DESCRIPTION
These are the code changes to add initial support for Pololu TIC stepper drivers.  This should add basic functionality.   

In mpf/config_spec.yaml I added the sections for pololu, and I added the homing_set_zero setting that will tell the driver to set its position to zero after the home switch is hit during homing.

In mpf/devices/stepper.py I fixed a type for the device monitor where it should be spelled is_homed to work with the monitor.  This is where I added the behavior for the homing_set_zero setting.

The other files are the new files for the pololu TIC drivers.

