### PR TITLE
Support 'priority' for ball_hold and ball_lock devices

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -171,6 +171,7 @@ ball_holds:
     source_playfield: single|machine(ball_devices)|playfield
     enable_events: event_handler|str:ms|None
     disable_events: event_handler|str:ms|None
+    priority: single|int|0
     reset_events: event_handler|str:ms|machine_reset_phase_3, ball_starting, ball_will_end, service_mode_entered
     release_one_events: event_handler|str:ms|None
     release_all_events: event_handler|str:ms|None
@@ -904,6 +905,7 @@ multiball_locks:
     enable_events: event_handler|str:ms|None
     disable_events: event_handler|str:ms|None
     locked_ball_counting_strategy: single|enum(virtual_only,min_virtual_physical,physical_only,no_virtual)|virtual_only
+    priority: single|int|1
     reset_all_counts_events: event_handler|str:ms|None
     reset_count_for_current_player_events: event_handler|str:ms|None
 mypinballs:

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -210,7 +210,7 @@ class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
         return balls_released
 
     def _register_handlers(self):
-        priority = (self.mode and self.mode.priority or 0) + \
+        priority = (self.mode.priority if self.mode else 0) + \
             self.config['priority']
         # register on ball_enter of hold_devices
         for device in self.hold_devices:

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -210,7 +210,7 @@ class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
         return balls_released
 
     def _register_handlers(self):
-        priority = (self.mode and self.mode.priority or 0) +
+        priority = (self.mode and self.mode.priority or 0) + \
             self.config['priority']
         # register on ball_enter of hold_devices
         for device in self.hold_devices:

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -210,7 +210,8 @@ class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
         return balls_released
 
     def _register_handlers(self):
-        priority = self.mode.priority + self.config['priority']
+        priority = (self.mode and self.mode.priority or 0) +
+            self.config['priority']
         # register on ball_enter of hold_devices
         for device in self.hold_devices:
             self.machine.events.add_handler(

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -210,11 +210,12 @@ class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
         return balls_released
 
     def _register_handlers(self):
+        priority = self.mode.priority + self.config['priority']
         # register on ball_enter of hold_devices
         for device in self.hold_devices:
             self.machine.events.add_handler(
                 'balldevice_' + device.name + '_ball_enter',
-                self._hold_ball, device=device)
+                self._hold_ball, device=device, priority=priority)
 
     def _unregister_handlers(self):
         # unregister ball_enter handlers

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -144,7 +144,8 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
                 self.config['locked_ball_counting_strategy']))
 
     def _register_handlers(self):
-        priority = self.mode.priority + self.config['priority']
+        priority = (self.mode and self.mode.priority or 0) +
+            self.config['priority']
         # register on ball_enter of lock_devices
         for device in self.lock_devices:
             self.machine.events.add_handler(

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -144,7 +144,7 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
                 self.config['locked_ball_counting_strategy']))
 
     def _register_handlers(self):
-        priority = (self.mode and self.mode.priority or 0) +
+        priority = (self.mode and self.mode.priority or 0) + \
             self.config['priority']
         # register on ball_enter of lock_devices
         for device in self.lock_devices:

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -144,14 +144,15 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
                 self.config['locked_ball_counting_strategy']))
 
     def _register_handlers(self):
+        priority = self.mode.priority + self.config['priority']
         # register on ball_enter of lock_devices
         for device in self.lock_devices:
             self.machine.events.add_handler(
                 'balldevice_' + device.name + '_ball_enter',
-                self._lock_ball, device=device, priority=self.mode.priority)
+                self._lock_ball, device=device, priority=priority)
             self.machine.events.add_handler(
                 'balldevice_' + device.name + '_ball_entered',
-                self._post_events, device=device, priority=self.mode.priority)
+                self._post_events, device=device, priority=priority)
 
     def _unregister_handlers(self):
         # unregister ball_enter handlers

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -144,7 +144,7 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
                 self.config['locked_ball_counting_strategy']))
 
     def _register_handlers(self):
-        priority = (self.mode and self.mode.priority or 0) + \
+        priority = (self.mode.priority if self.mode else 0) + \
             self.config['priority']
         # register on ball_enter of lock_devices
         for device in self.lock_devices:


### PR DESCRIPTION
This PR adjusts the behavior for `ball_holds` and `ball_locks` to support relative priority.

Currently, when a ball lock creates its _ball_enter_ handler, it uses the priority of the mode it's in. When a ball hold creates its _ball_enter_ handler, it uses no priority.

This change configures both holds and locks to use the mode priority *plus* an optional `priority:` config value. As a result, a ball hold and ball lock in the same mode can have a predictable order of event handling.