### PR TITLE
Ignore duplicate handler warnings during init phases

### DIFF
--- a/mpf/core/events.py
+++ b/mpf/core/events.py
@@ -213,7 +213,7 @@ class EventManager(MpfController):
                     handler.callback == self.machine.device_manager._control_event_handler:
                 cls = (handler.kwargs["callback"].__self__, handler.kwargs["ms_delay"])
 
-            if cls in devices:
+            if cls in devices and not event.startswith("init_phase_"):
                 handlers = [h for h in sorted_handlers if h.priority == priority and
                             inspect.ismethod(h.callback) and
                             h.condition == handler.condition and


### PR DESCRIPTION
The five init phases of MPF/MC generate a lot of anonymous event handlers without keys or priorities. This results in a slew of `Duplicate event handler` warnings that clog the logs.

This PR adds a condition to skip the log warning if the event is an `init_phase_(num)` event. 

There should be no danger or performance impact of this, because the only line affected is `self.info_log(...)` and it only affects initialization.