### PR TITLE
CoilSetPriority causing desyncs

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1575,9 +1575,12 @@ spike:
     oc_time: single|ms|100
     default_debounce_open: single|ms|4
     default_debounce_close: single|ms|4
+    node_config: dict|int:subconfig(spike_node)|None
 spike_switch_overwrites:
     debounce_open: single|ms|None
     debounce_close: single|ms|None
+spike_node:
+    coil_priorities: list|int|None
 steppers:
     __valid_in__: machine
     __type__: device

--- a/mpf/platforms/spike/spike.py
+++ b/mpf/platforms/spike/spike.py
@@ -1304,6 +1304,18 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
 
             await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetCoilCurrent, bytearray([0]), 12)
 
+        if self.node_firmware_version[node] >= 0x3100:
+            for node, config in self.config['node_config'].items():
+                if config['coil_priorities']:
+                    # configure coil priorities
+                    priority_response = await self.send_cmd_and_wait_for_response(
+                        node, SpikeNodebus.CoilSetPriority,
+                        bytearray([len(config['coil_priorities'])] + config['coil_priorities'] +
+                                  [len(config['coil_priorities'])]), 3)
+
+                    if not priority_response:
+                        self.log.warning("Failed to set coil priority on node %s", node)
+
         self.log.debug("Configuring traffic.")
         await self.send_cmd_sync(0, SpikeNodebus.SetTraffic, bytearray([0x11]))  # set traffic
 

--- a/mpf/platforms/spike/spike.py
+++ b/mpf/platforms/spike/spike.py
@@ -1251,8 +1251,8 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                 self.log.warning("Did not get status for node %s", node)
 
             if self.node_firmware_version[node] >= 0x3100:
-                self.log.debug("SetLEDMask, CoilSetMask, CoilSetOCTime, CoilSetOCBehavior, SetNumLEDsInputs and "
-                               "CoilSetPriority on node %s", node)
+                self.log.debug("SetLEDMask, CoilSetMask, CoilSetOCTime, CoilSetOCBehavior, and SetNumLEDsInputs "
+                               "on node %s", node)
 
                 node_status = await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetStatus, bytearray(), 10)
                 if node_status:
@@ -1303,24 +1303,6 @@ class SpikePlatform(SwitchPlatform, LightsPlatform, DriverPlatform, DmdPlatform,
                 await self.send_cmd_sync(node, SpikeNodebus.SetNumLEDsInputs, bytearray([40, 0, 40, 0]))
 
             await self.send_cmd_and_wait_for_response(node, SpikeNodebus.GetCoilCurrent, bytearray([0]), 12)
-
-        if self.node_firmware_version[node] >= 0x3100:
-            for node in self._nodes:
-                if node == 0:
-                    continue
-
-                # configure coil priorities
-                priority_response = await self.send_cmd_and_wait_for_response(
-                    node, SpikeNodebus.CoilSetPriority,
-                    bytearray([0x08, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]), 3)
-
-                if not priority_response:
-                    priority_response = await self.send_cmd_and_wait_for_response(
-                        node, SpikeNodebus.CoilSetPriority,
-                        bytearray([0x04, 0x00, 0x01, 0x02, 0x03, 0x04]), 3)
-
-                    if not priority_response:
-                        self.log.warning("Failed to set coil priority on node %s", node)
 
         self.log.debug("Configuring traffic.")
         await self.send_cmd_sync(0, SpikeNodebus.SetTraffic, bytearray([0x11]))  # set traffic

--- a/mpf/tests/machine_files/spike/config/config.yaml
+++ b/mpf/tests/machine_files/spike/config/config.yaml
@@ -9,6 +9,11 @@ spike:
    debug: True
    nodes: 0, 1, 8, 9, 10, 11
    poll_hz: 10
+   node_config:
+     8:
+        coil_priorities: 0, 5, 6, 7, 1, 4, 3, 2
+     11:
+        coil_priorities: 0, 1, 3, 5, 6, 7, 2, 4
 
 coils:
   c_test:

--- a/mpf/tests/test_Spike.py
+++ b/mpf/tests/test_Spike.py
@@ -645,6 +645,10 @@ class SpikePlatformFirmware0_49Test(MpfTestCase):
             self._checksummed_cmd(b'\x88\x05\x70\x0d\x05\x05'): b'',  # set debounce
             self._checksummed_cmd(b'\x88\x05\x70\x0f\x05\x05'): b'',  # set debounce
             self._checksummed_cmd(b'\x8a\x05\x70\x01\x05\x05'): b'',  # set debounce
+            self._checksummed_cmd(b'\x88\x0c\x43\x08\x00\x05\x06\x07\x01\x04\x03\x02\x08', 3):
+                self._checksummed_response(b'\x00'),  # set coil priorities
+            self._checksummed_cmd(b'\x8b\x0c\x43\x08\x00\x01\x03\x05\x06\x07\x02\x04\x08', 3):
+                self._checksummed_response(b'\x00'),  # set coil priorities
         }
         for node in [b'\x81', b'\x88', b'\x89', b'\x8a', b'\x8b']:
             additional_commands = {
@@ -673,8 +677,6 @@ class SpikePlatformFirmware0_49Test(MpfTestCase):
                 self._checksummed_cmd(node + b'\x04\x48\x80\x00'): b'',                        # SetOCTime
                 self._checksummed_cmd(node + b'\x03\x44\x01'): b'',                            # SetOCTime
                 self._checksummed_cmd(node + b'\x06\x14\x28\x00\x28\x00'): b'',                # SetNumLEDsInputs,
-                self._checksummed_cmd(node + b'\x0c\x43\x08\x00\x01\x02\x03\x04\x05\x06\x07\x08', 3):
-                    self._checksummed_response(b'\x00'),    # set coil priorities
             }
             self.serialMock.expected_commands.update(additional_commands)
 


### PR DESCRIPTION
The CoilSetPriority command is causing a desync condition on Node 9 and above.  If I recall right, this was added to troubleshoot hardware rules and isn't strictly required by spike, so I removed it.