### PR TITLE
prevent incorrect errors in virtual mode

### DIFF
--- a/mpf/devices/driver.py
+++ b/mpf/devices/driver.py
@@ -52,7 +52,7 @@ class Driver(SystemWideDevice):
             if not hasattr(coil, "hw_driver"):
                 # skip dual wound and other special devices
                 continue
-            key = (coil.platform, coil.hw_driver.number)
+            key = (coil.config['platform'], coil.hw_driver.number)
             if key in check_set:
                 raise AssertionError("Duplicate coil number {} for coil {}".format(coil.hw_driver.number, coil))
 

--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -122,7 +122,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
         for light in machine.lights:
             for drivers in light.hw_drivers.values():
                 for driver in drivers:
-                    key = (light.platform, driver.number, type(driver))
+                    key = (light.config['platform'], driver.number, type(driver))
                     if key in check_set:
                         raise AssertionError(
                             "Duplicate light number {} {} for light {}".format(

--- a/mpf/devices/switch.py
+++ b/mpf/devices/switch.py
@@ -64,7 +64,7 @@ class Switch(SystemWideDevice, DevicePositionMixin):
         del kwargs
         check_set = set()
         for switch in machine.switches:
-            key = (switch.platform, switch.hw_switch.number)
+            key = (switch.config['platform'], switch.hw_switch.number)
             if key in check_set:
                 raise AssertionError(
                     "Duplicate switch number {} for switch {}".format(

--- a/mpf/tests/machine_files/platform/config/test_virtual.yaml
+++ b/mpf/tests/machine_files/platform/config/test_virtual.yaml
@@ -5,6 +5,12 @@ switches:
         number: 1
         platform_settings:
             debounce_open: 20ms
+    switch1_p_roc:  # this should not cause duplicate switch exceptions
+        number: 1
+        platform: p_roc
+    switch1_p_fast:
+        number: 1
+        platform: fast
 
 coils:
     c_test:
@@ -18,3 +24,20 @@ coils:
     c_test_hold_power:
         number: 4
         default_hold_power: 0.1
+    coil1_p_roc:    # this should not cause duplicate coil exceptions
+        number: 1
+        platform: p_roc
+    coil1_fast:
+        number: 1
+        platform: fast
+
+# this should not cause duplicate light exceptions
+lights:
+    light1_p_roc:
+        number: 1
+        platform: p_roc
+    light1_fast:
+        number: 1
+        platform: fast
+    light1_virtual:
+        number: 1


### PR DESCRIPTION
only report duplicate coil/switch/light errors when using the same platform. this also applies when forcing MPF to use the virtual platform