### PR TITLE
Highlight setting in service menu

### DIFF
--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -223,10 +223,11 @@ down_events: list|str|sw_service_down_active
 
         self.machine.events.post("service_light_test_stop")
 
-    def _update_settings_slide(self, items, position):
+    def _update_settings_slide(self, items, position, is_change=False):
         setting = items[position]
         label = self.machine.settings.get_setting_value_label(setting.name)
-        self.machine.events.post("service_settings_start",
+        event = "service_settings_{}".format("edit" if is_change else "start")
+        self.machine.events.post(event,
                                  settings_label=setting.label,
                                  value_label=label)
 
@@ -267,20 +268,22 @@ down_events: list|str|sw_service_down_active
 
         values = list(items[position].values.keys())
         value_position = values.index(self.machine.settings.get_setting_value(items[position].name))
+        self._update_settings_slide(items, position, is_change=True)
 
         while True:
             key = yield from self._get_key()
             if key == 'ESC':
+                self._update_settings_slide(items, position)
                 break
             elif key == 'UP':
                 value_position += 1
                 if value_position >= len(values):
                     value_position = 0
                 self.machine.settings.set_setting_value(items[position].name, values[value_position])
-                self._update_settings_slide(items, position)
+                self._update_settings_slide(items, position, is_change=True)
             elif key == 'DOWN':
                 value_position -= 1
                 if value_position < 0:
                     value_position = len(values) - 1
                 self.machine.settings.set_setting_value(items[position].name, values[value_position])
-                self._update_settings_slide(items, position)
+                self._update_settings_slide(items, position, is_change=True)

--- a/mpf/modes/service/config/service.yaml
+++ b/mpf/modes/service/config/service.yaml
@@ -86,6 +86,12 @@ slide_player:
     service_settings:
       action: play
       priority: 2
+    service_settings_edit:
+      action: remove
+  service_settings_edit:
+    service_settings_edit:
+      action: play
+      priority: 3
   service_settings_stop:
     service_settings:
       action: remove
@@ -239,6 +245,23 @@ slides:
     text: "(settings_label)"
     style: small
     y: center+6
+  - type: text
+    text: "(value_label)"
+    style: small
+    y: center
+    opacity: 0.5
+  service_settings_edit:
+  - type: text
+    text: "Settings"
+    style: small
+    anchor_y: top
+    x: center
+    y: top
+  - type: text
+    text: "(settings_label)"
+    style: small
+    y: center+6
+    opacity: 0.5
   - type: text
     text: "(value_label)"
     style: small

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -320,6 +320,7 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.machine.settings.add_setting(SettingEntry("test2", "Test2", 2, "test2", False,
                                                        {True: "Yes", False: "No (default)"}))
         self.mock_event("service_settings_start")
+        self.mock_event("service_settings_edit")
         self.mock_event("service_settings_stop")
         # enter menu
         self.hit_and_release_switch("s_service_enter")
@@ -341,19 +342,19 @@ class TestServiceMode(MpfFakeGameTestCase):
         # change setting
         self.hit_and_release_switch("s_service_enter")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_start", settings_label='Test2', value_label="No (default)")
+        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="No (default)")
 
         self.hit_and_release_switch("s_service_up")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_start", settings_label='Test2', value_label="Yes")
+        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="Yes")
 
         self.hit_and_release_switch("s_service_up")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_start", settings_label='Test2', value_label="No (default)")
+        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="No (default)")
 
         self.hit_and_release_switch("s_service_down")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_start", settings_label='Test2', value_label="Yes")
+        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="Yes")
 
         # exit setting change
         self.hit_and_release_switch("s_service_esc")


### PR DESCRIPTION
This PR extends the behavior of the Service mode, particularly the "Settings" menu.

Currently when editing settings in the service mode, there is no indication whether the up/down buttons will change the setting or the value. This is not convenient and can lead to mistakes.

This PR creates a new event, _service_settings_edit_, that is triggered when the operator changes from selecting settings items to selecting values for an item. The slide_player uses this event to "highlight" the setting name *or* the setting value, reducing the other to 50% opacity.

With this change, when scrolling through settings the setting name is 100% and the current value is 50%. When scrolling through values, the setting name is 50% and the value is 100%.