### PR TITLE
Allow Fast RGB crashes to be ignored

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -552,6 +552,7 @@ fast:
     console_log: single|enum(none,basic,full)|none
     file_log: single|enum(none,basic,full)|basic
     firmware_updates: list|subconfig(fast_firmware_update)|None
+    ignore_rgb_crash: single|bool|False
 fast_firmware_update:
     type: single|enum(net,rgb)|
     file: single|str|

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -863,10 +863,9 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, DmdPlatform,
             remote_processor == self.rgb_connection.remote_processor
         if msg in ('00', '02'):
             action = "Ignoring RGB crash and continuing play." if ignore_rgb else "MPF will exit now."
-            self.error_log("The FAST {} processor rebooted. Unfortunately, that means that it lost all it's state "
-                           "(such as hardware rules or switch configs). This is likely cause by an unstable power "
-                           "supply but it might as well be a firmware bug. {}"
-                           .format(remote_processor, action))
+            self.error_log("The FAST %s processor rebooted. Unfortunately, that means that it lost all its state "
+                           "(such as hardware rules or switch configs). This is likely caused by an unstable "
+                           "power supply but it might also be a firmware bug. %s", remote_processor, action)
             if ignore_rgb:
                 self.machine.events.post("fast_rgb_rebooted", msg=msg)
                 return

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -859,8 +859,15 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, DmdPlatform,
     def receive_bootloader(self, msg, remote_processor):
         """Process bootloader message."""
         self.debug_log("Got Bootloader message: %s from", msg, remote_processor)
+        ignore_rgb = self.config['ignore_rgb_crash'] and \
+            remote_processor == self.rgb_connection.remote_processor
         if msg in ('00', '02'):
-            self.error_log("The FAST %s processor rebooted. Unfortunately, that means that it lost all it's state "
+            self.error_log("The FAST {} processor rebooted. Unfortunately, that means that it lost all it's state "
                            "(such as hardware rules or switch configs). This is likely cause by an unstable power "
-                           "supply but it might as well be a firmware bug. MPF will exit now.", remote_processor)
+                           "supply but it might as well be a firmware bug. {}".format(
+                                remote_processor,
+                                "Ignoring RGB crash and continuing play." if ignore_rgb else "MPF will exit now."))
+            if ignore_rgb:
+                self.machine.events.post("fast_rgb_rebooted", msg=msg)
+                return
             self.machine.stop("FAST {} rebooted during game".format(remote_processor))

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -862,11 +862,11 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, DmdPlatform,
         ignore_rgb = self.config['ignore_rgb_crash'] and \
             remote_processor == self.rgb_connection.remote_processor
         if msg in ('00', '02'):
+            action = "Ignoring RGB crash and continuing play." if ignore_rgb else "MPF will exit now."
             self.error_log("The FAST {} processor rebooted. Unfortunately, that means that it lost all it's state "
                            "(such as hardware rules or switch configs). This is likely cause by an unstable power "
-                           "supply but it might as well be a firmware bug. {}".format(
-                                remote_processor,
-                                "Ignoring RGB crash and continuing play." if ignore_rgb else "MPF will exit now."))
+                           "supply but it might as well be a firmware bug. {}"
+                           .format(remote_processor, action))
             if ignore_rgb:
                 self.machine.events.post("fast_rgb_rebooted", msg=msg)
                 return

--- a/mpf/tests/test_Fast.py
+++ b/mpf/tests/test_Fast.py
@@ -692,6 +692,23 @@ Update done.
 
         self.assertFalse(self.dmd_cpu.expected_commands)
 
+    def test_bootloader_crash(self):
+        # Test that the machine stops if the RGB processor sends a bootloader msg
+        self.machine.stop = MagicMock()
+        self.machine.default_platform.process_received_message("!B:00", "RGB")
+        self.advance_time_and_run(1)
+        self.assertTrue(self.machine.stop.called)
+
+    def test_bootloader_crash_ignored(self):
+        # Test that RGB processor bootloader msgs can be ignored
+        self.machine.default_platform.config['ignore_rgb_crash'] = True
+        self.mock_event('fast_rgb_rebooted')
+        self.machine.stop = MagicMock()
+        self.machine.default_platform.process_received_message("!B:00", "RGB")
+        self.advance_time_and_run(1)
+        self.assertFalse(self.machine.stop.called)
+        self.assertEventCalled('fast_rgb_rebooted')
+
     def test_lights_and_leds(self):
         self._test_matrix_light()
         self._test_pdb_gi_light()


### PR DESCRIPTION
### Summary
There is an instability in the Fast RGB processor that causes it to crash, typically the first time a game is played after bootup. While unfortunate, the crash does not _have_ to be fatal.

### Details
This PR adds an option to the `fast:` config settings: `ignore_rgb_crash`. If `True`, then RGB crashes will be logged but MPF will not exit. All light state will be lost, but any active light shows will immediately reappear when MPF sends the next step of the show. Any lights that were on static will be turned off.

When the RGB reboot occurs, a new event is posted: _fast_rgb_rebooted_. This event allows the game designer to provide emergency fallback lighting to ensure that the playfield is properly lit and any required lights are re-established. 

### Debug Log
```
INFO : FAST : Connected! Processor: RGB, Board Type: FP-CPU-002-2, Firmware: 01.00
INFO : EventManager : Event: ======'machine_var_fast_rgb_firmware'====== Args={'value': '01.00', 'prev_value': None, 'change': True}
INFO : EventManager : Event: ======'machine_var_fast_rgb_model'====== Args={'value': 'FP-CPU-002-2', 'prev_value': None, 'change': True}
ERROR : FAST : The FAST RGB processor rebooted. Unfortunately, that means that it lost all it's state (such as hardware rules or switch configs). This is likely cause by an unstable power supply but it might as well be a firmware bug. Ignoring RGB crash and continuing play.
INFO : EventManager : Event: ======'fast_rgb_rebooted'====== Args={'msg': '00'}
WARNING : FAST : Received malformed message: <0x11><0x11>XX:F from RGB
WARNING : FAST : Port RGB received more messages than were sent! Resetting!
ERROR : FAST : The FAST RGB processor rebooted. Unfortunately, that means that it lost all it's state (such as hardware rules or switch configs). This is likely cause by an unstable power supply but it might as well be a firmware bug. Ignoring RGB crash and continuing play.
INFO : EventManager : Event: ======'fast_rgb_rebooted'====== Args={'msg': '02'}
```