### PR TITLE
Ball save dynamic values

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -199,7 +199,7 @@ ball_saves:
     __valid_in__: machine, mode
     __type__: device
     source_playfield: single|machine(ball_devices)|playfield
-    active_time: single|template_secs|0
+    active_time: single|template_ms|0
     eject_delay: single|ms|0
     only_last_ball: single|bool|False
     hurry_up_time: single|ms|0

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -199,7 +199,7 @@ ball_saves:
     __valid_in__: machine, mode
     __type__: device
     source_playfield: single|machine(ball_devices)|playfield
-    active_time: single|template_ms|0
+    active_time: single|template_secs|0
     eject_delay: single|ms|0
     only_last_ball: single|bool|False
     hurry_up_time: single|ms|0

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -199,7 +199,7 @@ ball_saves:
     __valid_in__: machine, mode
     __type__: device
     source_playfield: single|machine(ball_devices)|playfield
-    active_time: single|ms|0
+    active_time: single|template_secs|0
     eject_delay: single|ms|0
     only_last_ball: single|bool|False
     hurry_up_time: single|ms|0

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -76,7 +76,7 @@ class BallSave(SystemWideDevice, ModeDevice):
         self.enabled = True
         self.state = 'enabled'
         self.active_time = self.config['active_time'].evaluate([])
-        self.debug_log("Enabling. Auto launch: {}, Balls to save: {}, Active time: {} ms".format(
+        self.debug_log("Enabling. Auto launch: {}, Balls to save: {}, Active time: {}s".format(
                        self.config['auto_launch'],
                        self.config['balls_to_save'],
                        self.active_time))
@@ -143,17 +143,17 @@ class BallSave(SystemWideDevice, ModeDevice):
 
         if self.active_time > 0:
             self.debug_log('Starting ball save timer: %ss',
-                           self.active_time / 1000.0)
-
+                           self.active_time)
+            active_time_ms = self.active_time * 1000
             self.delay.add(name='disable',
-                           ms=(self.active_time +
+                           ms=(active_time_ms +
                                self.config['grace_period']),
                            callback=self.disable)
             self.delay.add(name='grace_period',
-                           ms=self.active_time,
+                           ms=active_time_ms,
                            callback=self._grace_period)
             self.delay.add(name='hurry_up',
-                           ms=(self.active_time -
+                           ms=(active_time_ms -
                                self.config['hurry_up_time']),
                            callback=self._hurry_up)
 

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -23,8 +23,8 @@ class BallSave(SystemWideDevice, ModeDevice):
     collection = 'ball_saves'
     class_label = 'ball_save'
 
-    __slots__ = ["active_time", "unlimited_saves", "source_playfield", "delay", "enabled", "timer_started", "saves_remaining",
-                 "early_saved", "state", "_scheduled_balls"]
+    __slots__ = ["active_time", "unlimited_saves", "source_playfield", "delay", "enabled", "timer_started",
+                 "saves_remaining", "early_saved", "state", "_scheduled_balls"]
 
     def __init__(self, machine: "MachineController", name: str) -> None:
         """Initialise ball save."""

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -76,7 +76,7 @@ class BallSave(SystemWideDevice, ModeDevice):
         self.enabled = True
         self.state = 'enabled'
         self.active_time = self.config['active_time'].evaluate([])
-        self.debug_log("Enabling. Auto launch: {}, Balls to save: {}, Active time: {}".format(
+        self.debug_log("Enabling. Auto launch: {}, Balls to save: {}, Active time: {} ms".format(
                        self.config['auto_launch'],
                        self.config['balls_to_save'],
                        self.active_time))

--- a/mpf/tests/machine_files/ball_save/config/config.yaml
+++ b/mpf/tests/machine_files/ball_save/config/config.yaml
@@ -77,3 +77,6 @@ ball_saves:
     unlimited_delay:
         enable_events: enable5
         delayed_eject_events: eject5
+    dynamic_active_time:
+        active_time: current_player.save_time
+        enable_events: enable6

--- a/mpf/tests/test_BallSave.py
+++ b/mpf/tests/test_BallSave.py
@@ -495,8 +495,8 @@ class TestBallSave(MpfGameTestCase):
         self.advance_time_and_run(10)
         self.assertBallNumber(1)
 
-        # Set a player value that's very short, like 3s
-        self.machine.game.player["save_time"] = 3000
+        # Set a player value that's very short, like 2s
+        self.machine.game.player["save_time"] = 2
         self.post_event('enable6')
         self.advance_time_and_run()
         # Make sure the save is active
@@ -507,7 +507,7 @@ class TestBallSave(MpfGameTestCase):
         self.assertFalse(self.machine.ball_saves["dynamic_active_time"].enabled)
 
         # Set a player value that's longer and run the same tests
-        self.machine.game.player["save_time"] = 6000
+        self.machine.game.player["save_time"] = 10
         self.post_event('enable6')
         self.advance_time_and_run()
         # Make sure the save is active

--- a/mpf/tests/test_BallSave.py
+++ b/mpf/tests/test_BallSave.py
@@ -484,3 +484,35 @@ class TestBallSave(MpfGameTestCase):
         self.drain_all_balls()
         self.advance_time_and_run()
         self.assertGameIsNotRunning()
+
+    def test_dynamic_active_time(self):
+        # prepare game
+        self.fill_troughs()
+        self.advance_time_and_run()
+
+        # start game
+        self.start_game()
+        self.advance_time_and_run(10)
+        self.assertBallNumber(1)
+
+        # Set a player value that's very short, like 3s
+        self.machine.game.player["save_time"] = 3000
+        self.post_event('enable6')
+        self.advance_time_and_run()
+        # Make sure the save is active
+        self.assertTrue(self.machine.ball_saves["dynamic_active_time"].enabled)
+        # Run out the short time
+        self.advance_time_and_run(4)
+        # The ball save should be finished now
+        self.assertFalse(self.machine.ball_saves["dynamic_active_time"].enabled)
+
+        # Set a player value that's longer and run the same tests
+        self.machine.game.player["save_time"] = 6000
+        self.post_event('enable6')
+        self.advance_time_and_run()
+        # Make sure the save is active
+        self.assertTrue(self.machine.ball_saves["dynamic_active_time"].enabled)
+        # Run out the short time
+        self.advance_time_and_run(4)
+        # The ball save should still be active
+        self.assertTrue(self.machine.ball_saves["dynamic_active_time"].enabled)


### PR DESCRIPTION
This PR extends the behavior of `BallSave` to accept templates as the active time value. The default behavior is unchanged, so this change shouldn't break any existing code.

This change allows the use case where a player may earn a reward that increases their ball save time. The existing ball save(s) can be used and the active time changed on-the-fly.

```
ball_saves:
  default:
    active_time: 30 if current_player.extended_save else 10
  dynamic:
    active_time: 20 * (1 + current_player.ball_save_bonus_pct)
```

For readability, the `active_time` integer value is assumed to be _secs_ rather than _ms_. There is no functional difference, but it "feels" more natural to say `active_time: 30` rather than `active_time: 30000`.

Tests included!