### PR TITLE
Fixed issue with setting number of LEDs per node

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1575,9 +1575,12 @@ spike:
     oc_time: single|ms|100
     default_debounce_open: single|ms|4
     default_debounce_close: single|ms|4
+    node_config: dict|int:subconfig(spike_node)|None
 spike_switch_overwrites:
     debounce_open: single|ms|None
     debounce_close: single|ms|None
+spike_node:
+    coil_priorities: list|int|None
 steppers:
     __valid_in__: machine
     __type__: device

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1581,6 +1581,8 @@ spike_switch_overwrites:
     debounce_close: single|ms|None
 spike_node:
     coil_priorities: list|int|None
+    num_leds: single|int|None
+    num_inputs: single|int|None
 steppers:
     __valid_in__: machine
     __type__: device

--- a/mpf/platforms/spike/spike.py
+++ b/mpf/platforms/spike/spike.py
@@ -1304,6 +1304,18 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
 
             await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetCoilCurrent, bytearray([0]), 12)
 
+        if self.node_firmware_version[node] >= 0x3100:
+            for node, config in self.config['node_config'].items():
+                if config['coil_priorities']:
+                    # configure coil priorities
+                    priority_response = await self.send_cmd_and_wait_for_response(
+                        node, SpikeNodebus.CoilSetPriority,
+                        bytearray([len(config['coil_priorities'])] + config['coil_priorities'] +
+                                  [len(config['coil_priorities'])]), 3)
+
+                    if not priority_response:
+                        self.log.warning("Failed to set coil priority on node %s", node)
+
         self.log.debug("Configuring traffic.")
         await self.send_cmd_sync(0, SpikeNodebus.SetTraffic, bytearray([0x11]))  # set traffic
 

--- a/mpf/platforms/spike/spike.py
+++ b/mpf/platforms/spike/spike.py
@@ -686,19 +686,41 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
         if number == "0-0":
             return SpikeBacklight(number, self, self.machine.clock.loop, 3)
 
+        try:
+            node, index = number.split("-")
+        except IndexError:
+            return self.raise_config_error("Light number has to have the syntax node-index but is: {}".format(number),
+                                           7)
+
+        if int(node) in self.config['node_config'] and \
+                self.config['node_config'][int(node)]['num_leds'] is not None and \
+                int(index) > self.config['node_config'][int(node)]['num_leds']:
+            return self.raise_config_error("Light {} is larger than the maximum configured led {} for "
+                                           "node {}".format(number,
+                                                            self.config['node_config'][int(node)]['num_leds'],
+                                                            node), 8)
+
         # TODO: validate that light number is not used in a stepper and a light
         return SpikeLight(number, self, self._light_system)
 
     def configure_switch(self, number: str, config: SwitchConfig, platform_config: dict):
         """Configure switch on Stern Spike."""
         try:
-            node, _ = number.split("-")
+            node, index = number.split("-")
         except IndexError:
             return self.raise_config_error("Switch number has to have the syntax node-index but is: {}".format(number),
                                            2)
 
         if int(node) not in self._nodes:
             self.raise_config_error("Node {} not known for switch {}".format(node, number), 3)
+
+        if int(node) in self.config['node_config'] and \
+                self.config['node_config'][int(node)]['num_inputs'] is not None and \
+                int(index) > self.config['node_config'][int(node)]['num_inputs']:
+            return self.raise_config_error("Switch {} is larger than the maximum configured input {} for "
+                                           "node {}".format(number,
+                                                            self.config['node_config'][int(node)]['num_inputs'],
+                                                            node), 6)
 
         switch = SpikeSwitch(config, number, self, platform_config)
         switch.configure_debounce_and_recycle(config.debounce, config.invert, False)
@@ -1260,8 +1282,8 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                 else:
                     self.log.warning("Did not get status for node %s", node)
 
-                # set 96 leds and 60 inputs for now. we can probably speed things up using this command
-                await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs, bytearray([0x60, 0, 0x3c, 0]))
+                # set 96 leds and 60 inputs during OC detection
+                await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs, bytearray([0x60, 0, 0x40, 0]))
 
                 # mask out all coils
                 await self.send_cmd_sync(node, SpikeNodebus.CoilSetMask, bytearray([0xff, 0x01]))
@@ -1298,6 +1320,13 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                                          bytearray([oc_time & 0xff, (oc_time >> 8) & 0xff]))
                 # set whatever spike sets
                 await self.send_cmd_sync(node, SpikeNodebus.CoilSetOCBehavior, bytearray([0x01]))
+
+                # set number of LEDs and inputs based on node config
+                if node in self.config['node_config'] and self.config['node_config'][node]["num_leds"] is not None and \
+                        self.config['node_config'][node]["num_inputs"] is not None:
+                    await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs,
+                                             bytearray([self.config['node_config'][node]["num_leds"], 0,
+                                                        self.config['node_config'][node]["num_inputs"], 0]))
 
             await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetCoilCurrent, bytearray([0]), 12)
 

--- a/mpf/platforms/spike/spike.py
+++ b/mpf/platforms/spike/spike.py
@@ -1261,7 +1261,7 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                     self.log.warning("Did not get status for node %s", node)
 
                 # set 96 leds and 60 inputs for now. we can probably speed things up using this command
-                await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs, bytearray([60, 0, 40, 0]))
+                await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs, bytearray([0x60, 0, 0x3c, 0]))
 
                 # mask out all coils
                 await self.send_cmd_sync(node, SpikeNodebus.CoilSetMask, bytearray([0xff, 0x01]))
@@ -1298,9 +1298,6 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                                          bytearray([oc_time & 0xff, (oc_time >> 8) & 0xff]))
                 # set whatever spike sets
                 await self.send_cmd_sync(node, SpikeNodebus.CoilSetOCBehavior, bytearray([0x01]))
-
-                # set 64 led and 64 inputs (RGB LEDs are not supported yet anyway)
-                await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs, bytearray([40, 0, 40, 0]))
 
             await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetCoilCurrent, bytearray([0]), 12)
 

--- a/mpf/platforms/spike/spike.py
+++ b/mpf/platforms/spike/spike.py
@@ -1251,8 +1251,8 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                 self.log.warning("Did not get status for node %s", node)
 
             if self.node_firmware_version[node] >= 0x3100:
-                self.log.debug("SetLEDMask, CoilSetMask, CoilSetOCTime, CoilSetOCBehavior, SetNumLEDsInputs and "
-                               "CoilSetPriority on node %s", node)
+                self.log.debug("SetLEDMask, CoilSetMask, CoilSetOCTime, CoilSetOCBehavior, and SetNumLEDsInputs "
+                               "on node %s", node)
 
                 node_status = await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetStatus, bytearray(), 10)
                 if node_status:
@@ -1303,24 +1303,6 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                 await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs, bytearray([40, 0, 40, 0]))
 
             await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetCoilCurrent, bytearray([0]), 12)
-
-        if self.node_firmware_version[node] >= 0x3100:
-            for node in self._nodes:
-                if node == 0:
-                    continue
-
-                # configure coil priorities
-                priority_response = await self.send_cmd_and_wait_for_response(
-                    node, SpikeNodebus.CoilSetPriority,
-                    bytearray([0x08, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]), 3)
-
-                if not priority_response:
-                    priority_response = await self.send_cmd_and_wait_for_response(
-                        node, SpikeNodebus.CoilSetPriority,
-                        bytearray([0x04, 0x00, 0x01, 0x02, 0x03, 0x04]), 3)
-
-                    if not priority_response:
-                        self.log.warning("Failed to set coil priority on node %s", node)
 
         self.log.debug("Configuring traffic.")
         await self.send_cmd_sync(0, SpikeNodebus.SetTraffic, bytearray([0x11]))  # set traffic

--- a/mpf/tests/machine_files/spike/config/config.yaml
+++ b/mpf/tests/machine_files/spike/config/config.yaml
@@ -10,8 +10,13 @@ spike:
    nodes: 0, 1, 8, 9, 10, 11
    poll_hz: 10
    node_config:
+     1:
+        num_leds: 16
+        num_inputs: 22
      8:
         coil_priorities: 0, 5, 6, 7, 1, 4, 3, 2
+        num_leds: 56
+        num_inputs: 16
      11:
         coil_priorities: 0, 1, 3, 5, 6, 7, 2, 4
 

--- a/mpf/tests/machine_files/spike/config/config.yaml
+++ b/mpf/tests/machine_files/spike/config/config.yaml
@@ -9,6 +9,11 @@ spike:
    debug: True
    nodes: 0, 1, 8, 9, 10, 11
    poll_hz: 10
+   node_config:
+     8:
+        coil_priorities: 0, 5, 6, 7, 1, 4, 3, 2
+     11:
+        coil_priorities: 0, 1, 3, 5, 6, 7, 2, 4
 
 coils:
   c_test:

--- a/mpf/tests/test_Spike.py
+++ b/mpf/tests/test_Spike.py
@@ -649,10 +649,12 @@ class SpikePlatformFirmware0_49Test(MpfTestCase):
                 self._checksummed_response(b'\x00'),  # set coil priorities
             self._checksummed_cmd(b'\x8b\x0c\x43\x08\x00\x01\x03\x05\x06\x07\x02\x04\x08', 3):
                 self._checksummed_response(b'\x00'),  # set coil priorities
+            self._checksummed_cmd(b'\x81\x06\x14\x10\x00\x16\x00'): b'',                # SetNumLEDsInputs,
+            self._checksummed_cmd(b'\x88\x06\x14\x38\x00\x10\x00'): b'',                # SetNumLEDsInputs,
         }
         for node in [b'\x81', b'\x88', b'\x89', b'\x8a', b'\x8b']:
             additional_commands = {
-                self._checksummed_cmd(node + b'\x06\x14\x3c\x00\x28\x00'): b'',                # SetNumLEDsInputs,
+                self._checksummed_cmd(node + b'\x06\x14\x60\x00\x40\x00'): b'',                # SetNumLEDsInputs,
                 self._checksummed_cmd(node + b'\x04\x46\xff\x01'): b'',                        # CoilSetMask
                 self._checksummed_cmd(node + b'\x0e\x72\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'): b'',
                 self._checksummed_cmd(node + b'\x04\x48\x06\x00'): b'',                        # SetOCTime
@@ -676,7 +678,6 @@ class SpikePlatformFirmware0_49Test(MpfTestCase):
                 self._checksummed_cmd(node + b'\x0e\x72\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'): b'',
                 self._checksummed_cmd(node + b'\x04\x48\x80\x00'): b'',                        # SetOCTime
                 self._checksummed_cmd(node + b'\x03\x44\x01'): b'',                            # SetOCTime
-                self._checksummed_cmd(node + b'\x06\x14\x28\x00\x28\x00'): b'',                # SetNumLEDsInputs,
             }
             self.serialMock.expected_commands.update(additional_commands)
 

--- a/mpf/tests/test_Spike.py
+++ b/mpf/tests/test_Spike.py
@@ -645,6 +645,10 @@ class SpikePlatformFirmware0_49Test(MpfTestCase):
             self._checksummed_cmd(b'\x88\x05\x70\x0d\x05\x05'): b'',  # set debounce
             self._checksummed_cmd(b'\x88\x05\x70\x0f\x05\x05'): b'',  # set debounce
             self._checksummed_cmd(b'\x8a\x05\x70\x01\x05\x05'): b'',  # set debounce
+            self._checksummed_cmd(b'\x88\x0c\x43\x08\x00\x05\x06\x07\x01\x04\x03\x02\x08', 3):
+                self._checksummed_response(b'\x00'),  # set coil priorities
+            self._checksummed_cmd(b'\x8b\x0c\x43\x08\x00\x01\x03\x05\x06\x07\x02\x04\x08', 3):
+                self._checksummed_response(b'\x00'),  # set coil priorities
         }
         for node in [b'\x81', b'\x88', b'\x89', b'\x8a', b'\x8b']:
             additional_commands = {
@@ -673,8 +677,6 @@ class SpikePlatformFirmware0_49Test(MpfTestCase):
                 self._checksummed_cmd(node + b'\x04\x48\x80\x00'): b'',                        # SetOCTime
                 self._checksummed_cmd(node + b'\x03\x44\x01'): b'',                            # SetOCTime
                 self._checksummed_cmd(node + b'\x06\x14\x28\x00\x28\x00'): b'',                # SetNumLEDsInputs,
-                self._checksummed_cmd(node + b'\x0c\x43\x08\x00\x01\x02\x03\x04\x05\x06\x07\x08', 3):
-                    self._checksummed_response(b'\x00'),    # set coil priorities
             }
             self.serialMock.expected_commands.update(additional_commands)
 


### PR DESCRIPTION
The comment says to set LEDs to 96 and switches to 60.  This wasn't what was happening in the code. As a result, some of the LEDs on some nodes weren't working if their indices were too large. Should mpf auto-detect the number of LEDs/switches based on what's in the config file and set this accordingly?