### PR TITLE
Allow dynamic values in `timer: control_events: value:` settings

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1542,7 +1542,7 @@ timer_control_events:  # subconfig for mode timers
     __valid_in__: None
     action: single|enum(add,subtract,jump,start,stop,reset,restart,pause,set_tick_interval,change_tick_interval,reset_tick_interval)|
     event: single|str|
-    value: single|num|None
+    value: single|template_float|None  # float for change_tick_interval, int for the rest
 track_player:
     __valid_in__: machine, mode, show
     action: single|enum(play,stop,pause,set_volume,stop_all_sounds)|

--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -293,13 +293,13 @@ class Timer(ModeDevice):
         del kwargs
 
         if not timer_value:
-            timer_value = 0  # make sure it's not None, etc.
+            pause_ms = 0  # make sure it's not None, etc.
+        else:
+            pause_ms = self._get_timer_value(timer_value) * 1000  # delays happen in ms
 
-        self.info_log("Pausing Timer for %s secs", timer_value)
+        self.info_log("Pausing Timer for %s ms", pause_ms)
 
         self.running = False
-
-        pause_ms = timer_value * 1000 # delays happen in ms
 
         self._remove_system_timer()
         self.machine.events.post('timer_' + self.name + '_paused',
@@ -406,6 +406,7 @@ class Timer(ModeDevice):
         """
         del kwargs
 
+        timer_value = self._get_timer_value(timer_value)
         ticks_added = timer_value
 
         new_value = self.ticks + ticks_added
@@ -444,7 +445,7 @@ class Timer(ModeDevice):
         """
         del kwargs
 
-        ticks_subtracted = timer_value
+        ticks_subtracted = self._get_timer_value(timer_value)
 
         self.ticks -= ticks_subtracted
 
@@ -504,21 +505,28 @@ class Timer(ModeDevice):
             self.machine.clock.unschedule(self.timer)
             self.timer = None
 
+    def _get_timer_value(self, timer_value):
+        if hasattr(timer_value, "evaluate"):
+            # Convert to int for ticks; config_spec must be float for change_tick_interval
+            return int(timer_value.evaluate([]))
+        return timer_value
+
     def change_tick_interval(self, change=0.0, **kwargs):
         """Change the interval for each "tick" of this timer.
 
         Args:
             change: Float or int of the change you want to make to this timer's
-                tick rate. Note this value is added to the current tick
-                interval. To set an absolute value, use the set_tick_interval()
-                method. To shorten the tick rate, use a negative value.
+                tick rate. Note this value is multiplied by the current tick
+                interval: >1 will increase the tick interval (slow the timer) and
+                <1 will decrease the tick interval (accelerate the timer).
+                To set an absolute value, use the set_tick_interval() method.
             **kwargs: Not used in this method. Only exists since this method is
                 often registered as an event handler which may contain
                 additional keyword arguments.
         """
         del kwargs
 
-        self.tick_secs *= change
+        self.tick_secs *= change.evaluate([])
         self._create_system_timer()
 
     def set_tick_interval(self, timer_value, **kwargs):
@@ -536,7 +544,7 @@ class Timer(ModeDevice):
         """
         del kwargs
 
-        self.tick_secs = abs(timer_value)
+        self.tick_secs = abs(self._get_timer_value(timer_value))
         self._create_system_timer()
 
     def jump(self, timer_value, **kwargs):
@@ -553,7 +561,7 @@ class Timer(ModeDevice):
         """
         del kwargs
 
-        self.ticks = int(timer_value)
+        self.ticks = self._get_timer_value(timer_value)
 
         if self.max_value and self.ticks > self.max_value:
             self.ticks = self.max_value

--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -166,7 +166,8 @@ class Timer(ModeDevice):
                 raise AssertionError("Invalid control_event action {} in mode".
                                      format(entry['action']), self.name)
 
-            self.event_keys.append(self.machine.events.add_handler(entry['event'], handler, **kwargs))
+            self.event_keys.append(
+                self.machine.events.add_handler(entry['event'], handler, **kwargs))
 
     def _remove_control_events(self):
         self.debug_log("Removing control events")
@@ -480,7 +481,8 @@ class Timer(ModeDevice):
                 self.ticks >= self.end_value):
             self.timer_complete()
             return True
-        elif (self.direction == 'down' and
+
+        if (self.direction == 'down' and
                 self.ticks <= self.end_value):
             self.timer_complete()
             return True
@@ -505,7 +507,8 @@ class Timer(ModeDevice):
             self.machine.clock.unschedule(self.timer)
             self.timer = None
 
-    def _get_timer_value(self, timer_value):
+    @staticmethod
+    def _get_timer_value(timer_value):
         if hasattr(timer_value, "evaluate"):
             # Convert to int for ticks; config_spec must be float for change_tick_interval
             return int(timer_value.evaluate([]))

--- a/mpf/tests/machine_files/timer/modes/mode_with_timers2/config/mode_with_timers2.yaml
+++ b/mpf/tests/machine_files/timer/modes/mode_with_timers2/config/mode_with_timers2.yaml
@@ -10,3 +10,14 @@ timers:
         direction: up
         tick_interval: 1s
         start_running: yes
+    timer_with_player_var_control_events:
+        start_value: 0
+        control_events:
+            - action: start
+              event: start_player_var_timer
+            - action: add
+              event: add_player_var_timer
+              value: current_player.timer_amount
+            - action: subtract
+              event: subtract_player_var_timer
+              value: current_player.timer_amount

--- a/mpf/tests/test_Timer.py
+++ b/mpf/tests/test_Timer.py
@@ -377,3 +377,28 @@ class TestTimer(MpfFakeGameTestCase):
 
         self.assertEventCalled("timer_timer_player_var_complete")
         self.machine.events.post('stop_mode_with_timers')
+
+    def test_timer_control_with_player_var(self):
+        self.start_game()
+        self.machine.game.player.timer_amount = 10
+        timer = self.machine.timers['timer_with_player_var_control_events']
+
+        self.machine.events.post('start_player_var_timer')
+        self.advance_time_and_run(.1)
+        self.assertTrue(timer.running)
+        self.assertEqual(0, timer.ticks)
+        self.advance_time_and_run(1)
+        self.assertEqual(1, timer.ticks)
+
+        self.machine.events.post('add_player_var_timer')
+        self.advance_time_and_run(.1)
+        self.assertEqual(11, timer.ticks)
+        self.advance_time_and_run(1)
+        self.assertEqual(12, timer.ticks)
+
+        self.machine.game.player.timer_amount = 5
+        self.machine.events.post('subtract_player_var_timer')
+        self.advance_time_and_run(.1)
+        self.assertEqual(7, timer.ticks)
+        self.advance_time_and_run(1)
+        self.assertEqual(8, timer.ticks)


### PR DESCRIPTION
Based on a conversation in slack, this PR extends the Timer `control_events:value` setting to support dynamic values.

```
timers:
  timer_with_player_var_control_events:
    start_value: 0
    control_events:
      - event: start_player_var_timer
        action: start
      - event: add_player_var_timer
        action: add
        value: current_player.timer_amount
      - event: subtract_player_var_timer
        action: subtract
        value: current_player.timer_amount
```

I edited _config_spec_ to set the `value:` to be a template, which grants it an `evaluate()` method that is called during the Timer event handler.

**I'm not pleased with** defining the template as `template_float` and converting it to `int` after evaluation. Every control event value is an `int` except for _change_tick_interval_, which is a `float`.  I'd love a better way to enforce the proper validation without coercing floats -> ints.