### PR TITLE
Auto-detect FAST device ports

### DIFF
--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -7,7 +7,7 @@ boards.
 import os
 from copy import deepcopy
 from distutils.version import StrictVersion
-
+import serial.tools.list_ports
 from typing import Dict, Set
 
 from mpf.platforms.fast.fast_io_board import FastIoBoard
@@ -230,7 +230,31 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, DmdPlatform,
         This process will cause the connection threads to figure out which processor they've connected to
         and to register themselves.
         """
-        for port in self.config['ports']:
+        ports = None
+        if self.config['ports'][0] == "autodetect":
+            devices = [port.device for port in serial.tools.list_ports.comports()]
+            # Look for four devices with sequential tails of 0-3 or A-D
+            SEQS = (("Q", "1", "2", "3"), ("Q", "B", "C", "D"))
+            for d in devices:
+                for seq in SEQS:
+                    if d[-1] == seq[0]:
+                        root = d[:-1]
+                        if "{}{}".format(root, seq[1]) in devices and \
+                           "{}{}".format(root, seq[2]) in devices and \
+                           "{}{}".format(root, seq[3]) in devices:
+                           ports = ("{}{}".format(root, seq[1]), "{}{}".format(root, seq[2]))
+                           self.debug_log("Autodetect found ports! {}".format(ports))
+                           break
+                # If ports were found, skip the rest of the devices
+                if ports:
+                    break
+            if not ports:
+                raise RuntimeError("Unable to auto-detect FAST hardware from available devices: {}".format(
+                            ", ".join(devices)))
+        else:
+            ports = self.config['ports']
+
+        for port in ports:
             comm = FastSerialCommunicator(platform=self, port=port,
                                           baud=self.config['baud'])
             await comm.connect()

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -7,8 +7,8 @@ boards.
 import os
 from copy import deepcopy
 from distutils.version import StrictVersion
-import serial.tools.list_ports
 from typing import Dict, Set
+import serial.tools.list_ports
 
 from mpf.platforms.fast.fast_io_board import FastIoBoard
 from mpf.platforms.fast.fast_servo import FastServo
@@ -234,23 +234,23 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, DmdPlatform,
         if self.config['ports'][0] == "autodetect":
             devices = [port.device for port in serial.tools.list_ports.comports()]
             # Look for four devices with sequential tails of 0-3 or A-D
-            SEQS = (("Q", "1", "2", "3"), ("Q", "B", "C", "D"))
+            seqs = (("0", "1", "2", "3"), ("A", "B", "C", "D"))
             for d in devices:
-                for seq in SEQS:
+                for seq in seqs:
                     if d[-1] == seq[0]:
                         root = d[:-1]
                         if "{}{}".format(root, seq[1]) in devices and \
                            "{}{}".format(root, seq[2]) in devices and \
                            "{}{}".format(root, seq[3]) in devices:
-                           ports = ("{}{}".format(root, seq[1]), "{}{}".format(root, seq[2]))
-                           self.debug_log("Autodetect found ports! {}".format(ports))
-                           break
+                            ports = ("{}{}".format(root, seq[1]), "{}{}".format(root, seq[2]))
+                            self.debug_log("Autodetect found ports! {}".format(ports))
+                            break
                 # If ports were found, skip the rest of the devices
                 if ports:
                     break
             if not ports:
                 raise RuntimeError("Unable to auto-detect FAST hardware from available devices: {}".format(
-                            ", ".join(devices)))
+                                   ", ".join(devices)))
         else:
             ports = self.config['ports']
 


### PR DESCRIPTION
This PR enables the auto-detection of FAST hardware on serial ports. It's a crude, first-draft implementation, but it seems to work well on my hardware.

This change is to support people who use multiple machines to power their hardware, and/or have multiple USB ports that assign different `tty` ports to the same device. With the `autodetect` feature, these people don't have to change their hardware config each time they switch computers or USB ports.

With the `ports: autodetect` feature, MPF will attempt to find four tty devices with identical, sequential names ending in `0-4` or `A-D`. If it finds those four, it assumes that the middle two are the FAST Net and RGB devices.

It may not be the most performant approach, but this routine is used only once at bootup so it shouldn't be too bad...