### PR TITLE
Text ui config

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1518,6 +1518,10 @@ system11:
     file_log: single|enum(none,basic,full)|basic
 text_strings:
     __valid_in__: machine, mode                 # todo add to validator
+text_ui:
+    __valid_in__: machine
+    player_vars: list|str|None
+    machine_vars: list|str|None
 tic_stepper_settings:
     max_speed: single|int|2000000
     starting_speed: single|int|0

--- a/mpf/core/text_ui.py
+++ b/mpf/core/text_ui.py
@@ -53,14 +53,15 @@ class TextUi(MpfController):
     config_name = "text_ui"
 
     __slots__ = ["start_time", "machine", "_tick_task", "screen", "mpf_process", "ball_devices", "switches",
-                 "_pending_bcp_connection", "_asset_percent", "_player_widgets", "_machine_widgets",
+                 "config", "_pending_bcp_connection", "_asset_percent", "_player_widgets", "_machine_widgets",
                  "_bcp_status", "frame", "layout", "scene", "footer_memory", "switch_widgets", "mode_widgets",
                  "ball_device_widgets", "footer_cpu", "footer_mc_cpu", "footer_uptime", "delay", "_layout_change"]
 
-    def __init__(self, machine: "MachineController") -> None:
+    def __init__(self, machine: "MachineController", **kwargs) -> None:
         """Initialize TextUi."""
         super().__init__(machine)
         self.delay = DelayManager(machine)
+        self.config = machine.config.get('text_ui', {})
 
         self.screen = None
 
@@ -309,8 +310,9 @@ class TextUi(MpfController):
         player_vars.pop('number')
         player_vars.pop('ball')
 
-        for name, value in player_vars.items():
-            self._player_widgets.append(Label('{}: {}'.format(name, value)))
+        names = self.config.get('player_vars', player_vars.keys())
+        for name in names:
+            self._player_widgets.append(Label("{}: {}".format(name, player_vars[name])))
 
         self._layout_change = True
         self._schedule_draw_screen()
@@ -327,8 +329,10 @@ class TextUi(MpfController):
         self._machine_widgets.append(Label("MACHINE VARIABLES"))
         self._machine_widgets.append(Divider())
         machine_vars = self.machine.variables.machine_vars
-        for name, value in machine_vars.items():
-            self._machine_widgets.append(Label("{}: {}".format(name, value['value'])))
+        # If config defines explict vars to show, only show those. Otherwise, all
+        names = self.config.get('machine_vars', machine_vars.keys())
+        for name in names:
+            self._machine_widgets.append(Label("{}: {}".format(name, machine_vars[name]['value'])))
         self._layout_change = True
         self._schedule_draw_screen()
 

--- a/mpf/core/text_ui.py
+++ b/mpf/core/text_ui.py
@@ -57,7 +57,7 @@ class TextUi(MpfController):
                  "_bcp_status", "frame", "layout", "scene", "footer_memory", "switch_widgets", "mode_widgets",
                  "ball_device_widgets", "footer_cpu", "footer_mc_cpu", "footer_uptime", "delay", "_layout_change"]
 
-    def __init__(self, machine: "MachineController", **kwargs) -> None:
+    def __init__(self, machine: "MachineController") -> None:
         """Initialize TextUi."""
         super().__init__(machine)
         self.delay = DelayManager(machine)


### PR DESCRIPTION
@jabdoa2 refactored the TextUi as part of https://github.com/missionpinball/mpf/pull/1339, which improved the stability of the screen and provided a bunch more information (hurray!). Unfortunately for machines with 100+ machine and player variables, the overhead to maintain the UI had negative impacts on performance.

This PR introduces a config section `text_ui:` that allows a user to configure _which_ machine_vars and player_vars appear in the text UI. If unspecified, all will appear.

If approved, I'll update the docs to reflect the new options. Feedback/suggestions welcome!