### PR TITLE
Util string_to_list with braces

### DIFF
--- a/mpf/core/utility_functions.py
+++ b/mpf/core/utility_functions.py
@@ -102,8 +102,12 @@ class Util:
 
         """
         if isinstance(string, str):
-            # Convert commas to spaces, then split the string into a list
-            new_list = string.replace(',', ' ').split()
+            if "{" in string:
+                # Split the string on spaces/commas EXCEPT regions within braces
+                new_list = re.findall(r'([\w|-]+?\{.*?\}|[\w|-]+)', string)
+            else:
+                # Convert commas to spaces, then split the string into a list
+                new_list = string.replace(",", " ").split()
             # Look for string values of "None" and convert them to Nonetypes.
             for index, value in enumerate(new_list):
                 if isinstance(value, str) and len(value) == 4 and value.lower() == 'none':

--- a/mpf/tests/test_Utility_Functions.py
+++ b/mpf/tests/test_Utility_Functions.py
@@ -55,6 +55,13 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(type(result), list)
         self.assertFalse(result)
 
+        my_string = '0 1 2{not split here} 3 4 5'
+        result = Util.string_to_list(my_string)
+        self.assertEqual(type(result), list)
+        self.assertEqual(result[1], '1')
+        self.assertEqual(result[2], '2{not split here}')
+        self.assertEqual(result[3], '3')
+
     def test_string_to_lowercase_list(self):
         my_string = 'A B c d e'
         result = Util.string_to_lowercase_list(my_string)


### PR DESCRIPTION
The changes in #1327 caused new evaluations of `Util.string_to_list` that can result in the splitting of conditional events when merging dictionaries.

This PR extends the logic of `string_to_list` to maintain spaces within braces when it splits, resulting in the expected behavior
```
>>> Util.string_to_list("event1 event2{not some_condition} event3")
["event1", "event2{not some_condition}", "event3"]
```

Because the regex is more computionally demanding than the native `String.replace().split()`, the new logic is only performed if the string has a brace. Otherwise, the old logic is used.