### PR TITLE
Separate event handlers from normal code

### DIFF
--- a/mpf/config_players/coil_player.py
+++ b/mpf/config_players/coil_player.py
@@ -35,12 +35,12 @@ class CoilPlayer(DeviceConfigPlayer):
                 pass
 
             if action in ("disable", "off"):
-                coil.disable(**s)
+                coil.disable()
             elif action in ("on", "enable"):
                 instance_dict[coil.name] = coil
-                coil.enable(**s)
+                coil.enable(pulse_ms=s["pulse_ms"], pulse_power=s["pulse_power"], hold_power=s["hold_power"])
             elif action == "pulse":
-                coil.pulse(**s)
+                coil.pulse(pulse_ms=s['pulse_ms'], pulse_power=s['pulse_power'], max_wait_ms=s['max_wait_ms'])
             else:
                 self.raise_config_error("Invalid action {}".format(action), 1, context=context)
 

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -175,6 +175,7 @@ ball_locks:
     disable_events: event_handler|str:ms|None
     reset_events: event_handler|str:ms|machine_reset_phase_3, ball_starting, ball_will_end, service_mode_entered
     release_one_events: event_handler|str:ms|None
+    release_all_balls_events: event_handler|str:ms|None
     release_one_if_full_events: event_handler|str:ms|None
 ball_routings:
     __valid_in__: mode

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -482,7 +482,9 @@ extra_balls:
 extra_ball_groups:
     __valid_in__: machine
     enabled: single|bool|True
+    light_events: event_handler|str:ms|None
     award_events: event_handler|str:ms|None
+    award_lit_events: event_handler|str:ms|None
     max_per_game: single|int|None
     max_per_ball: single|int|None
     max_lit: single|int|None

--- a/mpf/core/device_manager.py
+++ b/mpf/core/device_manager.py
@@ -250,21 +250,10 @@ class DeviceManager(MpfController):
                                     method = getattr(self.collections[collection][device],
                                                      "event_{}".format(control_event[:-7]))
                                 except AttributeError:
-                                    pass
-                                else:
-                                    yield (event,
-                                           method,
-                                           delay,
-                                           self.collections[collection][device])
-                                    continue
-
-                                # fall back to the old style
-                                try:
-                                    method = getattr(self.collections[collection][device], control_event[:-7])
-                                except Exception:   # pylint: disable-msg=broad-except
-                                    raise AssertionError("Class {} needs to have method {} to handle {}".format(
+                                    raise AssertionError("Class {} needs to have method event_{} to handle {}".format(
                                         self.collections[collection][device], control_event[:-7], control_event
                                     ))
+
                                 yield (event,
                                        method,
                                        delay,

--- a/mpf/core/device_manager.py
+++ b/mpf/core/device_manager.py
@@ -245,6 +245,20 @@ class DeviceManager(MpfController):
                                 raise AssertionError("Type of {}:{} should be dict|str:ms| in config_spec".format(
                                     collection, control_event))
                             for event, delay in settings[control_event].items():
+                                # try the new style first
+                                try:
+                                    method = getattr(self.collections[collection][device],
+                                                     "event_{}".format(control_event[:-7]))
+                                except AttributeError:
+                                    pass
+                                else:
+                                    yield (event,
+                                           method,
+                                           delay,
+                                           self.collections[collection][device])
+                                    continue
+
+                                # fall back to the old style
                                 try:
                                     method = getattr(self.collections[collection][device], control_event[:-7])
                                 except Exception:   # pylint: disable-msg=broad-except

--- a/mpf/core/enable_disable_mixin.py
+++ b/mpf/core/enable_disable_mixin.py
@@ -39,9 +39,13 @@ class EnableDisableMixin(ModeDevice, metaclass=abc.ABCMeta):
         pass
 
     @event_handler(100)
-    def enable(self, **kwargs) -> None:
-        """Enable device."""
+    def event_enable(self, **kwargs) -> None:
+        """Handle enable control event."""
         del kwargs
+        self.enable()
+
+    def enable(self) -> None:
+        """Enable device."""
         if self.enabled is True:
             return
         self.enabled = True
@@ -52,9 +56,13 @@ class EnableDisableMixin(ModeDevice, metaclass=abc.ABCMeta):
         pass
 
     @event_handler(0)
-    def disable(self, **kwargs):
-        """Disable device."""
+    def event_disable(self, **kwargs):
+        """Handle disable control event."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable device."""
         if self.enabled is False:
             return
         self.enabled = False

--- a/mpf/core/enable_disable_mixin.py
+++ b/mpf/core/enable_disable_mixin.py
@@ -1,5 +1,6 @@
 """Implements enable and disable events for devices."""
 import abc
+import asyncio
 
 from mpf.core.events import event_handler
 
@@ -37,12 +38,6 @@ class EnableDisableMixin(ModeDevice, metaclass=abc.ABCMeta):
         This can be caused by a mode stop or by an disable_event.
         """
         pass
-
-    @event_handler(100)
-    def event_enable(self, **kwargs) -> None:
-        """Handle enable control event."""
-        del kwargs
-        self.enable()
 
     def enable(self) -> None:
         """Enable device."""
@@ -128,6 +123,8 @@ class EnableDisableMixin(ModeDevice, metaclass=abc.ABCMeta):
         self.player = None
         self._enabled = None
 
+    @asyncio.coroutine
     def device_added_system_wide(self) -> None:
         """Check enable on boot."""
+        yield from super().device_added_system_wide()
         self._load_enable_based_on_config_default()

--- a/mpf/core/mode_device.py
+++ b/mpf/core/mode_device.py
@@ -5,6 +5,7 @@ import asyncio
 from typing import Generator
 
 from mpf.core.device import Device
+from mpf.core.events import event_handler
 from mpf.core.machine import MachineController
 from mpf.core.mode import Mode
 from mpf.core.player import Player
@@ -54,7 +55,13 @@ class ModeDevice(Device, metaclass=abc.ABCMeta):
         del config
         raise AssertionError("Device {} cannot be overloaded.".format(self))
 
-    def enable(self, **kwargs) -> None:
+    @event_handler(20)
+    def event_enable(self, **kwargs):
+        """Event handler for enable event."""
+        del kwargs
+        self.enable()
+
+    def enable(self) -> None:
         """Enable handler."""
         pass
 
@@ -66,7 +73,7 @@ class ModeDevice(Device, metaclass=abc.ABCMeta):
         """
         if "enable_events" in self.config and not self.config['enable_events']:
             mode.add_mode_event_handler("mode_{}_started".format(mode.name),
-                                        self.enable, priority=100)
+                                        self.event_enable, priority=100)
 
     def remove_control_events_in_mode(self) -> None:
         """Remove control events."""

--- a/mpf/devices/achievement.py
+++ b/mpf/devices/achievement.py
@@ -62,21 +62,24 @@ class Achievement(ModeDevice):
 
         return config
 
-    @event_handler(10)
-    def enable(self, **kwargs):
+    def enable(self):
         """Enable the achievement.
 
         It can only start if it was enabled before.
         """
-        del kwargs
+        super().enable()
         if self._state in ("disabled", "selected", "started"):
             self._state = "enabled"
             self._run_state()
 
     @event_handler(5)
-    def start(self, **kwargs):
-        """Start achievement."""
+    def event_start(self, **kwargs):
+        """Event handler for start event."""
         del kwargs
+        self.start()
+
+    def start(self):
+        """Start achievement."""
         if self._state in ("enabled", "selected") or (
             self.config['restart_after_stop_possible'] and
                 self._state == "stopped"):
@@ -84,25 +87,37 @@ class Achievement(ModeDevice):
             self._run_state()
 
     @event_handler(4)
-    def complete(self, **kwargs):
-        """Complete achievement."""
+    def event_complete(self, **kwargs):
+        """Event handler for complete event."""
         del kwargs
+        self.complete()
+
+    def complete(self):
+        """Complete achievement."""
         if self._state in ("started", "selected"):
             self._state = "completed"
             self._run_state()
 
     @event_handler(2)
-    def stop(self, **kwargs):
-        """Stop achievement."""
+    def event_stop(self, **kwargs):
+        """Event handler for stop event."""
         del kwargs
+        self.stop()
+
+    def stop(self):
+        """Stop achievement."""
         if self._state in ("started", "selected"):
             self._state = "stopped"
             self._run_state()
 
     @event_handler(0)
-    def disable(self, **kwargs):
-        """Disable achievement."""
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable achievement."""
         if self._state in ("enabled", "selected") or (
             self.config['restart_after_stop_possible'] and
                 self._state == "stopped"):
@@ -110,9 +125,13 @@ class Achievement(ModeDevice):
             self._run_state()
 
     @event_handler(1)
-    def reset(self, **kwargs):
-        """Reset the achievement to its initial state."""
+    def event_reset(self, **kwargs):
+        """Event handler for reset event."""
         del kwargs
+        self.reset()
+
+    def reset(self):
+        """Reset the achievement to its initial state."""
         # if there is no player active
         if not self._player:
             return
@@ -125,10 +144,13 @@ class Achievement(ModeDevice):
         self._run_state()
 
     @event_handler(9)
-    def select(self, **kwargs):
-        """Highlight (select) this achievement."""
+    def event_select(self, **kwargs):
+        """Event handler for select event."""
         del kwargs
+        self.select()
 
+    def select(self):
+        """Highlight (select) this achievement."""
         if not self._player:
             return
 

--- a/mpf/devices/achievement_group.py
+++ b/mpf/devices/achievement_group.py
@@ -43,11 +43,9 @@ class AchievementGroup(ModeDevice):
         """Return enabled state."""
         return self._enabled
 
-    @event_handler(10)
-    def enable(self, **kwargs):
+    def enable(self):
         """Enable achievement group."""
-        del kwargs
-
+        super().enable()
         self.debug_log("Call to enable this group")
 
         if self._enabled:
@@ -73,9 +71,13 @@ class AchievementGroup(ModeDevice):
         self._process_current_member_state()
 
     @event_handler(0)
-    def disable(self, **kwargs):
-        """Disable achievement group."""
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable achievement group."""
         self.debug_log("Call to disable this group")
         if not self._enabled:
             self.debug_log("Group is already disabled. Aborting")
@@ -111,9 +113,13 @@ class AchievementGroup(ModeDevice):
         return self._selected_member
 
     @event_handler(5)
-    def start_selected(self, **kwargs):
-        """Start the currently selected achievement."""
+    def event_start_selected(self, **kwargs):
+        """Event handler for start_selected event."""
         del kwargs
+        self.start_selected()
+
+    def start_selected(self):
+        """Start the currently selected achievement."""
         self.debug_log("Call to start selected achievement")
         if not self._enabled:
             self.debug_log("Group not enabled. Aborting")
@@ -126,9 +132,13 @@ class AchievementGroup(ModeDevice):
             pass
 
     @event_handler(6)
-    def rotate_right(self, reverse=False, **kwargs):
-        """Rotate to the right."""
+    def event_rotate_right(self, reverse=False, **kwargs):
+        """Event handler for rotate_right event."""
         del kwargs
+        self.rotate_right(reverse)
+
+    def rotate_right(self, reverse=False):
+        """Rotate to the right."""
         self.debug_log("Call to rotate")
         if not self._is_ok_to_change_selection():
             return
@@ -162,9 +172,13 @@ class AchievementGroup(ModeDevice):
         self._rotation_in_progress = False
 
     @event_handler(7)
-    def rotate_left(self, **kwargs):
-        """Rotate to the left."""
+    def event_rotate_left(self, **kwargs):
+        """Event handler for rotate_left event."""
         del kwargs
+        self.rotate_left()
+
+    def rotate_left(self):
+        """Rotate to the left."""
         self.rotate_right(reverse=True)
 
     def _no_more_enabled(self):
@@ -175,16 +189,19 @@ class AchievementGroup(ModeDevice):
 
     def _all_complete(self):
         self.debug_log("All achievements are complete")
-        self.disable()  # disable before event post so event can reenable
+        self.disable()  # disable before event post so event can re-enable
 
         for e in self.config['events_when_all_completed']:
             self.machine.events.post(e)
 
     @event_handler(9)
-    def select_random_achievement(self, **kwargs):
-        """Select a random achievement."""
+    def event_select_random_achievement(self, **kwargs):
+        """Event handler for select_random_achievement event."""
         del kwargs
+        self.select_random_achievement()
 
+    def select_random_achievement(self):
+        """Select a random achievement."""
         self.debug_log("Selecting random achievement")
 
         if not self._is_ok_to_change_selection():

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -73,8 +73,15 @@ class AutofireCoil(SystemWideDevice):
                     self.config['playfield'].name), 1)
 
     @event_handler(1)
-    # to prevent multiple rules at the same time we prioritize disable > enable
-    def enable(self, **kwargs):
+    def event_enable(self, **kwargs):
+        """Handle enable control event.
+
+        To prevent multiple rules at the same time we prioritize disable > enable.
+        """
+        del kwargs
+        self.enable()
+
+    def enable(self):
         """Enable the autofire device.
 
         This causes the coil to respond to the switch hits. This is typically
@@ -91,8 +98,6 @@ class AutofireCoil(SystemWideDevice):
                 event callback.
 
         """
-        del kwargs
-
         if self._enabled:
             return
         self._enabled = True
@@ -111,8 +116,15 @@ class AutofireCoil(SystemWideDevice):
         )
 
     @event_handler(10)
-    # to prevent multiple rules at the same time we prioritize disable > enable
-    def disable(self, **kwargs):
+    def event_disable(self, **kwargs):
+        """Handle disable control event.
+
+        To prevent multiple rules at the same time we prioritize disable > enable.
+        """
+        del kwargs
+        self.disable()
+
+    def disable(self):
         """Disable the autofire device.
 
         This is typically called at the end of a ball and when a tilt event
@@ -123,8 +135,6 @@ class AutofireCoil(SystemWideDevice):
                 event callback.
 
         """
-        del kwargs
-
         self.delay.remove("_timeout_enable_delay")
 
         if not self._enabled:

--- a/mpf/devices/ball_device/ball_device.py
+++ b/mpf/devices/ball_device/ball_device.py
@@ -4,7 +4,7 @@ from collections import deque
 
 import asyncio
 
-from mpf.core.events import QueuedEvent
+from mpf.core.events import QueuedEvent, event_handler
 from mpf.devices.ball_device.ball_count_handler import BallCountHandler
 from mpf.devices.ball_device.ball_device_ejector import BallDeviceEjector
 
@@ -80,7 +80,8 @@ class BallDevice(SystemWideDevice):
             return self.counted_balls - 1
         return self.counted_balls
 
-    def entrance(self, **kwargs):
+    @event_handler(11)
+    def event_entrance(self, **kwargs):
         """Event handler for entrance events."""
         del kwargs
         self.ball_count_handler.counter.received_entrance_event()
@@ -572,7 +573,13 @@ class BallDevice(SystemWideDevice):
 
         return False
 
-    def request_ball(self, balls=1, **kwargs):
+    @event_handler(1)
+    def event_request_ball(self, balls=1, **kwargs):
+        """Handle request_ball control event."""
+        del kwargs
+        self.request_ball(balls)
+
+    def request_ball(self, balls=1):
         """Request that one or more balls is added to this device.
 
         Args:
@@ -581,7 +588,6 @@ class BallDevice(SystemWideDevice):
                 itself.
             **kwargs: unused
         """
-        del kwargs
         self.debug_log("Requesting Ball(s). Balls=%s", balls)
 
         for dummy_iterator in range(balls):
@@ -706,12 +712,17 @@ class BallDevice(SystemWideDevice):
 
         return False
 
-    def eject(self, balls=1, target=None, **kwargs) -> int:
+    @event_handler(2)
+    def event_eject(self, balls=1, target=None, **kwargs):
+        """Handle eject control event."""
+        del kwargs
+        self.eject_all(balls, target)
+
+    def eject(self, balls=1, target=None) -> int:
         """Eject balls to target.
 
         Return the number of balls found for eject. The remaining balls are queued for eject when available.
         """
-        del kwargs
         if not target:
             target = self._target_on_unexpected_ball
 
@@ -726,7 +737,13 @@ class BallDevice(SystemWideDevice):
 
         return balls_found
 
-    def eject_all(self, target=None, **kwargs):
+    @event_handler(3)
+    def event_eject_all(self, target=None, **kwargs):
+        """Handle eject_all control event."""
+        del kwargs
+        self.eject_all(target)
+
+    def eject_all(self, target=None):
         """Eject all the balls from this device.
 
         Args:
@@ -737,7 +754,6 @@ class BallDevice(SystemWideDevice):
         Returns:
             True if there are balls to eject. False if this device is empty.
         """
-        del kwargs
         self.debug_log("Ejecting all balls")
         if self.available_balls > 0:
             self.eject(balls=self.available_balls, target=target)
@@ -745,7 +761,8 @@ class BallDevice(SystemWideDevice):
         else:
             return False
 
-    def hold(self, **kwargs):
+    @event_handler(10)
+    def event_hold(self, **kwargs):
         """Event handler for hold event."""
         del kwargs
         # TODO: remove when migrating config to ejectors

--- a/mpf/devices/ball_device/ball_device.py
+++ b/mpf/devices/ball_device/ball_device.py
@@ -716,7 +716,7 @@ class BallDevice(SystemWideDevice):
     def event_eject(self, balls=1, target=None, **kwargs):
         """Handle eject control event."""
         del kwargs
-        self.eject_all(balls, target)
+        self.eject(balls, target)
 
     def eject(self, balls=1, target=None) -> int:
         """Eject balls to target.

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -68,17 +68,12 @@ class BallHold(SystemWideDevice, ModeDevice):
 
         self.source_playfield = self.config['source_playfield']
 
-    @event_handler(10)
-    def enable(self, **kwargs):
+    def enable(self):
         """Enable the hold.
 
         If the hold is not enabled, no balls will be held.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
-
+        super().enable()
         if not self.enabled:
             self.debug_log("Enabling...")
             self._register_handlers()
@@ -89,31 +84,33 @@ class BallHold(SystemWideDevice, ModeDevice):
                 "enabled")
 
     @event_handler(0)
-    def disable(self, **kwargs):
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
+        del kwargs
+        self.disable()
+
+    def disable(self):
         """Disable the hold.
 
         If the hold is not enabled, no balls will be held.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
         self.debug_log("Disabling...")
         self._unregister_handlers()
         self.enabled = False
 
     @event_handler(1)
-    def reset(self, **kwargs):
+    def event_reset(self, **kwargs):
+        """Event handler for reset event."""
+        del kwargs
+        self.reset()
+
+    def reset(self):
         """Reset the hold.
 
         Will release held balls. Device status will stay the same
         (enabled/disabled). It will wait for those balls to drain and block
         ball_ending until they do. Those balls are not included in ball_in_play.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
         self._released_balls += self.release_all()
         self.balls_held = 0
 
@@ -156,26 +153,34 @@ class BallHold(SystemWideDevice, ModeDevice):
             self._release_hold = queue
 
     @event_handler(9)
-    def release_one_if_full(self, **kwargs):
-        """Release one ball if hold is full."""
+    def event_release_one_if_full(self, **kwargs):
+        """Event handler for release_one_if_full event."""
         del kwargs
+        self.release_one_if_full()
+
+    def release_one_if_full(self):
+        """Release one ball if hold is full."""
         if self.is_full():
             self.release_one()
 
     @event_handler(8)
-    def release_one(self, **kwargs):
-        """Release one ball.
-
-        Args:
-            **kwargs: unused
-        """
+    def event_release_one(self, **kwargs):
+        """Event handler for release_one event."""
         del kwargs
+        self.release_one()
+
+    def release_one(self):
+        """Release one ball."""
         self.release_balls(balls_to_release=1)
 
     @event_handler(7)
-    def release_all(self, **kwargs):
-        """Release all balls in hold."""
+    def event_release_all(self, **kwargs):
+        """Event handler for release_all event."""
         del kwargs
+        self.release_all()
+
+    def release_all(self):
+        """Release all balls in hold."""
         return self.release_balls(self.balls_held)
 
     def release_balls(self, balls_to_release):

--- a/mpf/devices/ball_lock.py
+++ b/mpf/devices/ball_lock.py
@@ -64,46 +64,44 @@ class BallLock(SystemWideDevice, ModeDevice):
 
         self.source_playfield = self.config['source_playfield']
 
-    @event_handler(10)
-    def enable(self, **kwargs):
+    def enable(self):
         """Enable the lock.
 
         If the lock is not enabled, no balls will be locked.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
         self.debug_log("Enabling...")
+        super().enable()
         if not self.enabled:
             self._register_handlers()
         self.enabled = True
 
     @event_handler(0)
-    def disable(self, **kwargs):
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
+        del kwargs
+        self.disable()
+
+    def disable(self):
         """Disable the lock.
 
         If the lock is not enabled, no balls will be locked.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
         self.debug_log("Disabling...")
         self._unregister_handlers()
         self.enabled = False
 
     @event_handler(1)
-    def reset(self, **kwargs):
+    def event_reset(self, **kwargs):
+        """Event handler for reset event."""
+        del kwargs
+        self.reset()
+
+    def reset(self):
         """Reset the lock.
 
         Will release locked balls. Device will status will stay the same (enabled/disabled). It will wait for those
         balls to drain and block ball_ending until they did. Those balls are not included in ball_in_play.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
         self._released_balls += self.release_all_balls()
         self.balls_locked = 0
 
@@ -146,23 +144,32 @@ class BallLock(SystemWideDevice, ModeDevice):
             self._release_lock = queue
 
     @event_handler(9)
-    def release_one_if_full(self, **kwargs):
-        """Release one ball if lock is full."""
+    def event_release_one_if_full(self, **kwargs):
+        """Event handler for release_one_if_full event."""
         del kwargs
+        self.release_one_if_full()
+
+    def release_one_if_full(self):
+        """Release one ball if lock is full."""
         if self.is_full():
             self.release_one()
 
     @event_handler(8)
-    def release_one(self, **kwargs):
-        """Release one ball.
-
-        Args:
-            **kwargs: unused
-        """
+    def event_release_one(self, **kwargs):
+        """Event handler for release_one event."""
         del kwargs
+        self.release_one()
+
+    def release_one(self):
+        """Release one ball."""
         self.release_balls(balls_to_release=1)
 
     @event_handler(7)
+    def event_release_all_balls(self, **kwargs):
+        """Event handler for release_all_balls event."""
+        del kwargs
+        self.release_all_balls()
+
     def release_all_balls(self):
         """Release all balls in lock."""
         return self.release_balls(self.balls_locked)

--- a/mpf/devices/ball_routing.py
+++ b/mpf/devices/ball_routing.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 import asyncio
 
+from mpf.core.events import event_handler
 from mpf.devices.ball_device.ball_device import BallDevice
 
 from mpf.core.machine import MachineController
@@ -26,9 +27,14 @@ class BallRouting(ModeDevice):
         self._balls_at_target = 0
         self._handler = []
 
-    def enable(self, **kwargs):
-        """Enable routing."""
+    @event_handler(2)
+    def event_enable(self, **kwargs):
+        """Event handler for enable events."""
         del kwargs
+        self.enable()
+
+    def enable(self):
+        """Enable routing."""
         if self._enabled:
             return
         self._enabled = True
@@ -85,9 +91,14 @@ class BallRouting(ModeDevice):
 
         return {}
 
-    def disable(self, **kwargs):
-        """Disable routing."""
+    @event_handler(1)
+    def event_disable(self, **kwargs):
+        """Event handler for disable events."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable routing."""
         if not self._enabled:
             return
         self.debug_log("Disabling")

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -66,10 +66,9 @@ class BallSave(SystemWideDevice, ModeDevice):
 
         return config
 
-    @event_handler(10)
-    def enable(self, **kwargs) -> None:
+    def enable(self) -> None:
         """Enable ball save."""
-        del kwargs
+        super().enable()
         if self.enabled:
             return
 
@@ -96,9 +95,13 @@ class BallSave(SystemWideDevice, ModeDevice):
         '''
 
     @event_handler(1)
-    def disable(self, **kwargs) -> None:
-        """Disable ball save."""
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
         del kwargs
+        self.disable()
+
+    def disable(self) -> None:
+        """Disable ball save."""
         if not self.enabled:
             return
 
@@ -117,12 +120,16 @@ class BallSave(SystemWideDevice, ModeDevice):
         '''
 
     @event_handler(9)
-    def timer_start(self, **kwargs) -> None:
+    def event_timer_start(self, **kwargs):
+        """Event handler for timer start event."""
+        del kwargs
+        self.timer_start()
+
+    def timer_start(self) -> None:
         """Start the timer.
 
         This is usually called after the ball was ejected while the ball save may have been enabled earlier.
         """
-        del kwargs
         if self.timer_started or not self.enabled:
             return
 
@@ -220,7 +227,7 @@ class BallSave(SystemWideDevice, ModeDevice):
         balls_to_save = self._get_number_of_balls_to_save(balls)
 
         self.debug_log("Ball(s) drained while active. Requesting new one(s). "
-                       "Autolaunch: %s", self.config['auto_launch'])
+                       "Auto launch: %s", self.config['auto_launch'])
 
         self.machine.events.post('ball_save_{}_saving_ball'.format(self.name),
                                  balls=balls_to_save, early_save=False)
@@ -239,9 +246,13 @@ class BallSave(SystemWideDevice, ModeDevice):
         return {'balls': balls - balls_to_save}
 
     @event_handler(8)
-    def early_ball_save(self, **kwargs) -> None:
-        """Perform early ball save if enabled."""
+    def event_early_ball_save(self, **kwargs):
+        """Event handler for early_ball_save event."""
         del kwargs
+        self.early_ball_save()
+
+    def early_ball_save(self) -> None:
+        """Perform early ball save if enabled."""
         if not self.enabled:
             return
 
@@ -288,9 +299,13 @@ class BallSave(SystemWideDevice, ModeDevice):
             self._add_balls(balls_to_save)
 
     @event_handler(4)
-    def delayed_eject(self, **kwargs):
-        """Trigger eject of all scheduled balls."""
+    def event_delayed_eject(self, **kwargs):
+        """Event handler for delayed_eject event."""
         del kwargs
+        self.delayed_eject()
+
+    def delayed_eject(self):
+        """Trigger eject of all scheduled balls."""
         self._add_balls(self._scheduled_balls)
         self._scheduled_balls = 0
 

--- a/mpf/devices/digital_output.py
+++ b/mpf/devices/digital_output.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Union, Tuple
 
 from mpf.core.delays import DelayManager
+from mpf.core.events import event_handler
 
 from mpf.core.machine import MachineController
 from mpf.core.platform import DriverConfig
@@ -84,9 +85,14 @@ class DigitalOutput(SystemWideDevice):
         else:
             return 0.0, -1, True
 
-    def pulse(self, pulse_ms, **kwargs):
-        """Pulse digital output."""
+    @event_handler(3)
+    def event_pulse(self, pulse_ms, **kwargs):
+        """Handle pulse control event."""
         del kwargs
+        self.pulse(pulse_ms)
+
+    def pulse(self, pulse_ms):
+        """Pulse digital output."""
         if self.type == "driver":
             self.hw_driver.pulse(PulseSettings(power=1.0, duration=pulse_ms))
         elif self.type == "light":
@@ -98,9 +104,14 @@ class DigitalOutput(SystemWideDevice):
         else:
             raise AssertionError("Invalid type {}".format(self.type))
 
-    def enable(self, **kwargs):
-        """Enable digital output."""
+    @event_handler(2)
+    def event_enable(self, **kwargs):
+        """Handle enable control event."""
         del kwargs
+        self.enable()
+
+    def enable(self):
+        """Enable digital output."""
         if self.type == "driver":
             self.hw_driver.enable(PulseSettings(power=1.0, duration=0),
                                   HoldSettings(power=1.0))
@@ -111,9 +122,14 @@ class DigitalOutput(SystemWideDevice):
         else:
             raise AssertionError("Invalid type {}".format(self.type))
 
-    def disable(self, **kwargs):
-        """Disable digital output."""
+    @event_handler(1)
+    def event_disable(self, **kwargs):
+        """Handle disable control event."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable digital output."""
         if self.type == "driver":
             self.hw_driver.disable()
         elif self.type == "light":

--- a/mpf/devices/diverter.py
+++ b/mpf/devices/diverter.py
@@ -94,16 +94,15 @@ class Diverter(SystemWideDevice):
     def event_enable(self, auto=False, **kwargs):
         """Handle enable control event."""
         del kwargs
-        self.enable(self, auto)
+        self.enable(auto)
 
     def enable(self, auto=False):
         """Enable this diverter.
 
         Args:
             auto: Boolean value which is used to indicate whether this
-                diverter enabled itself automatically. This is passed to the
-                event which is posted.
-            **kwargs: unused
+                  diverter enabled itself automatically. This is passed to the
+                  event which is posted.
 
         If an 'activation_switches' is configured, then this method writes a
         hardware autofire rule to the pinball controller which fires the
@@ -137,7 +136,7 @@ class Diverter(SystemWideDevice):
     def event_disable(self, auto=False, **kwargs):
         """Handle disable control event."""
         del kwargs
-        self.disable(self, auto)
+        self.disable(auto)
 
     def disable(self, auto=False):
         """Disable this diverter.

--- a/mpf/devices/diverter.py
+++ b/mpf/devices/diverter.py
@@ -81,13 +81,22 @@ class Diverter(SystemWideDevice):
                 switch.name, self.disable)
 
     @event_handler(1)
-    def reset(self, **kwargs):
-        """Reset and deactivate the diverter."""
+    def event_reset(self, **kwargs):
+        """Handle reset control event."""
         del kwargs
+        self.reset()
+
+    def reset(self):
+        """Reset and deactivate the diverter."""
         self.deactivate()
 
     @event_handler(10)
-    def enable(self, auto=False, **kwargs):
+    def event_enable(self, auto=False, **kwargs):
+        """Handle enable control event."""
+        del kwargs
+        self.enable(self, auto)
+
+    def enable(self, auto=False):
         """Enable this diverter.
 
         Args:
@@ -103,7 +112,6 @@ class Diverter(SystemWideDevice):
         If no `activation_switches` is specified, then the diverter is activated
         immediately.
         """
-        del kwargs
         self.enabled = True
 
         self.machine.events.post('diverter_' + self.name + '_enabling',
@@ -126,7 +134,12 @@ class Diverter(SystemWideDevice):
             self.activate()
 
     @event_handler(0)
-    def disable(self, auto=False, **kwargs):
+    def event_disable(self, auto=False, **kwargs):
+        """Handle disable control event."""
+        del kwargs
+        self.disable(self, auto)
+
+    def disable(self, auto=False):
         """Disable this diverter.
 
         This method will remove the hardware rule if this diverter is activated
@@ -141,7 +154,6 @@ class Diverter(SystemWideDevice):
                 configuration file, so we don't know what event that might be
                 or whether it has random kwargs attached to it.
         """
-        del kwargs
         self.enabled = False
 
         self.machine.events.post('diverter_' + self.name + '_disabling',
@@ -183,9 +195,13 @@ class Diverter(SystemWideDevice):
             self.config['deactivation_coil'].pulse()
 
     @event_handler(9)
-    def activate(self, **kwargs):
-        """Physically activate this diverter's coil."""
+    def event_activate(self, **kwargs):
+        """Handle activate control event."""
         del kwargs
+        self.activate()
+
+    def activate(self):
+        """Physically activate this diverter's coil."""
         self.debug_log("Activating Diverter")
         self.active = True
 
@@ -199,13 +215,17 @@ class Diverter(SystemWideDevice):
         self.schedule_deactivation()
 
     @event_handler(2)
-    def deactivate(self, **kwargs):
+    def event_deactivate(self, **kwargs):
+        """Handle deactivate control event."""
+        del kwargs
+        self.deactivate()
+
+    def deactivate(self):
         """Deactivate this diverter.
 
         This method will disable the activation_coil, and (optionally) if it's
         configured with a deactivation coil, it will pulse it.
         """
-        del kwargs
         self.debug_log("Deactivating Diverter")
         self.active = False
 

--- a/mpf/devices/driver.py
+++ b/mpf/devices/driver.py
@@ -172,7 +172,12 @@ class Driver(SystemWideDevice):
         return pulse_ms
 
     @event_handler(2)
-    def enable(self, pulse_ms: int = None, pulse_power: float = None, hold_power: float = None, **kwargs):
+    def event_enable(self, pulse_ms: int = None, pulse_power: float = None, hold_power: float = None, **kwargs):
+        """Event handler for control enable."""
+        del kwargs
+        self.enable(pulse_ms, pulse_power, hold_power)
+
+    def enable(self, pulse_ms: int = None, pulse_power: float = None, hold_power: float = None):
         """Enable a driver by holding it 'on'.
 
         Args:
@@ -192,8 +197,6 @@ class Driver(SystemWideDevice):
 
         allow_enable: True
         """
-        del kwargs
-
         pulse_ms = self.get_and_verify_pulse_ms(pulse_ms)
 
         pulse_power = self.get_and_verify_pulse_power(pulse_power)
@@ -211,9 +214,13 @@ class Driver(SystemWideDevice):
                                                      pulse_ms=pulse_ms, pulse_power=pulse_power, hold_power=hold_power)
 
     @event_handler(1)
-    def disable(self, **kwargs):
-        """Disable this driver."""
+    def event_disable(self, **kwargs):
+        """Event handler for disable control event."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable this driver."""
         self.info_log("Disabling Driver")
         self.machine.delay.remove(name='{}_timed_enable'.format(self.name))
         self.hw_driver.disable()
@@ -245,7 +252,12 @@ class Driver(SystemWideDevice):
                                                      pulse_ms=pulse_ms, pulse_power=pulse_power)
 
     @event_handler(3)
-    def pulse(self, pulse_ms: int = None, pulse_power: float = None, max_wait_ms: int = None, **kwargs) -> int:
+    def event_pulse(self, pulse_ms: int = None, pulse_power: float = None, max_wait_ms: int = None, **kwargs) -> None:
+        """Event handler for pulse control events."""
+        del kwargs
+        self.pulse(pulse_ms, pulse_power, max_wait_ms)
+
+    def pulse(self, pulse_ms: int = None, pulse_power: float = None, max_wait_ms: int = None) -> int:
         """Pulse this driver.
 
         Args:
@@ -254,8 +266,6 @@ class Driver(SystemWideDevice):
                 enabled for the value specified in the config dictionary.
             pulse_power: The pulse power. A float between 0.0 and 1.0.
         """
-        del kwargs
-
         pulse_ms = self.get_and_verify_pulse_ms(pulse_ms)
         pulse_power = self.get_and_verify_pulse_power(pulse_power)
         wait_ms = self._get_wait_ms(pulse_ms, max_wait_ms)

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -163,23 +163,35 @@ class DropTarget(SystemWideDevice):
             self._update_state_from_switch, 1)
 
     @event_handler(6)
-    def enable_keep_up(self, **kwargs):
-        """Keep the target up by enabling the coil."""
+    def event_enable_keep_up(self, **kwargs):
+        """Handle enable_keep_up control event."""
         del kwargs
+        self.enable_keep_up()
+
+    def enable_keep_up(self):
+        """Keep the target up by enabling the coil."""
         if self.reset_coil:
             self.reset_coil.enable()
 
     @event_handler(5)
-    def disable_keep_up(self, **kwargs):
-        """No longer keep up the target up."""
+    def event_disable_keep_up(self, **kwargs):
+        """Handle disable_keep_up control event."""
         del kwargs
+        self.disable_keep_up()
+
+    def disable_keep_up(self):
+        """No longer keep up the target up."""
         if self.reset_coil:
             self.reset_coil.disable()
 
     @event_handler(7)
-    def knockdown(self, **kwargs):
-        """Pulse the knockdown coil to knock down this drop target."""
+    def event_knockdown(self, **kwargs):
+        """Handle knockdown control event."""
         del kwargs
+        self.knockdown()
+
+    def knockdown(self):
+        """Pulse the knockdown coil to knock down this drop target."""
         if self.knockdown_coil and not self.machine.switch_controller.is_active(self.config['switch'].name):
             self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
             self.knockdown_coil.pulse(max_wait_ms=self.config['knockdown_coil_max_wait_ms'])
@@ -242,7 +254,12 @@ class DropTarget(SystemWideDevice):
         self.banks.remove(bank)
 
     @event_handler(1)
-    def reset(self, **kwargs):
+    def event_reset(self, **kwargs):
+        """Handle reset control event."""
+        del kwargs
+        self.reset()
+
+    def reset(self):
         """Reset this drop target.
 
         If this drop target is configured with a reset coil, then this method
@@ -254,8 +271,6 @@ class DropTarget(SystemWideDevice):
         handler should reset the target profile on its own when the drop target
         physically moves back to the up position.
         """
-        del kwargs
-
         if self.reset_coil and self.machine.switch_controller.is_active(self.config['switch'].name):
             self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
             self.reset_coil.pulse(max_wait_ms=self.config['reset_coil_max_wait_ms'])
@@ -315,7 +330,12 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
         self.debug_log('Drop Targets: %s', self.drop_targets)
 
     @event_handler(5)
-    def reset(self, **kwargs):
+    def event_reset(self, **kwargs):
+        """Handle reset control event."""
+        del kwargs
+        self.reset()
+
+    def reset(self):
         """Reset this bank of drop targets.
 
         This method has some intelligence to figure out what coil(s) it should
@@ -325,7 +345,6 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
         coil list is a "set" which means it only sends a single pulse to each
         coil, even if each drop target is configured with its own coil.)
         """
-        del kwargs
         self.debug_log('Resetting')
 
         if self.down == 0:

--- a/mpf/devices/dual_wound_coil.py
+++ b/mpf/devices/dual_wound_coil.py
@@ -18,24 +18,37 @@ class DualWoundCoil(SystemWideDevice):
         self.machine.coils[name] = self
 
     @event_handler(2)
-    def enable(self, **kwargs):
+    def event_enable(self, **kwargs):
+        """Event handler for enable event."""
+        del kwargs
+        self.enable()
+
+    def enable(self):
         """Enable a dual wound coil.
 
         Pulse main coil and enable hold coil.
         """
-        del kwargs
         self.config['main_coil'].pulse()
         self.config['hold_coil'].enable()
 
     @event_handler(1)
-    def disable(self, **kwargs):
-        """Disable a driver."""
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable a driver."""
         self.config['main_coil'].disable()
         self.config['hold_coil'].disable()
 
     @event_handler(3)
-    def pulse(self, milliseconds: int = None, power: float = None, **kwargs):
+    def event_pulse(self, milliseconds: int = None, power: float = None, **kwargs):
+        """Event handler for pulse event."""
+        del kwargs
+        self.pulse(milliseconds, power)
+
+    def pulse(self, milliseconds: int = None, power: float = None):
         """Pulse this driver.
 
         Args:
@@ -46,6 +59,5 @@ class DualWoundCoil(SystemWideDevice):
                 typically a float between 0.0 and 1.0. (Note this is can only be used
                 if milliseconds is also specified.)
         """
-        del kwargs
         self.config['main_coil'].pulse(milliseconds, power)
         self.config['hold_coil'].pulse(milliseconds, power)

--- a/mpf/devices/extra_ball.py
+++ b/mpf/devices/extra_ball.py
@@ -44,7 +44,12 @@ class ExtraBall(ModeDevice):
         self.group = self.config['group']
 
     @event_handler(2)
-    def light(self, **kwargs):
+    def event_light(self, **kwargs):
+        """Handle light control event."""
+        del kwargs
+        self.light()
+
+    def light(self):
         """Light an extra ball for potential collection by the player.
 
         Lighting an extra ball will immediately increase count against the
@@ -55,8 +60,6 @@ class ExtraBall(ModeDevice):
         Note that this only really does anything if this extra ball is a
         member of a group.
         """
-        del kwargs
-
         if self.is_ok_to_light():
             self.machine.events.post('extra_ball_{}_lit'.format(self.name))
             '''event: extra_ball_(name)_lit
@@ -69,10 +72,13 @@ class ExtraBall(ModeDevice):
             self._award_disabled()
 
     @event_handler(1)
-    def award(self, **kwargs):
-        """Award extra ball to player (if enabled)."""
+    def event_award(self, **kwargs):
+        """Handle award control event."""
         del kwargs
+        self.award()
 
+    def award(self):
+        """Award extra ball to player (if enabled)."""
         if self.is_ok_to_award():
             self.player['extra_ball_{}_num_awarded'.format(self.name)] += 1
             self.machine.events.post('extra_ball_{}_awarded'.format(self.name))

--- a/mpf/devices/extra_ball_group.py
+++ b/mpf/devices/extra_ball_group.py
@@ -102,14 +102,17 @@ class ExtraBallGroup(SystemWideDevice):
             self.player['extra_ball_group_{}_num_lit'.format(self.name)])
 
     @event_handler(2)
-    def award_lit(self, **kwargs):
+    def event_award_lit(self, **kwargs):
+        """Handle award_lit control event."""
+        del kwargs
+        self.award_lit()
+
+    def award_lit(self):
         """Award a lit extra ball.
 
         If the player does not have any lit extra balls, this method does
         nothing.
         """
-        del kwargs
-
         if not self.player:
             return
 
@@ -128,10 +131,15 @@ class ExtraBallGroup(SystemWideDevice):
         else:
             posted_unlit_events = True
 
-        self.award(posted_unlit_event=posted_unlit_events)
+        self.award(posted_unlit_events=posted_unlit_events)
 
     @event_handler(1)
-    def award(self, posted_unlit_events=False, **kwargs):
+    def event_award(self, posted_unlit_events=False, **kwargs):
+        """Handle award control event."""
+        del kwargs
+        self.award(posted_unlit_events)
+
+    def award(self, posted_unlit_events=False):
         """Immediately awards an extra ball.
 
         This event first checks to make sure the limits of the max extra
@@ -141,8 +149,6 @@ class ExtraBallGroup(SystemWideDevice):
         extra balls or extra balls lit. You can use this to directly award an
         extra ball.
         """
-        del kwargs
-
         if not self.enabled:
             self.award_disabled()
             return
@@ -165,15 +171,18 @@ class ExtraBallGroup(SystemWideDevice):
                 self._post_unlit_events()
 
     @event_handler(3)
-    def light(self, **kwargs):
+    def event_light(self, **kwargs):
+        """Handle light control event."""
+        del kwargs
+        self.light()
+
+    def light(self):
         """Light the extra ball for possible collection by the player.
 
         This method checks that the group is enabled and that the max lit
         value has not been exceeded. If so, this method will post the extra
         ball disabled events.
         """
-        del kwargs
-
         if self.is_ok_to_light():
             self.player['extra_ball_group_{}_num_lit'.format(self.name)] += 1
 

--- a/mpf/devices/flipper.py
+++ b/mpf/devices/flipper.py
@@ -126,6 +126,7 @@ class Flipper(SystemWideDevice):
 
         To prevent multiple rules at the same time we prioritize disable > enable.
         """
+        del kwargs
         self.disable()
 
     def disable(self):

--- a/mpf/devices/flipper.py
+++ b/mpf/devices/flipper.py
@@ -50,8 +50,15 @@ class Flipper(SystemWideDevice):
                 self.config['ball_search_order'], self._ball_search, self.name)
 
     @event_handler(1)
-    # to prevent multiple rules at the same time we prioritize disable > enable
-    def enable(self, **kwargs):
+    def event_enable(self, **kwargs):
+        """Handle enable control event.
+
+        To prevent multiple rules at the same time we prioritize disable > enable.
+        """
+        del kwargs
+        self.enable()
+
+    def enable(self):
         """Enable the flipper by writing the necessary hardware rules to the hardware controller.
 
         The hardware rules for coils can be kind of complex given all the
@@ -91,8 +98,6 @@ class Flipper(SystemWideDevice):
         rules). Note that this rule is the letter "i", not a numeral 1.
         I. Enable power if button is active and EOS is not active
         """
-        del kwargs
-
         # prevent duplicate enable
         if self._enabled:
             return
@@ -116,15 +121,20 @@ class Flipper(SystemWideDevice):
                 self._enable_hold_coil_rule()
 
     @event_handler(10)
-    # to prevent multiple rules at the same time we prioritize disable > enable
-    def disable(self, **kwargs):
+    def event_disable(self, **kwargs):
+        """Handle disable control event.
+
+        To prevent multiple rules at the same time we prioritize disable > enable.
+        """
+        self.disable()
+
+    def disable(self):
         """Disable the flipper.
 
         This method makes it so the cabinet flipper buttons no longer control
         the flippers. Used when no game is active and when the player has
         tilted.
         """
-        del kwargs
         if not self._enabled:
             return
 
@@ -223,7 +233,12 @@ class Flipper(SystemWideDevice):
         self._active_rules.append(rule)
 
     @event_handler(6)
-    def sw_flip(self, **kwargs):
+    def event_sw_flip(self, **kwargs):
+        """Handle sw_flip control event."""
+        del kwargs
+        self.sw_flip()
+
+    def sw_flip(self):
         """Activate the flipper via software as if the flipper button was pushed.
 
         This is needed because the real flipper activations are handled in
@@ -233,7 +248,6 @@ class Flipper(SystemWideDevice):
         Note this method will keep this flipper enabled until you call
         sw_release().
         """
-        del kwargs
         if not self._enabled:
             return
 
@@ -246,12 +260,16 @@ class Flipper(SystemWideDevice):
             self.config['main_coil'].enable()
 
     @event_handler(5)
-    def sw_release(self, **kwargs):
+    def event_sw_release(self, **kwargs):
+        """Handle sw_release control event."""
+        del kwargs
+        self.sw_release()
+
+    def sw_release(self):
         """Deactive the flipper via software as if the flipper button was released.
 
         See the documentation for sw_flip() for details.
         """
-        del kwargs
         self._sw_flipped = False
 
         # disable the flipper coil(s)

--- a/mpf/devices/magnet.py
+++ b/mpf/devices/magnet.py
@@ -25,10 +25,14 @@ class Magnet(SystemWideDevice):
         self._active = False
         self._release_in_progress = False
 
-    @event_handler(10)
-    def enable(self, **kwargs):
-        """Enable magnet."""
+    @event_handler(20)
+    def event_enable(self, **kwargs):
+        """Event handler for enable event."""
         del kwargs
+        self.enable()
+
+    def enable(self):
+        """Enable magnet."""
         if self._enabled:
             return
 
@@ -39,9 +43,13 @@ class Magnet(SystemWideDevice):
             self.config['grab_switch'].add_handler(self.grab_ball)
 
     @event_handler(0)
-    def disable(self, **kwargs):
-        """Disable magnet."""
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
         del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable magnet."""
         if not self._enabled:
             return
 
@@ -52,17 +60,25 @@ class Magnet(SystemWideDevice):
             self.config['grab_switch'].remove_handler(self.grab_ball)
 
     @event_handler(1)
-    def reset(self, **kwargs):
-        """Release ball and disable magnet."""
+    def event_reset(self, **kwargs):
+        """Event handler for reset event."""
         del kwargs
+        self.reset()
+
+    def reset(self):
+        """Release ball and disable magnet."""
         self.debug_log("Resetting Magnet")
         self.release_ball()
         self.disable()
 
     @event_handler(9)
-    def grab_ball(self, **kwargs):
-        """Grab a ball."""
+    def event_grab_ball(self, **kwargs):
+        """Event handler for grab_ball event."""
         del kwargs
+        self.grab_ball()
+
+    def grab_ball(self):
+        """Grab a ball."""
         # mark the playfield active no matter what
         self.config['playfield'].mark_playfield_active_from_device_action()
         # check if magnet is enabled or already active
@@ -91,9 +107,13 @@ class Magnet(SystemWideDevice):
         '''
 
     @event_handler(8)
-    def release_ball(self, **kwargs):
-        """Release the grabbed ball."""
+    def event_release_ball(self, **kwargs):
+        """Event handler for release_ball event."""
         del kwargs
+        self.release_ball()
+
+    def release_ball(self):
+        """Release the grabbed ball."""
         if not self._active or self._release_in_progress:
             return
 
@@ -118,9 +138,13 @@ class Magnet(SystemWideDevice):
         '''
 
     @event_handler(7)
-    def fling_ball(self, **kwargs):
-        """Fling the grabbed ball."""
+    def event_fling_ball(self, **kwargs):
+        """Event handler for fling_ball event."""
         del kwargs
+        self.fling_ball()
+
+    def fling_ball(self):
+        """Fling the grabbed ball."""
         if not self._active or self._release_in_progress:
             return
 

--- a/mpf/devices/motor.py
+++ b/mpf/devices/motor.py
@@ -53,7 +53,7 @@ class Motor(SystemWideDevice):
         for event, position in self.config['go_to_position'].items():
             if position not in self.config['position_switches']:
                 self.raise_config_error("Invalid position {} in go_to_position".format(position), 4)
-            self.machine.events.add_handler(event, self.go_to_position, position=position)
+            self.machine.events.add_handler(event, self.event_go_to_position, position=position)
 
         if self.config['include_in_ball_search']:
             self.machine.events.add_handler("ball_search_started",
@@ -62,15 +62,26 @@ class Motor(SystemWideDevice):
                                             self._ball_search_stop)
 
     @event_handler(1)
-    def reset(self, **kwargs):
-        """Go to reset position."""
+    def event_reset(self, **kwargs):
+        """Event handler for reset event."""
         del kwargs
+        self. reset()
+
+    def reset(self):
+        """Go to reset position."""
         self.go_to_position(self.config['reset_position'])
 
     @event_handler(10)
-    def go_to_position(self, position, **kwargs):
-        """Move motor to a specific position."""
+    def event_go_to_position(self, position=None, **kwargs):
+        """Event handler for go_to_position event."""
         del kwargs
+        if position is None:
+            raise AssertionError("Got go_to_position event without position.")
+
+        self.go_to_position(position)
+
+    def go_to_position(self, position):
+        """Move motor to a specific position."""
         self.log.info("Moving motor to position %s", position)
         self._target_position = position
         self._move_to_position(position)

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -93,9 +93,13 @@ class Multiball(SystemWideDevice, ModeDevice):
         self.balls_added_live += balls_to_replace
 
     @event_handler(10)
-    def start(self, **kwargs):
-        """Start multiball."""
+    def event_start(self, **kwargs):
+        """Event handler for start event."""
         del kwargs
+        self.start()
+
+    def start(self):
+        """Start multiball."""
         if not self.enabled:
             return
 
@@ -186,9 +190,13 @@ class Multiball(SystemWideDevice, ModeDevice):
             self.debug_log("Ball drained. MB ended.")
 
     @event_handler(5)
-    def stop(self, **kwargs):
-        """Stop shoot again."""
+    def event_stop(self, **kwargs):
+        """Event handler for stop event."""
         del kwargs
+        self.stop()
+
+    def stop(self):
+        """Stop shoot again."""
         self.debug_log("Stopping shoot again of multiball")
         self.shoot_again = False
 
@@ -205,9 +213,13 @@ class Multiball(SystemWideDevice, ModeDevice):
         self.machine.events.add_handler('ball_drain', self._ball_drain_count_balls)
 
     @event_handler(8)
-    def add_a_ball(self, **kwargs):
-        """Add a ball if multiball has started."""
+    def event_add_a_ball(self, **kwargs):
+        """Event handler for add_a_ball event."""
         del kwargs
+        self.add_a_ball()
+
+    def add_a_ball(self):
+        """Add a ball if multiball has started."""
         if self.balls_live_target > 0:
             self.debug_log("Adding a ball.")
             self.balls_live_target += 1
@@ -216,48 +228,49 @@ class Multiball(SystemWideDevice, ModeDevice):
             self.source_playfield.add_ball(balls=1)
 
     @event_handler(9)
-    def start_or_add_a_ball(self, **kwargs):
-        """Start multiball or add a ball if multiball has started."""
+    def event_start_or_add_a_ball(self, **kwargs):
+        """Event handler for start_or_add_a_ball event."""
         del kwargs
+        self.start_or_add_a_ball()
+
+    def start_or_add_a_ball(self):
+        """Start multiball or add a ball if multiball has started."""
         if self.balls_live_target > 0:
             self.add_a_ball()
         else:
             self.start()
 
-    @event_handler(20)
-    def enable(self, **kwargs):
+    def enable(self):
         """Enable the multiball.
 
         If the multiball is not enabled, it cannot start.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
+        super().enable()
         self.debug_log("Enabling...")
         self.enabled = True
 
     @event_handler(1)
-    def disable(self, **kwargs):
+    def event_disable(self, **kwargs):
+        """Event handler for disable event."""
+        del kwargs
+        self.disable()
+
+    def disable(self):
         """Disable the multiball.
 
         If the multiball is not enabled, it cannot start. Will not stop a running multiball.
-
-        Args:
-            **kwargs: unused
         """
-        del kwargs
         self.debug_log("Disabling...")
         self.enabled = False
 
     @event_handler(2)
-    def reset(self, **kwargs):
-        """Reset the multiball and disable it.
-
-        Args:
-            **kwargs: unused
-        """
+    def event_reset(self, **kwargs):
+        """Event handler for reset event."""
         del kwargs
+        self.reset()
+
+    def reset(self):
+        """Reset the multiball and disable it."""
         self.enabled = False
         self.shoot_again = False
         self.balls_added_live = 0

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -2,6 +2,7 @@
 import asyncio
 
 from mpf.core.device_monitor import DeviceMonitor
+from mpf.core.events import event_handler
 from mpf.core.system_wide_device import SystemWideDevice
 from mpf.core.ball_search import BallSearch
 from mpf.core.delays import DelayManager
@@ -253,7 +254,7 @@ class Playfield(SystemWideDevice):
             for _ in range(balls):
                 source_device.setup_player_controlled_eject(target=self)
         else:
-            source_device.eject(balls=balls, target=self, get_ball=True)
+            source_device.eject(balls=balls, target=self)
 
         return True
 
@@ -373,7 +374,8 @@ class Playfield(SystemWideDevice):
         """Stop tracking an incoming ball."""
         self._incoming_balls.remove(incoming_ball)
 
-    def ball_search_disable(self, **kwargs):
+    @event_handler(1)
+    def event_ball_search_disable(self, **kwargs):
         """Disable ball search for this playfield.
 
         If the ball search timer is running, it will stop and disable it. If
@@ -382,7 +384,8 @@ class Playfield(SystemWideDevice):
         del kwargs
         self.ball_search.disable()
 
-    def ball_search_enable(self, **kwargs):
+    @event_handler(2)
+    def event_ball_search_enable(self, **kwargs):
         """Enable ball search for this playfield.
 
         Note this does not start the ball search process, rather, it starts the
@@ -391,7 +394,8 @@ class Playfield(SystemWideDevice):
         del kwargs
         self.ball_search.enable()
 
-    def ball_search_block(self, **kwargs):
+    @event_handler(3)
+    def event_ball_search_block(self, **kwargs):
         """Block ball search for this playfield.
 
         Blocking will disable ball search if it's enabled or running, and will
@@ -401,7 +405,8 @@ class Playfield(SystemWideDevice):
         del kwargs
         self.ball_search.block()
 
-    def ball_search_unblock(self, **kwargs):
+    @event_handler(4)
+    def event_ball_search_unblock(self, **kwargs):
         """Unblock ball search for this playfield.
 
         This will check to see if there are balls on the playfield, and if so,

--- a/mpf/devices/playfield_transfer.py
+++ b/mpf/devices/playfield_transfer.py
@@ -4,6 +4,7 @@ E.g. lower to upper playfield via a ramp.
 """
 import asyncio
 
+from mpf.core.events import event_handler
 from mpf.core.system_wide_device import SystemWideDevice
 
 
@@ -41,9 +42,14 @@ class PlayfieldTransfer(SystemWideDevice):
             callback=self.transfer,
             state=1, ms=0)
 
-    def transfer(self, **kwargs):
-        """Transfer a ball to the target playfield."""
+    @event_handler(1)
+    def event_transfer(self, **kwargs):
+        """Event handler for transfer event."""
         del kwargs
+        self.transfer()
+
+    def transfer(self):
+        """Transfer a ball to the target playfield."""
         self.debug_log("Ball went from %s to %s", self.source.name,
                        self.target.name)
 
@@ -74,7 +80,7 @@ class PlayfieldTransfer(SystemWideDevice):
             balls=1)
         # event docstring covered elsewhere
 
-        # inform target playfield about incomming ball
+        # inform target playfield about incoming ball
         self.machine.events.post(
             'balldevice_' + self.name + '_ejecting_ball',
             balls=1,

--- a/mpf/devices/servo.py
+++ b/mpf/devices/servo.py
@@ -57,9 +57,13 @@ class Servo(SystemWideDevice):
         self.set_acceleration_limit(self.acceleration_limit)
 
     @event_handler(1)
-    def reset(self, **kwargs):
-        """Go to reset position."""
+    def event_reset(self, **kwargs):
+        """Event handler for reset event."""
         del kwargs
+        self.reset()
+
+    def reset(self):
+        """Go to reset position."""
         self.go_to_position(self.config['reset_position'])
 
     @event_handler(5)

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -1,7 +1,6 @@
 """A shot in MPF."""
 import asyncio
-import uuid
-from copy import copy, deepcopy
+from copy import deepcopy
 
 from mpf.core.device_monitor import DeviceMonitor
 
@@ -65,7 +64,7 @@ class Shot(EnableDisableMixin, ModeDevice):
         self._handlers = []
         for switch in self.config['switches']:
             self._handlers.append(self.machine.events.add_handler("{}_active".format(switch.name),
-                                                                  self.hit, priority=self.mode.priority,
+                                                                  self.event_hit, priority=self.mode.priority,
                                                                   blocking_facility="shot"))
 
         for switch in list(self.config['delay_switch'].keys()):
@@ -83,15 +82,18 @@ class Shot(EnableDisableMixin, ModeDevice):
         self._handlers = []
 
     @event_handler(6)
-    def advance(self, force=False, **kwargs) -> bool:
+    def event_advance(self, force=False, **kwargs):
+        """Handle advance control event."""
+        del kwargs
+        self.advance(force)
+
+    def advance(self, force=False) -> bool:
         """Advance a shot profile forward.
 
         If this profile is at the last step and configured to loop, it will
         roll over to the first step. If this profile is at the last step and not
         configured to loop, this method has no effect.
         """
-        del kwargs
-
         if not self.enabled and not force:
             return False
 
@@ -220,7 +222,19 @@ class Shot(EnableDisableMixin, ModeDevice):
             self.running_show = None
 
     @event_handler(5)
-    def hit(self, **kwargs):
+    def event_hit(self, **kwargs):
+        """Handle hit control event."""
+        self.hit()
+
+        if self.profile.config['block']:
+            min_priority = kwargs.get("_min_priority", {"all": 0})
+            min_shots = min_priority.get("shot", 0)
+            min_priority["shot"] = self.mode.priority if self.mode.priority > min_shots else min_shots
+            return {"_min_priority": min_priority}
+
+        return None
+
+    def hit(self):
         """Advance the currently-active shot profile.
 
         Note that the shot must be enabled in order for this hit to be
@@ -324,14 +338,6 @@ class Shot(EnableDisableMixin, ModeDevice):
         profile: The name of the profile that was active when hit.
         state: The name of the state the profile was in when it was hit'''
 
-        if self.profile.config['block']:
-            min_priority = kwargs.get("_min_priority", {"all": 0})
-            min_shots = min_priority.get("shot", 0)
-            min_priority["shot"] = self.mode.priority if self.mode.priority > min_shots else min_shots
-            return {"_min_priority": min_priority}
-
-        return None
-
     def _notify_monitors(self, profile, state):
         if Shot.monitor_enabled and "shots" in self.machine.monitors:
             for callback in self.machine.monitors['shots']:
@@ -360,10 +366,7 @@ class Shot(EnableDisableMixin, ModeDevice):
         Args:
             state: int of the state number you want to jump to. Note that states
                 are zero-based, so the first state is 0.
-            show_step: The step number that the associated light script
-                should start playing at. Useful with rotations so this shot can
-                pick up right where it left off. Default is 1 (the first step
-                in the show)
+            force: if try also jumps if disabled
 
         """
         self.debug_log("Received jump request. State: %s, Force: %s", state, force)
@@ -389,20 +392,28 @@ class Shot(EnableDisableMixin, ModeDevice):
         self._update_show()
 
     @event_handler(1)
-    def reset(self, **kwargs):
-        """Reset the shot profile for the passed mode back to the first state (State 0) and reset all sequences."""
+    def event_reset(self, **kwargs):
+        """Handle reset control event."""
         del kwargs
+        self.reset()
+
+    def reset(self):
+        """Reset the shot profile for the passed mode back to the first state (State 0) and reset all sequences."""
         self.debug_log("Resetting.")
 
         self.jump(state=0)
 
     @event_handler(2)
-    def restart(self, **kwargs):
+    def event_restart(self, **kwargs):
+        """Handle restart control event."""
+        del kwargs
+        self.restart()
+
+    def restart(self):
         """Restart the shot profile by calling reset() and enable().
 
         Automatically called when one fo the restart_events is called.
         """
-        del kwargs
         self.reset()
         self.enable()
 

--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -97,37 +97,49 @@ class ShotGroup(ModeDevice):
         are in the same state named (state).
         '''
 
-    def enable(self, **kwargs):
-        """Enable all member shots.
+    @event_handler(2)
+    def event_enable(self, **kwargs):
+        """Handle enable control event."""
+        del kwargs
+        self.enable()
 
-        Args:
-            kwargs: passed to member shots
-        """
+    def enable(self):
+        """Enable all member shots."""
         for shot in self.config['shots']:
-            shot.enable(**kwargs)
+            shot.enable()
 
-    def disable(self, **kwargs):
-        """Disable all member shots.
+    @event_handler(3)
+    def event_disable(self, **kwargs):
+        """Handle disable control event."""
+        del kwargs
+        self.disable()
 
-        Args:
-            kwargs: passed to member shots
-        """
+    def disable(self):
+        """Disable all member shots."""
         for shot in self.config['shots']:
-            shot.disable(**kwargs)
+            shot.disable()
 
-    def reset(self, **kwargs):
-        """Reset all member shots.
+    @event_handler(1)
+    def event_reset(self, **kwargs):
+        """Handle reset control event."""
+        del kwargs
+        self.reset()
 
-        Args:
-            kwargs: passed to member shots
-        """
+    def reset(self):
+        """Reset all member shots."""
         for shot in self.config['shots']:
-            shot.reset(**kwargs)
+            shot.reset()
 
-    def restart(self, **kwargs):
+    @event_handler(4)
+    def event_restart(self, **kwargs):
+        """Handle restart control event."""
+        del kwargs
+        self.restart()
+
+    def restart(self):
         """Restart all member shots."""
         for shot in self.config['shots']:
-            shot.restart(**kwargs)
+            shot.restart()
 
     def _hit(self, advancing, **kwargs):
         """One of the member shots in this shot group was hit.
@@ -154,27 +166,40 @@ class ShotGroup(ModeDevice):
         '''
 
     @event_handler(9)
-    def enable_rotation(self, **kwargs):
+    def event_enable_rotation(self, **kwargs):
+        """Handle enable_rotation control event."""
+        del kwargs
+        self.enable_rotation()
+
+    def enable_rotation(self):
         """Enable shot rotation.
 
         If disabled, rotation events do not actually rotate the shots.
         """
-        del kwargs
         self.debug_log('Enabling rotation')
         self.rotation_enabled = True
 
     @event_handler(2)
-    def disable_rotation(self, **kwargs):
+    def event_disable_rotation(self, **kwargs):
+        """Handle disable rotation control event."""
+        del kwargs
+        self.disable_rotation()
+
+    def disable_rotation(self):
         """Disable shot rotation.
 
         If disabled, rotation events do not actually rotate the shots.
         """
-        del kwargs
         self.debug_log('Disabling rotation')
         self.rotation_enabled = False
 
     @event_handler(4)
-    def rotate(self, direction=None, **kwargs):
+    def event_rotate(self, direction=None, **kwargs):
+        """Handle rotate control event."""
+        del kwargs
+        self.rotate(direction)
+
+    def rotate(self, direction=None):
         """Rotate (or "shift") the state of all the shots in this group.
 
         This is used for things like lane change, where hitting the flipper
@@ -190,21 +215,10 @@ class ShotGroup(ModeDevice):
                 to the left or right. Values are 'right' or 'left'. Default of
                 None will cause the shot group to rotate in the direction as
                 specified by the rotation_pattern.
-            states: A string of a state or a list of strings that represent the
-                targets that will be selected to rotate. If None (default), then
-                all targets will be included.
-            exclude_states: A string of a state or a list of strings that
-                controls whether any targets will *not* be rotated. (Any
-                targets with an active profile in one of these states will not
-                be included in the rotation. Default is None which means all
-                targets will be rotated)
-            kwargs: unused
 
         Note that this shot group must, and rotation_events for this
         shot group, must both be enabled for the rotation events to work.
         """
-        del kwargs
-
         if not self.rotation_enabled:
             self.debug_log("Received rotation request. "
                            "Rotation Enabled: %s. Will NOT rotate",
@@ -236,27 +250,27 @@ class ShotGroup(ModeDevice):
             shot.jump(state=shot_state_list[i], force=True)
 
     @event_handler(8)
-    def rotate_right(self, mode=None, **kwargs):
+    def event_rotate_right(self, **kwargs):
+        """Handle rotate right control event."""
+        del kwargs
+        self.rotate_right()
+
+    def rotate_right(self):
         """Rotate the state of the shots to the right.
 
         This method is the same as calling rotate('right')
-
-        Args:
-            kwargs: unused
-
         """
-        del kwargs
-        self.rotate(direction='right', mode=mode)
+        self.rotate(direction='right')
 
     @event_handler(7)
-    def rotate_left(self, mode=None, **kwargs):
+    def event_rotate_left(self, **kwargs):
+        """Handle rotate left control event."""
+        del kwargs
+        self.rotate_left()
+
+    def rotate_left(self):
         """Rotate the state of the shots to the left.
 
         This method is the same as calling rotate('left')
-
-        Args:
-            kwargs: unused
-
         """
-        del kwargs
-        self.rotate(direction='left', mode=mode)
+        self.rotate(direction='left')

--- a/mpf/tests/test_DeviceManager.py
+++ b/mpf/tests/test_DeviceManager.py
@@ -18,10 +18,7 @@ class TestDeviceManager(MpfTestCase):
                     continue
                 method_name = k[:-7]
                 method = getattr(device_cls, "event_{}".format(method_name), None)
-                if not method:
-                    # fallback to old style
-                    method = getattr(device_cls, method_name, None)
-                self.assertIsNotNone(method, "Method {}.{} is missing for {}".format(device_type, method_name, k))
+                self.assertIsNotNone(method, "Method {}.event_{} is missing for {}".format(device_type, method_name, k))
 
                 sig = inspect.signature(method)
 
@@ -36,3 +33,7 @@ class TestDeviceManager(MpfTestCase):
                 self.assertEqual(sig.parameters['kwargs'].kind, inspect._VAR_KEYWORD,
                     "Method {}.{} kwargs param is missing '**'".format(
                     device_type, method_name))
+
+                self.assertTrue(hasattr(method, "relative_priority"),
+                                "Method {}.{} is missing a relative_priority. Did you apply the event_handler "
+                                "decorator?".format(device_type, method_name))

--- a/mpf/tests/test_DeviceManager.py
+++ b/mpf/tests/test_DeviceManager.py
@@ -17,7 +17,10 @@ class TestDeviceManager(MpfTestCase):
                 if not k.endswith('_events') or k == "control_events":
                     continue
                 method_name = k[:-7]
-                method = getattr(device_cls, method_name, None)
+                method = getattr(device_cls, "event_{}".format(method_name), None)
+                if not method:
+                    # fallback to old style
+                    method = getattr(device_cls, method_name, None)
                 self.assertIsNotNone(method, "Method {}.{} is missing for {}".format(device_type, method_name, k))
 
                 sig = inspect.signature(method)


### PR DESCRIPTION
Prefix all event handlers with event_. Previously, all kinds of methods had `**kwargs` and would swallow additional/incorrect arguments. Mark experienced this in custom code. This is a try to increase correctness. This only covers control events but it should be 90% of the handlers.