### PR TITLE
Add control events to counters

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -705,7 +705,7 @@ counters:
     control_events: list|subconfig(counter_control_events)|None
 counter_control_events:  # subconfig for mode counters
     __valid_in__: None
-    action: single|enum(add,subtract,set_value)|
+    action: single|enum(add,subtract,jump)|
     event: single|str|
     value: single|int|None  # int for all
 sequences:

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -702,6 +702,12 @@ counters:
     count_interval: single|int|1
     direction: single|str|up
     starting_count: single|template_int|0
+    control_events: list|subconfig(counter_control_events)|None
+counter_control_events:  # subconfig for mode counters
+    __valid_in__: None
+    action: single|enum(add,subtract,set_value)|
+    event: single|str|
+    value: single|int|None  # int for all
 sequences:
     __valid_in__: machine, mode
     events: list|str|

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -707,7 +707,7 @@ counter_control_events:  # subconfig for mode counters
     __valid_in__: None
     action: single|enum(add,subtract,jump)|
     event: single|str|
-    value: single|int|None  # int for all
+    value: single|template_int|None
 sequences:
     __valid_in__: machine, mode
     events: list|str|

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -320,6 +320,87 @@ class Counter(LogicBlock):
             self.hit_value *= -1
         elif self.config['direction'] == 'up' and self.hit_value < 0:
             self.hit_value *= -1
+        # Add control events if included in the config
+        if self.config['control_events']:
+            self._setup_control_events(self.config['control_events'])
+
+    def add_control_events_in_mode(self, mode: Mode) -> None:
+        """Do not auto enable this device in modes."""
+        pass
+
+    def _setup_control_events(self, event_list):
+        self.debug_log("Setting up control events")
+
+        kwargs = {}
+        for entry in event_list:
+            if entry['action'] in ('add', 'subtract', 'set_value'):
+                handler = getattr(self, entry['action'])
+                kwargs = {'value': entry['value']}
+            else:
+                raise AssertionError("Invalid control_event action {} in mode".
+                                     format(entry['action']), self.name)
+            self.machine.events.add_handler(entry['event'], handler, **kwargs)
+
+    def check_complete(self, count_complete_value=None):
+        '''
+        Returns true if the counter has reached or surpassed its specified
+        completion value, returns False if no completion criteria or is
+        not complete.
+        '''
+        # If count_complete_value was not passed, obtain it
+        if count_complete_value is None:
+            count_complete_value = self.config['count_complete_value']\
+                .evaluate([]) if self.config['count_complete_value']\
+                is not None else None
+
+        if count_complete_value is not None:
+
+            if self.config['direction'] == 'up' and self._state.value >= count_complete_value:
+                return True
+
+            elif self.config['direction'] == 'down' and self._state.value <=\
+                    count_complete_value:
+                return True
+        return False
+
+    def add(self, **kwargs):
+        '''Add to the value of this counter.
+
+        Args:
+            kwargs: Used for the "value" member which contains how much to add
+            to the counter.
+        '''
+        # Add to the counter the specified value
+        self._state.value += kwargs['value']
+        # Check if count is complete given the updated value
+        if self.check_complete():
+            self.complete()
+
+    def subtract(self, **kwargs):
+        '''Subtract from the value of this counter.
+
+        Args:
+            kwargs: Used for the "value" member which contains how much to
+            subtract from the counter.
+        '''
+        # Subtract from the counter the specified value
+        self._state.value -= kwargs['value']
+        # Check if count is complete given the updated value
+        if self.check_complete():
+            self.complete()
+
+    def set_value(self, **kwargs):
+        '''Set the internal value of the counter.
+
+        Args:
+            kwargs: Used for the "value" member which contains what to set
+            the counter value to.
+        '''
+        # Set the internal value of the counter to the specified value
+        self._state.value = kwargs['value']
+        # Check if count is complete given the updated value
+        if self.check_complete():
+            self.complete()
 
     def get_start_value(self) -> int:
         """Return start count."""
@@ -368,13 +449,8 @@ class Counter(LogicBlock):
 
             self._post_hit_events(**args)
 
-            if count_complete_value is not None:
-
-                if self.config['direction'] == 'up' and self._state.value >= count_complete_value:
-                    self.complete()
-
-                elif self.config['direction'] == 'down' and self._state.value <= count_complete_value:
-                    self.complete()
+            if self.check_complete(count_complete_value):
+                self.complete()
 
             if self.config['multiple_hit_window']:
                 self.debug_log("Beginning Ignore Hits")

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -360,41 +360,53 @@ class Counter(LogicBlock):
                 return self._state.value <= count_complete_value
         return False
 
-    def event_add(self, **kwargs):
+    def event_add(self, value, **kwargs):
         """Add to the value of this counter.
 
         Args:
             kwargs: Used for the "value" member which contains how much to add
             to the counter.
         """
+        evaluated_value = value.evaluate_or_none(kwargs)
+        if evaluated_value is None:
+            self.log.warning("Placeholder %s for counter add did not evaluate with args %s", value, kwargs)
+            return
         # Add to the counter the specified value
-        self._state.value += kwargs['value']
+        self._state.value += evaluated_value
         # Check if count is complete given the updated value
         if self.check_complete():
             self.complete()
 
-    def event_subtract(self, **kwargs):
+    def event_subtract(self, value, **kwargs):
         """Subtract from the value of this counter.
 
         Args:
             kwargs: Used for the "value" member which contains how much to
             subtract from the counter.
         """
+        evaluated_value = value.evaluate_or_none(kwargs)
+        if evaluated_value is None:
+            self.log.warning("Placeholder %s for counter substract did not evaluate with args %s", value, kwargs)
+            return
         # Subtract from the counter the specified value
-        self._state.value -= kwargs['value']
+        self._state.value -= evaluated_value
         # Check if count is complete given the updated value
         if self.check_complete():
             self.complete()
 
-    def event_jump(self, **kwargs):
+    def event_jump(self, value, **kwargs):
         """Set the internal value of the counter.
 
         Args:
             kwargs: Used for the "value" member which contains what to set
             the counter value to.
         """
+        evaluated_value = value.evaluate_or_none(kwargs)
+        if evaluated_value is None:
+            self.log.warning("Placeholder %s for counter jump did not evaluate with args %s", value, kwargs)
+            return
         # Set the internal value of the counter to the specified value
-        self._state.value = kwargs['value']
+        self._state.value = evaluated_value
         # Check if count is complete given the updated value
         if self.check_complete():
             self.complete()

--- a/mpf/tests/machine_files/logic_blocks/config/config.yaml
+++ b/mpf/tests/machine_files/logic_blocks/config/config.yaml
@@ -97,3 +97,4 @@ modes:
     - mode1
     - mode2
     - mode3
+    - mode4

--- a/mpf/tests/machine_files/logic_blocks/modes/mode4/config/mode4.yaml
+++ b/mpf/tests/machine_files/logic_blocks/modes/mode4/config/mode4.yaml
@@ -33,10 +33,10 @@ counters:
             action: subtract
             value: 0
           - event: set_counter6_25
-            action: set_value
+            action: jump
             value: 25
           - event: set_counter6_0
-            action: set_value
+            action: jump
             value: 0
   counter7:
       count_events: counter7_count
@@ -58,13 +58,13 @@ counters:
             action: subtract
             value: 3
           - event: set_counter7_negative25
-            action: set_value
+            action: jump
             value: -25
           - event: set_counter7_3
-            action: set_value
+            action: jump
             value: 3
           - event: set_counter7_0
-            action: set_value
+            action: jump
             value: 0
 accruals:
   accrual6:

--- a/mpf/tests/machine_files/logic_blocks/modes/mode4/config/mode4.yaml
+++ b/mpf/tests/machine_files/logic_blocks/modes/mode4/config/mode4.yaml
@@ -66,6 +66,16 @@ counters:
           - event: set_counter7_0
             action: jump
             value: 0
+          - event: set_counter_placeholder
+            action: jump
+            value: machine.test2
+          - event: subtract_counter_placeholder
+            action: subtract
+            value: machine.test3
+          - event: add_counter_placeholder
+            action: add
+            value: machine.test4
+
 accruals:
   accrual6:
       events:

--- a/mpf/tests/machine_files/logic_blocks/modes/mode4/config/mode4.yaml
+++ b/mpf/tests/machine_files/logic_blocks/modes/mode4/config/mode4.yaml
@@ -1,0 +1,74 @@
+#config_version=5
+mode:
+  start_events: start_mode4
+  stop_events: stop_mode4
+
+counters:
+  counter6:
+      count_events: counter6_count
+      events_when_hit: counter6_hit
+      events_when_complete: counter6_complete
+      starting_count: 0
+      count_complete_value: 10
+      direction: up
+      reset_on_complete: True
+      disable_on_complete: False
+      control_events:
+          - event: increase_counter6_5
+            action: add
+            value: 5
+          - event: increase_counter6_3
+            action: add
+            value: 3
+          - event: increase_counter6_0
+            action: add
+            value: 0
+          - event: reduce_counter6_5
+            action: subtract
+            value: 5
+          - event: reduce_counter6_3
+            action: subtract
+            value: 3
+          - event: reduce_counter6_0
+            action: subtract
+            value: 0
+          - event: set_counter6_25
+            action: set_value
+            value: 25
+          - event: set_counter6_0
+            action: set_value
+            value: 0
+  counter7:
+      count_events: counter7_count
+      events_when_hit: counter7_hit
+      events_when_complete: counter7_complete
+      starting_count: 5
+      count_complete_value: 0
+      direction: down
+      reset_on_complete: True
+      disable_on_complete: False
+      control_events:
+          - event: increase_counter7_5
+            action: add
+            value: 5
+          - event: reduce_counter7_5
+            action: subtract
+            value: 5
+          - event: reduce_counter7_3
+            action: subtract
+            value: 3
+          - event: set_counter7_negative25
+            action: set_value
+            value: -25
+          - event: set_counter7_3
+            action: set_value
+            value: 3
+          - event: set_counter7_0
+            action: set_value
+            value: 0
+accruals:
+  accrual6:
+      events:
+        - accrual6_step1
+        - accrual6_step2
+      persist_state: True

--- a/mpf/tests/test_LogicBlocks.py
+++ b/mpf/tests/test_LogicBlocks.py
@@ -386,6 +386,30 @@ class TestLogicBlocks(MpfFakeGameTestCase):
         self.post_event("counter7_count")
         self.assertEventCalledWith("counter7_hit", count=2, remaining=-2)
 
+        self.assertPlaceholderEvaluates(2, "device.counters.counter7.value")
+
+        # nothing happens because machine.test2 is undefined
+        self.post_event("set_counter_placeholder")
+        self.assertPlaceholderEvaluates(2, "device.counters.counter7.value")
+
+        self.machine.set_machine_var("test2", 4)
+        self.post_event("set_counter_placeholder")
+        self.assertPlaceholderEvaluates(4, "device.counters.counter7.value")
+
+        self.post_event("subtract_counter_placeholder")
+        self.assertPlaceholderEvaluates(4, "device.counters.counter7.value")
+
+        self.machine.set_machine_var("test3", 3)
+        self.post_event("subtract_counter_placeholder")
+        self.assertPlaceholderEvaluates(1, "device.counters.counter7.value")
+
+        self.post_event("add_counter_placeholder")
+        self.assertPlaceholderEvaluates(1, "device.counters.counter7.value")
+
+        self.machine.set_machine_var("test4", 1)
+        self.post_event("add_counter_placeholder")
+        self.assertPlaceholderEvaluates(2, "device.counters.counter7.value")
+
     def test_logic_block_outside_game(self):
         self.mock_event("logicblock_accrual2_complete")
 


### PR DESCRIPTION
Implements control events for the counter class, as well as unit tests. Implements the feature requested in issue 1180.
https://github.com/missionpinball/mpf/issues/1180