### PR TITLE
Set sound_player default max_queue_time to ‘None’

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1324,7 +1324,7 @@ sound_player:
     fade_in: single|secs|None
     fade_out: single|secs|None
     about_to_finish_time: single|secs|-1
-    max_queue_time: single|secs|-1
+    max_queue_time: single|secs|None
     events_when_played: list|str|use_sound_setting
     events_when_stopped: list|str|use_sound_setting
     events_when_looping: list|str|use_sound_setting


### PR DESCRIPTION
This PR changes the config_spec default for **sound_player:max_queue_time** from `-1` to `None`.

This change is consistent with the default value for **sounds:max_queue_time** as well as the documentation. The value of `-1` caused a bug where on-demand sounds would never play because the queue time would expire before the asset loaded. 

This bug was brought to light after PR https://github.com/missionpinball/mpf/pull/1290, which unified the passing of event triggers via BCP. Prior to that commit, MC events without explicit `max_queue_time` would have that value not defined, equivalent to `None`. After that commit, MPF populates all default values before triggering the event—ensuring that `-1` was always defined.