### PR TITLE
Event kwargs in event placeholders

### DIFF
--- a/mpf/config_players/event_player.py
+++ b/mpf/config_players/event_player.py
@@ -34,16 +34,16 @@ class EventPlayer(FlatConfigPlayer):
             if event_dict['number']:
                 delay = Util.string_to_ms(event_dict['number'])
                 self.delay.add(callback=self._post_event, ms=delay,
-                               event=event_dict['name'], s=s)
+                               event=event_dict['name'], s=s, **kwargs)
             else:
-                self._post_event(event_dict['name'], s)
+                self._post_event(event_dict['name'], s, **kwargs)
 
-    def _post_event(self, event, s):
+    def _post_event(self, event, s, **kwargs):
         event_name_placeholder = TextTemplate(self.machine, event.replace("(", "{").replace(")", "}"))
         for key, param in s.items():
             if isinstance(param, dict):
                 s[key] = self._evaluate_event_param(param)
-        self.machine.events.post(event_name_placeholder.evaluate({}), **s)
+        self.machine.events.post(event_name_placeholder.evaluate(kwargs), **s)
 
     def _evaluate_event_param(self, param):
         if param.get("type") == "float":

--- a/mpf/config_players/event_player.py
+++ b/mpf/config_players/event_player.py
@@ -42,10 +42,10 @@ class EventPlayer(FlatConfigPlayer):
         event_name_placeholder = TextTemplate(self.machine, event.replace("(", "{").replace(")", "}"))
         for key, param in s.items():
             if isinstance(param, dict):
-                s[key] = self._evaluate_event_param(param)
+                s[key] = self._evaluate_event_param(param, kwargs)
         self.machine.events.post(event_name_placeholder.evaluate(kwargs), **s)
 
-    def _evaluate_event_param(self, param):
+    def _evaluate_event_param(self, param, kwargs):
         if param.get("type") == "float":
             placeholder = self.machine.placeholder_manager.build_float_template(param["value"])
         elif param.get("type") == "int":
@@ -54,7 +54,7 @@ class EventPlayer(FlatConfigPlayer):
             placeholder = self.machine.placeholder_manager.build_bool_template(param["value"])
         else:
             placeholder = self.machine.placeholder_manager.build_string_template(param["value"])
-        return placeholder.evaluate({})
+        return placeholder.evaluate(kwargs)
 
     def get_list_config(self, value):
         """Parse list."""

--- a/mpf/tests/machine_files/event_players/config/test_event_player.yaml
+++ b/mpf/tests/machine_files/event_players/config/test_event_player.yaml
@@ -59,7 +59,14 @@ event_player:
       loaded_event_notype:
         foo:
           value: machine.testnotype
-
+    play_event_with_kwargs:
+      - event_always
+      - event_(name)
+    play_event_with_param_kwargs:
+      event_with_param_kwargs:
+        foo:
+          value: (result)
+          type: string
 
 shows:
   test_event_show:

--- a/mpf/tests/machine_files/event_players/config/test_event_player.yaml
+++ b/mpf/tests/machine_files/event_players/config/test_event_player.yaml
@@ -67,6 +67,9 @@ event_player:
         foo:
           value: (result)
           type: string
+        maths:
+          value: 5 * (initial)
+          type: int
 
 shows:
   test_event_show:

--- a/mpf/tests/test_EventPlayer.py
+++ b/mpf/tests/test_EventPlayer.py
@@ -230,6 +230,6 @@ class TestEventPlayer(MpfTestCase):
     def test_value_kwarg_evaluation(self):
         self.mock_event('event_with_param_kwargs')
 
-        self.post_event_with_params("play_event_with_param_kwargs", result="bar")
-        self.assertEqual({"foo": "bar", "priority": 0}, self._last_event_kwargs["event_with_param_kwargs"])
+        self.post_event_with_params("play_event_with_param_kwargs", result="bar", initial=6)
+        self.assertEqual({"foo": "bar", "maths": 30, "priority": 0}, self._last_event_kwargs["event_with_param_kwargs"])
 

--- a/mpf/tests/test_EventPlayer.py
+++ b/mpf/tests/test_EventPlayer.py
@@ -216,3 +216,20 @@ class TestEventPlayer(MpfTestCase):
         self.assertEqual({"foo": True, "priority": 0}, self._last_event_kwargs['loaded_event_bool'])
         self.assertEqual({"foo": "foobar", "priority": 0}, self._last_event_kwargs['loaded_event_string'])
         self.assertEqual({"foo": "barfoo", "priority": 0}, self._last_event_kwargs['loaded_event_notype'])
+
+    def test_kwarg_placeholder(self):
+        self.mock_event('event_always')
+        self.mock_event('event_foobar')
+        self.mock_event('event_(name)')
+
+        self.post_event_with_params("play_event_with_kwargs", name="foobar")
+        self.assertEventCalled("event_always")
+        self.assertEventCalled("event_foobar")
+        self.assertEventNotCalled("event_(name)")
+
+    def test_value_kwarg_evaluation(self):
+        self.mock_event('event_with_param_kwargs')
+
+        self.post_event_with_params("play_event_with_param_kwargs", result="bar")
+        self.assertEqual({"foo": "bar", "priority": 0}, self._last_event_kwargs["event_with_param_kwargs"])
+


### PR DESCRIPTION
This PR extends the work of evaluating event_player events (https://github.com/missionpinball/mpf/pull/1212) by including kwargs from the triggering event in the evaluation.

This change merely passes `kwargs` when evaluating the event name to be posted (_event_name_placeholder_) as well as when calculating the values of any args to be posted with that event (_event_param_).

Includes tests!