### PR TITLE
Remove 'use_sound_setting' as default value

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1315,7 +1315,7 @@ sound_loop_sets:
 sound_player:
     __valid_in__: machine, mode, show
     action: single|enum(play,stop,stop_looping,load,unload)|play
-    track: single|str|use_sound_setting
+    track: single|str|None
     volume: single|gain|None
     pan: single|float_or_token|0
     loops: single|int_or_token|None
@@ -1325,11 +1325,11 @@ sound_player:
     fade_out: single|secs|None
     about_to_finish_time: single|secs|-1
     max_queue_time: single|secs|None
-    events_when_played: list|str|use_sound_setting
-    events_when_stopped: list|str|use_sound_setting
-    events_when_looping: list|str|use_sound_setting
-    events_when_about_to_finish: list|str|use_sound_setting
-    mode_end_action: single|enum(stop,stop_looping,use_sound_setting)|use_sound_setting
+    events_when_played: list|str|None
+    events_when_stopped: list|str|None
+    events_when_looping: list|str|None
+    events_when_about_to_finish: list|str|None
+    mode_end_action: single|enum(stop,stop_looping,use_sound_setting,None)|None
     key: single|str|None
 sound_pools:
     __valid_in__: machine, mode                      # todo add to validator


### PR DESCRIPTION
This PR is a possible approach to fix https://github.com/missionpinball/mpf-mc/issues/344 where the string "use_sound_setting" is passed through MPF/MC, resulting in undesireable behavior. From my investigation, I've identified that there are two different courses of behavior that conflict, creating the issue.

1. When SoundPlayer configs are validated, settings with a value of the string "use_sound_setting" are deleted from the dict. During playback, the SoundPlayer evaluates whether these settings are in the dict and handles them if so. For the track, the Sound's `track:` value is set as a default on the dict. All of this behavior works as expected.

2. In contrast, these same settings have a default value of `"use_sound_setting"` in config_spec. Whenever they are not defined, at the time of playback the default value is pulled and the string is passed around as though it were a value. This circumvents the validation-deletion logic above and results in funky behavior. 

The fix I present here removes `"use_sound_setting"` as a fallback value, allowing the behavior #1 above to be universal. 

There is a related MC code change to handle the track selection.