### PR TITLE
Honor disable_random setting on random_event_player

### DIFF
--- a/mpf/config_players/random_event_player.py
+++ b/mpf/config_players/random_event_player.py
@@ -36,11 +36,14 @@ class RandomEventPlayer(ConfigPlayer):
                 variables that start with "random\_" are.
                 '''
 
-            if settings['force_all']:
-                self.machine.game.player[key].force_all = True
+                if settings['force_all']:
+                    self.machine.game.player[key].force_all = True
 
-            if not settings['force_different']:
-                self.machine.game.player[key].force_different = False
+                if not settings['force_different']:
+                    self.machine.game.player[key].force_different = False
+
+                if settings['disable_random']:
+                    self.machine.game.player[key].disable_random = True
 
             return self.machine.game.player[key]
 
@@ -48,11 +51,14 @@ class RandomEventPlayer(ConfigPlayer):
             if key not in self._machine_wide_dict:
                 self._machine_wide_dict[key] = Randomizer(settings['events'])
 
-            if settings['force_all']:
-                self._machine_wide_dict[key].force_all = True
+                if settings['force_all']:
+                    self._machine_wide_dict[key].force_all = True
 
-            if not settings['force_different']:
-                self._machine_wide_dict[key].force_different = False
+                if not settings['force_different']:
+                    self._machine_wide_dict[key].force_different = False
+
+                if settings['disable_random']:
+                    self._machine_wide_dict[key].disable_random = True
 
             return self._machine_wide_dict[key]
 

--- a/mpf/tests/machine_files/event_players/config/test_random_event_player.yaml
+++ b/mpf/tests/machine_files/event_players/config/test_random_event_player.yaml
@@ -1,0 +1,52 @@
+#config_version=5
+
+modes:
+  - mode2
+
+game:
+  balls_per_game: 1
+
+switches:
+  s_ball:
+    number:
+
+coils:
+  c_eject:
+    number:
+
+playfields:
+  playfield:
+    default_source_device: s_trough
+    tags: default
+
+ball_devices:
+  s_trough:
+    ball_switches: s_ball
+    eject_coil: c_eject
+    tags: trough, drain, home
+
+random_event_player:
+  test_machine_force_different:
+    scope: machine
+    force_different: true
+    events:
+      - event1
+      - event2
+      - event3
+      - event4
+  test_machine_force_all:
+    scope: machine
+    force_all: true
+    events:
+      - event1
+      - event2
+      - event3
+      - event4
+  test_machine_disable_random:
+    scope: machine
+    disable_random: true
+    events:
+      - event1
+      - event2
+      - event3
+      - event4

--- a/mpf/tests/machine_files/event_players/modes/mode2/config/mode2.yaml
+++ b/mpf/tests/machine_files/event_players/modes/mode2/config/mode2.yaml
@@ -1,0 +1,27 @@
+#config_version=5
+mode:
+  start_events: start_mode2
+  stop_events: stop_mode2
+
+random_event_player:
+  test_player_force_different:
+    force_different: true
+    events:
+      - event1
+      - event2
+      - event3
+      - event4
+  test_player_force_all:
+    force_all: true
+    events:
+      - event1
+      - event2
+      - event3
+      - event4
+  test_player_disable_random:
+    disable_random: true
+    events:
+      - event1
+      - event2
+      - event3
+      - event4

--- a/mpf/tests/test_RandomEventPlayer.py
+++ b/mpf/tests/test_RandomEventPlayer.py
@@ -1,0 +1,100 @@
+"""Test event player."""
+from mpf.tests.MpfTestCase import MpfTestCase
+from mpf.tests.MpfGameTestCase import MpfGameTestCase
+
+# How many test iterations do we run to convince of randomness?
+RANDOM_RUNS = 20
+
+
+class TestRandomEventPlayer(MpfTestCase):
+
+    def getConfigFile(self):
+        return 'test_random_event_player.yaml'
+
+    def getMachinePath(self):
+        return 'tests/machine_files/event_players/'
+
+    def test_machine_tests(self):
+        tester = TestRandomEventPlayerBase(self, "machine")
+        tester.run_all_tests()
+
+
+class TestRandomEventPlayerGame(MpfGameTestCase):
+
+    def getConfigFile(self):
+        return 'test_random_event_player.yaml'
+
+    def getMachinePath(self):
+        return 'tests/machine_files/event_players/'
+
+    def get_platform(self):
+        return 'smart_virtual'
+
+    def test_player_tests(self):
+        self.fill_troughs()
+        self.start_game()
+        self.advance_time_and_run(4)
+        self.machine.events.post("start_mode2")
+        self.advance_time_and_run(4)
+        self.assertTrue(self.machine.modes.mode2.active)
+        self.assertTrue(self.machine.mode_controller.is_active('mode2'))
+
+        tester = TestRandomEventPlayerBase(self, "player")
+        tester.run_all_tests()
+
+
+# Below are the common setup and test run methods shared by the machine and player test cases
+class TestRandomEventPlayerBase():
+    def __init__(self, runner, scope, events=["event1", "event2", "event3", "event4"]):
+        self.runner = runner
+        self.scope = scope
+        self.events = events
+        for event in events:
+            runner.machine.events.add_handler(event=event, handler=self._handle_event, event_name=event)
+
+    def run_all_tests(self):
+        for test in [self._test_force_different, self._test_force_all, self._test_disable_random]:
+            test()
+
+    def _reset(self):
+        self.eventHistory = []
+        self.uniqueEvents = set()
+        self.prevEvent = None
+        self.lastEvent = None
+
+    def _handle_event(self, **kwargs):
+        self.prevEvent = self.lastEvent
+        self.lastEvent = kwargs['event_name']
+        self.eventHistory.append(self.lastEvent)
+        self.uniqueEvents.add(self.lastEvent)
+
+    def _test_force_different(self):
+        self._reset()
+        for x in range(0, RANDOM_RUNS):
+            self.runner.post_event("test_{}_force_different".format(self.scope))
+            self.runner.advance_time_and_run()
+            self.runner.assertNotEqual(self.prevEvent, self.lastEvent)
+
+    def _test_force_all(self):
+        self._reset()
+        for x in range(0, RANDOM_RUNS):
+            # If we have done all the events, reset the unique list
+            if len(self.events) == len(self.uniqueEvents):
+                self.uniqueEvents = set()
+                self.eventHistory = []
+            self.runner.post_event("test_{}_force_all".format(self.scope))
+            self.runner.advance_time_and_run()
+            self.runner.assertNotEqual(self.prevEvent, self.lastEvent)
+            # If we force all, the set should always get an entry
+            self.runner.assertEqual(len(self.uniqueEvents), len(self.eventHistory))
+
+    def _test_disable_random(self):
+        self._reset()
+        # Set initial values for our lookback
+        self.prevEvent = self.events[:1]
+        for x in range(0, RANDOM_RUNS):
+            expectedIdx = x % 4
+            self.runner.post_event("test_{}_disable_random".format(self.scope))
+            self.runner.advance_time_and_run()
+            self.runner.assertNotEqual(self.prevEvent, self.lastEvent)
+            self.runner.assertEqual(self.lastEvent, self.events[expectedIdx])


### PR DESCRIPTION
This PR adds support for a documented-but-unimplemented setting for RandomEventPlayer: `disable_random`.

The underlying Randomizer accepts a disable_random setting to return items sequentially, but RandomEventPlayer never passed the setting to the Randomizer. This PR makes that change, for both machine and player RandomEventPlayers.

Also changed: currently, the RandomEventPlayer sets the `force_different` and `force_all` properties on its Randomizer every time the randomizer is accessed. This PR increases the indentation of that behavior so that the properties are only set when the randomizer is created, not every time its used.

Also also, tests! Lots of tests!