### PR TITLE
Bugfix settings dict lookup

### DIFF
--- a/mpf/core/settings_controller.py
+++ b/mpf/core/settings_controller.py
@@ -63,7 +63,7 @@ class SettingsController(MpfController):
 
     def __getattr__(self, item):
         """Return setting."""
-        if "_settings" not in self.__dict__ or item not in self.__dict__['settings']:
+        if "_settings" not in self.__dict__ or item not in self.__dict__['_settings']:
             raise AttributeError()
         return self.get_setting_value(item)
 

--- a/mpf/tests/machine_files/settings/config/config.yaml
+++ b/mpf/tests/machine_files/settings/config/config.yaml
@@ -1,0 +1,21 @@
+#config_version=5
+
+settings:
+    custom_setting_int:
+        label: "Int Setting"
+        key_type: int
+        default: 0
+        sort: 1
+        values:
+            0: "Zero"
+            1: "One"
+            2: "Two"
+    custom_setting_str:
+        label: "String Setting"
+        key_type: str
+        default: "one"
+        sort: 2
+        values:
+            zero: "Zero"
+            one: "One"
+            two: "Two"

--- a/mpf/tests/test_Settings.py
+++ b/mpf/tests/test_Settings.py
@@ -1,0 +1,26 @@
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestSettings(MpfTestCase):
+
+    def getConfigFile(self):
+        return 'config.yaml'
+
+    def getMachinePath(self):
+        return 'tests/machine_files/settings/'
+
+    def get_platform(self):
+        return 'smart_virtual'
+
+    def _tilted(self, **kwargs):
+        del kwargs
+        self._is_tilted = True
+
+    def test_settings_values(self):
+        self.assertEqual(0, self.machine.settings.custom_setting_int)
+        self.machine.settings.set_setting_value("custom_setting_int", 2)
+        self.assertEqual(2, self.machine.settings.custom_setting_int)
+
+        self.assertEqual("one", self.machine.settings.custom_setting_str)
+        self.machine.settings.set_setting_value("custom_setting_str", "zero")
+        self.assertEqual("zero", self.machine.settings.custom_setting_str)


### PR DESCRIPTION
This PR fixes a bug in `SettingsController` that prevented programmatic access to the machine settings.

The settings are stored as `machine.__dict__["_settings"]` (with underscore) but the lookup item's check was against `machine.__dict__["settings"]` (without underscore). As a result, any attempt to access `machine.settings["foo"]` would throw.

This PR adds the underscore so the lookup is in the correct place and machine settings values are accessible.