### PR TITLE
Correct a couple __valid_in__ values in config_spec

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ their spare time, unpaid, for the love of pinball!
  * Adam Dziedzic <dziedada@umich.edu>
  * Michael Fuegemann <mfuegemann@yahoo.de>
  * Pinki Mansukhani <birdsofpassage7@gmail.com>
+ * Kevin Lee Drum <kevinleedrum@gmail.com>
 
 MPF is inspired by pyprocgame and skeletongame which were written by:
 

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1058,7 +1058,7 @@ rpi_dmd:
     daemon:             single|bool|False
     drop_privileges:    single|bool|True
 score_queue_player:
-    __valid_in__: modes
+    __valid_in__: mode
     int: single|template_int|None
 score_queues:
     __valid_in__: machine
@@ -1621,7 +1621,7 @@ trinamics_steprocker:
     __valid_in__: machine
     port: single|str|
 variable_player:
-    __valid_in__: modes
+    __valid_in__: mode
     int: single|template_int|None
     float: single|template_float|None
     string: single|str|None


### PR DESCRIPTION
This is probably inconsequential, but I found a couple sections in `config_spec.yaml` that had their `__valid_in__` values set to `modes`.  I'm pretty sure these should be `mode`, but please correct me if I'm wrong.