### PR TITLE
Remove self.machine.game dependency in carousel logic

### DIFF
--- a/mpf/modes/carousel/code/carousel.py
+++ b/mpf/modes/carousel/code/carousel.py
@@ -45,11 +45,13 @@ class Carousel(Mode):
         self._register_handlers(self._previous_item_events, self._previous_item)
         self._register_handlers(self._select_item_events, self._select_item)
 
-        player = self.machine.game.player
-        if not player.is_player_var('available_items_{}'.format(self.name)):
-            player['available_items_{}'.format(self.name)] = copy.deepcopy(self._items)
-        self._highlighted_item_index = 0
+        # If there is a player, track the carousel items as a variable
+        if self.machine.game:
+            player = self.machine.game.player
+            if not player.is_player_var('available_items_{}'.format(self.name)):
+                player['available_items_{}'.format(self.name)] = copy.deepcopy(self._items)
 
+        self._highlighted_item_index = 0
         self._update_highlighted_item(None)
 
     def _register_handlers(self, events, handler):
@@ -71,8 +73,12 @@ class Carousel(Mode):
             '''
 
     def _get_available_items(self):
-        player = self.machine.game.player
-        return player['available_items_{}'.format(self.name)]
+        # If items were stored in the player, use them
+        if self.machine.game:
+            player = self.machine.game.player
+            return player['available_items_{}'.format(self.name)]
+        # Otherwise, return the default items
+        return self._items
 
     def _next_item(self, **kwargs):
         del kwargs


### PR DESCRIPTION
The code for **Carousel.py** includes a call to `self.machine.game.player`, which implicitly requires a game to exist or else that line will throw on _AttributeError: 'NoneType' object has no attribute 'player'_

The Carousel mode is ideal for an attract mode slideshow that allows the user to move between slides (e.g. high scores, replay value). This would require Carousel to exist as a non-game mode, which is impossible for the above reason.

This PR creates a fallback for if `self.machine.game` does not exist, and handles the expected behavior for rotating items.