### PR TITLE
Fix to allow '#' characters in config values

### DIFF
--- a/mpf/core/bcp/bcp_socket_client.py
+++ b/mpf/core/bcp/bcp_socket_client.py
@@ -39,7 +39,7 @@ def decode_command_string(bcp_string) -> Tuple[str, dict]:
     will be preserved.
 
     """
-    bcp_command = urlsplit(bcp_string)
+    bcp_command = urlsplit(bcp_string, allow_fragments=False)
 
     if bcp_command.query[0:5] == "json=":
         kwargs = json.loads(bcp_command.query[5:])

--- a/mpf/tests/test_BcpSocketClient.py
+++ b/mpf/tests/test_BcpSocketClient.py
@@ -108,6 +108,20 @@ class TestBcpSocketClientEncoding(unittest.TestCase):
         self.assertEqual(decoded_dict['dict2'][1],
                          dict(key3='value5', key4='value6'))
 
+    def test_json_encoding_decoding_with_hashtags(self):
+        # see: https://github.com/missionpinball/mpf/issues/1495
+        command = 'play'
+        kwargs = dict()
+        kwargs['dict1'] = dict(key1='value1 #', key2='value2 #')
+
+        encoded_string = encode_command_string(command, **kwargs)
+        decoded_command, decoded_dict = decode_command_string(encoded_string)
+
+        self.assertEqual('play', decoded_command)
+        self.assertIn('dict1', decoded_dict)
+        self.assertEqual(decoded_dict['dict1']['key1'], 'value1 #')
+        self.assertEqual(decoded_dict['dict1']['key2'], 'value2 #')
+
 
 class MockBcpQueueSocket(MockQueueSocket):
 


### PR DESCRIPTION
So I think the issue is that MPF uses URL parsing libs for parsing the BCP query.   The value gets encoded correctly but when decoding using `urlsplit` the part of the query after the `#` is treated as a URL fragment so it is removed when decoding.  If we call `urlsplit` with `allow_fragments=False` then this appears to fix the issue.   From the python docs:

> If the allow_fragments argument is false, fragment identifiers are not recognized. Instead, they are parsed as part of the path, parameters or query component, and fragment is set to the empty string in the return value.

https://docs.python.org/3/library/urllib.parse.html