### PR TITLE
Include 'triggering_switch' in combo switch events

### DIFF
--- a/mpf/core/switch_controller.py
+++ b/mpf/core/switch_controller.py
@@ -585,6 +585,12 @@ class SwitchController(MpfController):
         self.remove_switch_handler_obj(switch_handler.switch_name, switch_handler.callback, switch_handler.state,
                                        switch_handler.ms)
 
+    def remove_switch_handler_by_keys(self, switch_handlers: List[SwitchHandler]):
+        """Remove switch handlers by list of keys returned from add_switch_handler."""
+        for switch_handler in switch_handlers:
+            self.remove_switch_handler_obj(switch_handler.switch_name, switch_handler.callback, switch_handler.state,
+                                           switch_handler.ms)
+
     def remove_switch_handler(self, switch_name, callback, state=1, ms=0):
         """Remove a registered switch handler.
 

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -1,4 +1,6 @@
 """Contains the Combo Switch device class."""
+from functools import partial
+
 from mpf.core.delays import DelayManager
 from mpf.core.device_monitor import DeviceMonitor
 from mpf.core.mode import Mode
@@ -119,7 +121,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
             self._activate_switches_1(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['hold_time'],
-                                           self._activate_switches_1,
+                                           partial(self._activate_switches_1, switch_name),
                                            'switch_1_active')
 
     def _switch_2_went_active(self, switch_name, **kwargs):
@@ -134,7 +136,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
             self._activate_switches_2(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['hold_time'],
-                                           self._activate_switches_2,
+                                           partial(self._activate_switches_2, switch_name),
                                            'switch_2_active')
 
     def _switch_1_went_inactive(self, switch_name, **kwargs):
@@ -151,7 +153,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
             self._release_switches_1(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['release_time'],
-                                           self._release_switches_1,
+                                           partial(self._release_switches_1, switch_name),
                                            'switch_1_inactive')
 
     def _switch_2_went_inactive(self, switch_name, **kwargs):
@@ -168,7 +170,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
             self._release_switches_2(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['release_time'],
-                                           self._release_switches_2,
+                                           partial(self._release_switches_2, switch_name),
                                            'switch_2_inactive')
 
     def _activate_switches_1(self, switch_name):

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -186,7 +186,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
 
                 return
 
-            self._switch_state('both')
+            self._switch_state('both', triggering_switch=1)
         elif self.config['max_offset_time'] >= 0:
             self.delay.add_if_doesnt_exist(self.config['max_offset_time'] * 1000, self._post_only_one_active_event,
                                            "switch_1_only", number=1)
@@ -208,7 +208,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
                                self.config['max_offset_time'])
                 return
 
-            self._switch_state('both')
+            self._switch_state('both', triggering_switch=2)
         elif self.config['max_offset_time'] >= 0:
             self.delay.add_if_doesnt_exist(self.config['max_offset_time'] * 1000, self._post_only_one_active_event,
                                            "switch_2_only", number=2)
@@ -222,20 +222,20 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
                        'releases')
         self._switches_1_active = None
         if self._switches_2_active and self._state == 'both':
-            self._switch_state('one')
+            self._switch_state('one', triggering_switch=1)
         elif self._state == 'one':
-            self._switch_state('inactive')
+            self._switch_state('inactive', triggering_switch=1)
 
     def _release_switches_2(self):
         self.debug_log('Switches_2 has passed the release time and is now '
                        'releases')
         self._switches_2_active = None
         if self._switches_1_active and self._state == 'both':
-            self._switch_state('one')
+            self._switch_state('one', triggering_switch=2)
         elif self._state == 'one':
-            self._switch_state('inactive')
+            self._switch_state('inactive', triggering_switch=2)
 
-    def _switch_state(self, state):
+    def _switch_state(self, state, triggering_switch):
         """Post events for current step."""
         if state not in self.states:
             raise ValueError("Received invalid state: {}".format(state))
@@ -247,7 +247,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self.debug_log("New State: %s", state)
 
         for event in self.config['events_when_{}'.format(state)]:
-            self.machine.events.post(event)
+            self.machine.events.post(event, triggering_switch=triggering_switch)
             '''event: (combo_switch)_(state)
             desc: Combo switch (name) changed to state (state).
 

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -108,6 +108,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self.delay.clear()
 
     def _switch_1_went_active(self, switch_name, **kwargs):
+        del kwargs
         self.debug_log('A switch from switches_1 just went active')
         self.delay.remove('switch_1_inactive')
 
@@ -122,6 +123,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
                                            'switch_1_active')
 
     def _switch_2_went_active(self, switch_name, **kwargs):
+        del kwargs
         self.debug_log('A switch from switches_2 just went active')
         self.delay.remove('switch_2_inactive')
 
@@ -136,6 +138,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
                                            'switch_2_active')
 
     def _switch_1_went_inactive(self, switch_name, **kwargs):
+        del kwargs
         self.debug_log('A switch from switches_1 just went inactive')
         for switch in self.config['switches_1']:
             if switch.state:
@@ -152,6 +155,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
                                            'switch_1_inactive')
 
     def _switch_2_went_inactive(self, switch_name, **kwargs):
+        del kwargs
         self.debug_log('A switch from switches_2 just went inactive')
         for switch in self.config['switches_2']:
             if switch.state:

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -88,26 +88,26 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
 
     def _register_switch_handlers(self):
         for switch in self.config['switches_1']:
-            switch.add_handler(self._switch_1_went_active, state=1)
-            switch.add_handler(self._switch_1_went_inactive, state=0)
+            switch.add_handler(self._switch_1_went_active, state=1, return_info=True)
+            switch.add_handler(self._switch_1_went_inactive, state=0, return_info=True)
 
         for switch in self.config['switches_2']:
-            switch.add_handler(self._switch_2_went_active, state=1)
-            switch.add_handler(self._switch_2_went_inactive, state=0)
+            switch.add_handler(self._switch_2_went_active, state=1, return_info=True)
+            switch.add_handler(self._switch_2_went_inactive, state=0, return_info=True)
 
     def _remove_switch_handlers(self):
         for switch in self.config['switches_1']:
-            switch.remove_handler(self._switch_1_went_active, state=1)
-            switch.remove_handler(self._switch_1_went_inactive, state=0)
+            switch.remove_handler(self._switch_1_went_active, state=1, return_info=True)
+            switch.remove_handler(self._switch_1_went_inactive, state=0, return_info=True)
 
         for switch in self.config['switches_2']:
-            switch.remove_handler(self._switch_2_went_active, state=1)
-            switch.remove_handler(self._switch_2_went_inactive, state=0)
+            switch.remove_handler(self._switch_2_went_active, state=1, return_info=True)
+            switch.remove_handler(self._switch_2_went_inactive, state=0, return_info=True)
 
     def _kill_delays(self):
         self.delay.clear()
 
-    def _switch_1_went_active(self):
+    def _switch_1_went_active(self, switch_name, **kwargs):
         self.debug_log('A switch from switches_1 just went active')
         self.delay.remove('switch_1_inactive')
 
@@ -115,13 +115,13 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
             return
 
         if not self.config['hold_time']:
-            self._activate_switches_1()
+            self._activate_switches_1(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['hold_time'],
                                            self._activate_switches_1,
                                            'switch_1_active')
 
-    def _switch_2_went_active(self):
+    def _switch_2_went_active(self, switch_name, **kwargs):
         self.debug_log('A switch from switches_2 just went active')
         self.delay.remove('switch_2_inactive')
 
@@ -129,13 +129,13 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
             return
 
         if not self.config['hold_time']:
-            self._activate_switches_2()
+            self._activate_switches_2(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['hold_time'],
                                            self._activate_switches_2,
                                            'switch_2_active')
 
-    def _switch_1_went_inactive(self):
+    def _switch_1_went_inactive(self, switch_name, **kwargs):
         self.debug_log('A switch from switches_1 just went inactive')
         for switch in self.config['switches_1']:
             if switch.state:
@@ -145,13 +145,13 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self.delay.remove('switch_1_active')
 
         if not self.config['release_time']:
-            self._release_switches_1()
+            self._release_switches_1(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['release_time'],
                                            self._release_switches_1,
                                            'switch_1_inactive')
 
-    def _switch_2_went_inactive(self):
+    def _switch_2_went_inactive(self, switch_name, **kwargs):
         self.debug_log('A switch from switches_2 just went inactive')
         for switch in self.config['switches_2']:
             if switch.state:
@@ -161,13 +161,13 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self.delay.remove('switch_2_active')
 
         if not self.config['release_time']:
-            self._release_switches_2()
+            self._release_switches_2(switch_name)
         else:
             self.delay.add_if_doesnt_exist(self.config['release_time'],
                                            self._release_switches_2,
                                            'switch_2_inactive')
 
-    def _activate_switches_1(self):
+    def _activate_switches_1(self, switch_name):
         self.debug_log('Switches_1 has passed the hold time and is now '
                        'active')
         self._switches_1_active = self.machine.clock.get_time()
@@ -186,12 +186,12 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
 
                 return
 
-            self._switch_state('both', triggering_switch=1)
+            self._switch_state('both', group=1, switch=switch_name)
         elif self.config['max_offset_time'] >= 0:
             self.delay.add_if_doesnt_exist(self.config['max_offset_time'] * 1000, self._post_only_one_active_event,
                                            "switch_1_only", number=1)
 
-    def _activate_switches_2(self):
+    def _activate_switches_2(self, switch_name):
         self.debug_log('Switches_2 has passed the hold time and is now '
                        'active')
         self._switches_2_active = self.machine.clock.get_time()
@@ -208,7 +208,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
                                self.config['max_offset_time'])
                 return
 
-            self._switch_state('both', triggering_switch=2)
+            self._switch_state('both', group=2, switch=switch_name)
         elif self.config['max_offset_time'] >= 0:
             self.delay.add_if_doesnt_exist(self.config['max_offset_time'] * 1000, self._post_only_one_active_event,
                                            "switch_2_only", number=2)
@@ -217,25 +217,25 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         for event in self.config['events_when_switches_{}'.format(number)]:
             self.machine.events.post(event)
 
-    def _release_switches_1(self):
+    def _release_switches_1(self, switch_name):
         self.debug_log('Switches_1 has passed the release time and is now '
                        'releases')
         self._switches_1_active = None
         if self._switches_2_active and self._state == 'both':
-            self._switch_state('one', triggering_switch=1)
+            self._switch_state('one', group=1, switch=switch_name)
         elif self._state == 'one':
-            self._switch_state('inactive', triggering_switch=1)
+            self._switch_state('inactive', group=1, switch=switch_name)
 
-    def _release_switches_2(self):
+    def _release_switches_2(self, switch_name):
         self.debug_log('Switches_2 has passed the release time and is now '
                        'releases')
         self._switches_2_active = None
         if self._switches_1_active and self._state == 'both':
-            self._switch_state('one', triggering_switch=2)
+            self._switch_state('one', group=2, switch=switch_name)
         elif self._state == 'one':
-            self._switch_state('inactive', triggering_switch=2)
+            self._switch_state('inactive', group=2, switch=switch_name)
 
-    def _switch_state(self, state, triggering_switch):
+    def _switch_state(self, state, group, switch):
         """Post events for current step."""
         if state not in self.states:
             raise ValueError("Received invalid state: {}".format(state))
@@ -247,7 +247,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self.debug_log("New State: %s", state)
 
         for event in self.config['events_when_{}'.format(state)]:
-            self.machine.events.post(event, triggering_switch=triggering_switch)
+            self.machine.events.post(event, triggering_group=group, triggering_switch=switch)
             '''event: (combo_switch)_(state)
             desc: Combo switch (name) changed to state (state).
 


### PR DESCRIPTION
This PR adds a new kwarg, `triggering_switch`, to events posted by a ComboSwitch device.

When the player enters a combination switch, e.g. hold one flipper and press the other, it can be useful to know _which_ switch was hit when. Currently this requires quite a bit of logic to implement.

With this PR, the combo events include a kwarg `triggering_switch` that declares the `tag:` group number of the switch that caused the event.

For example:
```
combo_switches:
  both_flippers:
    tag_1: left_flipper
    tag_2: right_flipper
    events_when_both: flipper_cancel
```

Player holds left flipper, presses right flipper:
```
Event: ======'both_flippers'====== Args={'triggering_switch': 2}
```
Player releases left flipper, still holding right:
```
Event: ======'both_flippers_one'====== Args={'triggering_switch': 1}
```

This change makes it easy for game logic to perform actions based on combo switches, for example rotating selections left or right by holding one flipper and pressing the other, or triggering event based on which direction an orbit shot was completed in.
