### PR TITLE
Fix "enabled" value in placeholder for devices

### DIFF
--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -10,7 +10,7 @@ from mpf.core.mode_device import ModeDevice
 from mpf.core.system_wide_device import SystemWideDevice
 
 
-@DeviceMonitor("balls_held", "enabled")
+@DeviceMonitor("balls_held", _enabled="enabled")
 class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
 
     """Ball hold device which can be used to keep balls in ball devices and control their eject later on."""

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -10,7 +10,7 @@ from mpf.core.mode_device import ModeDevice
 from mpf.core.system_wide_device import SystemWideDevice
 
 
-@DeviceMonitor("balls_held", enabled="_enabled")
+@DeviceMonitor("balls_held", "enabled")
 class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
 
     """Ball hold device which can be used to keep balls in ball devices and control their eject later on."""

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -11,7 +11,7 @@ from mpf.core.placeholder_manager import NativeTypeTemplate
 from mpf.core.system_wide_device import SystemWideDevice
 
 
-@DeviceMonitor("shoot_again", "balls_added_live", "balls_live_target", "enabled")
+@DeviceMonitor("shoot_again", "balls_added_live", "balls_live_target", _enabled="enabled")
 class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
 
     """Multiball device for MPF."""

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -11,7 +11,7 @@ from mpf.core.placeholder_manager import NativeTypeTemplate
 from mpf.core.system_wide_device import SystemWideDevice
 
 
-@DeviceMonitor("shoot_again", "balls_added_live", "balls_live_target", enabled="_enabled")
+@DeviceMonitor("shoot_again", "balls_added_live", "balls_live_target", "enabled")
 class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
 
     """Multiball device for MPF."""

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -12,7 +12,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.ball_device.ball_device import BallDevice
 
 
-@DeviceMonitor("locked_balls", "enabled")
+@DeviceMonitor("locked_balls", _enabled="enabled")
 class MultiballLock(EnableDisableMixin, ModeDevice):
 
     """Ball lock device which locks balls for a multiball."""

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -12,7 +12,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.ball_device.ball_device import BallDevice
 
 
-@DeviceMonitor("locked_balls", enabled="_enabled")
+@DeviceMonitor("locked_balls", "enabled")
 class MultiballLock(EnableDisableMixin, ModeDevice):
 
     """Ball lock device which locks balls for a multiball."""

--- a/mpf/tests/machine_files/ball_holds/config/test_ball_holds.yaml
+++ b/mpf/tests/machine_files/ball_holds/config/test_ball_holds.yaml
@@ -83,3 +83,9 @@ event_player:
         - "yes"
     test_conditional_event.2{device.ball_holds.hold_test["balls_held"] == 0}:
         - "no"
+    test_event_when_enabled:
+        - should_post_when_enabled{device.ball_holds.hold_test.enabled}
+        - should_not_post_when_enabled{not device.ball_holds.hold_test.enabled}
+    test_event_when_disabled:
+        - should_post_when_disabled{not device.ball_holds.hold_test.enabled}
+        - should_not_post_when_disabled{device.ball_holds.hold_test.enabled}

--- a/mpf/tests/machine_files/multiball/config/config.yaml
+++ b/mpf/tests/machine_files/multiball/config/config.yaml
@@ -11,6 +11,14 @@ coils:
     eject_coil3:
         number:
 
+event_player:
+    test_event_when_enabled:
+        - should_post_when_enabled{device.multiballs.mb1.enabled}
+        - should_not_post_when_enabled{not device.multiballs.mb1.enabled}
+    test_event_when_disabled:
+        - should_post_when_disabled{not device.multiballs.mb1.enabled}
+        - should_not_post_when_disabled{device.multiballs.mb1.enabled}
+
 switches:
     s_start:
         number:

--- a/mpf/tests/machine_files/multiball_locks/config/testDefault.yaml
+++ b/mpf/tests/machine_files/multiball_locks/config/testDefault.yaml
@@ -1,0 +1,5 @@
+#config_version=5
+config: config.yaml
+
+modes:
+    - default

--- a/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
+++ b/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
@@ -1,0 +1,18 @@
+#config_version=5
+mode:
+  start_events: start_default
+
+event_player:
+  test_event_when_enabled:
+    - should_post_when_enabled{device.multiball_locks.lock_default.enabled}
+    - should_not_post_when_enabled{not device.multiball_locks.lock_default.enabled}
+  test_event_when_disabled:
+    - should_post_when_disabled{not device.multiball_locks.lock_default.enabled}
+    - should_not_post_when_disabled{device.multiball_locks.lock_default.enabled}
+
+multiball_locks:
+    lock_default:
+        lock_devices: bd_lock
+        balls_to_lock: 2
+        locked_ball_counting_strategy: virtual_only
+        debug: True

--- a/mpf/tests/test_BallHold.py
+++ b/mpf/tests/test_BallHold.py
@@ -533,6 +533,26 @@ class TestBallHold(MpfTestCase):
     def test_auto_capacity(self):
         self.assertEqual(self.machine.ball_holds.hold_test3.config['balls_to_hold'], 2)
 
+    def test_enabled_state_in_placeholder(self):
+        self.mock_event("should_post_when_enabled")
+        self.mock_event("should_post_when_disabled")
+        self.mock_event("should_not_post_when_enabled")
+        self.mock_event("should_not_post_when_disabled")
+        hold = self.machine.ball_holds['hold_test']
+
+        hold.enable()
+        self.assertTrue(hold.enabled)
+        self.post_event("test_event_when_enabled")
+        self.assertEventCalled("should_post_when_enabled")
+        self.assertEventNotCalled("should_not_post_when_enabled")
+
+        hold.disable()
+        self.assertFalse(hold.enabled)
+        self.post_event("test_event_when_disabled")
+        self.assertEventCalled("should_post_when_disabled")
+        self.assertEventNotCalled("should_not_post_when_disabled")
+
+
 class TestBallHoldSmart(MpfTestCase):
 
     def getConfigFile(self):

--- a/mpf/tests/test_MultiBall.py
+++ b/mpf/tests/test_MultiBall.py
@@ -957,3 +957,26 @@ class TestMultiBall(MpfGameTestCase):
         # game should end
         self.advance_time_and_run(1)
         self.assertEqual(None, self.machine.game)
+
+    def testMultiballStateInPlaceholder(self):
+        self.fill_troughs()
+        self.start_game()
+
+        self.post_event("start_default")
+        self.mock_event("should_post_when_enabled")
+        self.mock_event("should_post_when_disabled")
+        self.mock_event("should_not_post_when_enabled")
+        self.mock_event("should_not_post_when_disabled")
+        mb = self.machine.multiballs["mb1"]
+
+        self.assertFalse(mb.enabled)
+        self.post_event("test_event_when_disabled")
+        self.assertEventCalled("should_post_when_disabled")
+        self.assertEventNotCalled("should_not_post_when_disabled")
+
+        mb.enable()
+        self.assertTrue(mb.enabled)
+        self.post_event("test_event_when_enabled")
+        self.assertEventCalled("should_post_when_enabled")
+        self.assertEventNotCalled("should_not_post_when_enabled")
+        

--- a/mpf/tests/test_MultiballLock.py
+++ b/mpf/tests/test_MultiballLock.py
@@ -13,6 +13,28 @@ class TestMultiballLock(MpfGameTestCase):
     def get_platform(self):
         return 'smart_virtual'
 
+    def testDefault(self):
+        self.fill_troughs()
+        self.start_game()
+
+        self.post_event("start_default")
+        self.mock_event("should_post_when_enabled")
+        self.mock_event("should_post_when_disabled")
+        self.mock_event("should_not_post_when_enabled")
+        self.mock_event("should_not_post_when_disabled")
+        lock = self.machine.multiball_locks["lock_default"]
+
+        self.assertTrue(lock.enabled)
+        self.post_event("test_event_when_enabled")
+        self.assertEventCalled("should_post_when_enabled")
+        self.assertEventNotCalled("should_not_post_when_enabled")
+
+        lock.disable()
+        self.assertFalse(lock.enabled)
+        self.post_event("test_event_when_disabled")
+        self.assertEventCalled("should_post_when_disabled")
+        self.assertEventNotCalled("should_not_post_when_disabled")
+
     def testNoVirtual(self):
         # prepare game
         self.fill_troughs()


### PR DESCRIPTION
This PR reverts a behavior change in #1327 that introduced a bug on Device `enabled` values in placeholders. I didn't sort out exactly the issue, but I think something was double-escaping the underscored property or doubling the alias lookback. Suffice it to say, `event{device.type.devicename.enabled}` conditions always evaluated to false, throwing on the DevicePlaceholder not having an "enabled" property.

Changing the placeholder to be `event{device.type.devicename._enabled}` behaved as expected, but that feels incorrect.

This PR reverts the alias underscore of the "enabled" property for BallHold, MultiBall, and MultiballLock, and adds tests to confirm the expected behavior.

NOTE: BallRouting also includes the "_enabled" change, but I'm not familiar enough with how routing devices work to write tests for them.