### PR TITLE
924 Implement create_config command to bootstrap essential configs

### DIFF
--- a/mpf/commands/create_config.py
+++ b/mpf/commands/create_config.py
@@ -34,7 +34,7 @@ class Command(MpfCommandLineParser):
         self.creation_loop()
 
     def creation_loop(self):
-        """Sets up the main creation loop."""
+        """Set up the main creation loop."""
         selection = button_dialog(
             title='Selection',
             text='What would you like to create?',
@@ -77,7 +77,7 @@ class Command(MpfCommandLineParser):
             message_dialog(
                 title='Mode',
                 text=HTML(
-                    ''''<style fg="green">Success:</style> Created mode {}.
+                    '''<style fg="green">Success:</style> Created mode {}.
                     \nDon\'t forget to add it to your mode list.'''.format(
                         mode_name)),
                 style=self.example_style
@@ -135,8 +135,8 @@ class Command(MpfCommandLineParser):
             style=self.example_style).run()
 
         # create shows folder
-        show_path = os.path.join(self.machine_path, "shows", show_name)
-        shows_dir = os.path.join(self.machine_path, "shows")
+        show_path = os.path.normpath(os.path.join(self.machine_path, "shows", show_name))
+        shows_dir = os.path.normpath(os.path.join(self.machine_path, "shows"))
 
         if not os.path.exists(show_path):
             if self.in_machine_folder():
@@ -160,11 +160,11 @@ class Command(MpfCommandLineParser):
             self._create_machine_config()
 
     def in_machine_folder(self):
-        """Checks if current directory is a machine folder."""
+        """Check if current directory is a machine folder."""
         return os.path.exists(os.path.join(self.current_path, "config"))
 
     def show_not_in_machine_folder_dialog(self):
-        """Shows error message if current directory is not a machine folder."""
+        """Show error message if current directory is not a machine folder."""
         message_dialog(
             title='Wrong directory',
             text=HTML(
@@ -175,22 +175,22 @@ class Command(MpfCommandLineParser):
 
     @staticmethod
     def create_machine_config_structure(config_name, machine_path):
-        """Creates the basic hierarchy of a new machine folder including test and config files."""
-        os.makedirs(machine_path)
-        os.makedirs(os.path.join(machine_path, "config"))
-        with open(os.path.join(machine_path, "config", "config.yaml"), "w") as f:
+        """Create the basic hierarchy of a new machine folder including test and config files."""
+        os.makedirs(os.path.normpath(machine_path))
+        os.makedirs(os.path.normpath(os.path.join(machine_path, "config")))
+        with open(os.path.normpath(os.path.join(machine_path, "config", "config.yaml")), "w") as f:
             f.write("#config_version=5")
 
         # create test folder
-        os.makedirs(os.path.join(machine_path, "tests"))
+        os.makedirs(os.path.normpath(os.path.join(machine_path, "tests")))
 
         test_file_name = "test_{}.yaml".format(config_name)
-        with open(os.path.join(machine_path, "tests", test_file_name), "w"):
+        with open(os.path.normpath(os.path.join(machine_path, "tests", test_file_name)), "w"):
             pass
 
     @staticmethod
     def create_show_structure(show_name, shows_dir, machine_path):
-        """Creates the basic hierarchy of a new show folder."""
+        """Create the basic hierarchy of a new show folder."""
         if not os.path.exists(shows_dir):
             os.makedirs(shows_dir)
         # create shows file
@@ -201,10 +201,10 @@ class Command(MpfCommandLineParser):
 
     @staticmethod
     def create_mode_structure(mode_name, mode_path, machine_path):
-        """Creates the basic hierarchy of a new mode folder."""
+        """Create the basic hierarchy of a new mode folder."""
         os.makedirs(mode_path)
         # create config folder
-        os.makedirs(os.path.join(machine_path, "modes", mode_name, "config"))
+        os.makedirs(os.path.normpath(os.path.join(machine_path, "modes", mode_name, "config")))
         # create config file
         file_content = """#config_version=5
 
@@ -212,12 +212,14 @@ class Command(MpfCommandLineParser):
                 start_events: ball_started
                 priority: 100
             """
+        config_file_name = "{}.yaml".format(mode_name)
+        config_path = os.path.normpath(os.path.join(machine_path, "modes", mode_name, "config", config_file_name))
         Command.write_config_file(
-            os.path.join(machine_path, "modes", mode_name, "config", "{}.yaml".format(mode_name)), file_content)
+            config_path, file_content)
 
     @staticmethod
     def write_config_file(path, config_file_content):
-        """Creates config files for machine folders or modes."""
+        """Create config files for machine folders or modes."""
         # create config file
         with open(path, "w") as f:
             f.write(config_file_content)

--- a/mpf/commands/create_config.py
+++ b/mpf/commands/create_config.py
@@ -1,0 +1,211 @@
+"""Command to format yaml files."""
+
+import os
+from mpf.commands import MpfCommandLineParser
+from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.shortcuts import message_dialog
+from prompt_toolkit.styles import Style
+from prompt_toolkit.shortcuts import button_dialog
+from prompt_toolkit.shortcuts import input_dialog
+
+SUBCOMMAND = True
+
+
+class Command(MpfCommandLineParser):
+    """Run a text unit test from cli."""
+
+    def __init__(self, args, path):
+        """Parse args."""
+        super().__init__(args, path)
+        self.current_path = path
+        if self.in_machine_folder():
+            self.machine_path = self.current_path
+
+        self.example_style = Style.from_dict({
+            'dialog': 'bg:#f2521d',
+            'dialog frame.label': 'bg:#ffffff #000000',
+            'dialog.body': 'bg:#000000 #FFFFFF',
+            'dialog shadow': 'bg:#79290E',
+            'dialog text-area': 'bg:#f2521d #FFFFFF'
+        })
+
+        self.creation_loop()
+
+    def creation_loop(self):
+
+        selection = button_dialog(
+            title='Selection',
+            text='What would you like to create?',
+
+            buttons=[
+                ('Machine', 'machine'),
+                ('Mode', 'mode'),
+                ('Show', 'show'),
+                ('Cancel', 'cancel'),
+            ],
+            style=self.example_style
+        ).run()
+        if selection == 'machine':
+            self.create_machine_config()
+        elif selection == 'mode':
+            if self.in_machine_folder():
+                self.create_mode()
+            else:
+                self.show_not_in_machine_folder_dialog()
+        elif selection == 'show':
+            if self.in_machine_folder():
+                self.create_show()
+            else:
+                self.show_not_in_machine_folder_dialog()
+        else:
+            exit()
+        self.creation_loop()
+
+    def create_mode(self):
+        """Create a mode."""
+
+        mode_name = input_dialog(
+            title='Mode',
+            text='Cool, got a name for your mode?',
+            style=self.example_style).run()
+
+        # create mode folder
+        mode_path = os.path.join(self.machine_path, "modes", mode_name)
+        if not os.path.exists(mode_path):
+            self.create_mode_structure(mode_name, mode_path, self.machine_path)
+            message_dialog(
+                title='Mode',
+                text=HTML(
+                    '<style fg="green">Success:</style> Created mode {}.\nDon\'t forget to add it to your mode list.'.format(
+                        mode_name)),
+                style=self.example_style
+            ).run()
+
+        else:
+            message_dialog(
+                title='Mode',
+                text=HTML(
+                    '<style fg="red">Error:</style> A mode with this name exists already\nPlease pick another one'),
+                style=self.example_style
+            ).run()
+            self.create_mode()
+
+    def create_machine_config(self):
+        """Create a machine config."""
+        config_name = input_dialog(
+            title='Machine Config',
+            text='Please enter the name of your machine config:',
+            style=self.example_style).run()
+
+        if config_name == None:
+            quit()
+
+        # create machine_config folder
+        self.machine_path = os.path.join(self.current_path, config_name)
+
+        if not os.path.exists(self.machine_path):
+
+            self.create_machine_config_structure(config_name, self.machine_path)
+            self.current_path = self.machine_path
+            message_dialog(
+                title='Mode',
+                text=HTML(
+                    '<style fg="green">Success:</style> Created machine config {}.\nYou can now create modes and shows.'.format(
+                        config_name)),
+                style=self.example_style
+            ).run()
+        else:
+            message_dialog(
+                title='Mode',
+                text=HTML(
+                    '<style fg="red">Error:</style> A machine config with this name exists already\nPlease pick another one'),
+                style=self.example_style
+            ).run()
+            self._create_machine_config()
+
+    def create_show(self):
+        """Create a mode."""
+
+        show_name = input_dialog(
+            title='Mode',
+            text='Cool, got a name for your show?',
+            style=self.example_style).run()
+
+        # create shows folder
+        show_path = os.path.join(self.machine_path, "shows", show_name)
+        shows_dir = os.path.join(self.machine_path, "shows")
+
+        if not os.path.exists(show_path):
+            if self.in_machine_folder():
+                self.create_show_structure(show_name, shows_dir, self.machine_path)
+                message_dialog(
+                    title='Shows',
+                    text=HTML('<style fg="green">Success:</style> Created show {}.'.format(show_name)),
+                    # text='Success: Created machine config {}.'.format(config_name),
+                    style=self.example_style
+                ).run()
+            else:
+                self.show_not_in_machine_folder_dialog()
+
+        else:
+            message_dialog(
+                title='Mode',
+                text=HTML(
+                    '<style fg="red">Error:</style> A show with this name already exists\nPlease pick another one!'),
+                style=self.example_style
+            ).run()
+            self._create_machine_config()
+
+    def in_machine_folder(self):
+        return os.path.exists(os.path.join(self.current_path, "config"))
+
+    def show_not_in_machine_folder_dialog(self):
+        message_dialog(
+            title='Wrong directory',
+            text=HTML(
+                '<style fg="red">Error:</style> You dont\'t seem to be in a machine folder.\nPlease switch to one!'),
+            style=self.example_style
+        ).run()
+        quit()
+
+    @staticmethod
+    def create_machine_config_structure(config_name, machine_path):
+        os.makedirs(machine_path)
+        os.makedirs(os.path.join(machine_path, "config"))
+        with open(os.path.join(machine_path, "config", "config.yaml"), "w") as f:
+            f.write("#config_version=5")
+
+        # create test folder
+        os.makedirs(os.path.join(machine_path, "tests"))
+        with open(os.path.join(machine_path, "tests", "test_{}.yaml".format(config_name)), "w"):
+            pass
+
+    @staticmethod
+    def create_show_structure(show_name, shows_dir, machine_path):
+        if not os.path.exists(shows_dir):
+            os.makedirs(shows_dir)
+        # create shows file
+        file_content = "#show_version=5"
+        config_path = os.path.join(machine_path, "shows", "{}.yaml".format(show_name))
+        Command.write_config_file(config_path, file_content)
+
+    @staticmethod
+    def create_mode_structure(mode_name, mode_path, machine_path):
+        os.makedirs(mode_path)
+        # create config folder
+        os.makedirs(os.path.join(machine_path, "modes", mode_name, "config"))
+        # create config file
+        file_content = """#config_version=5
+
+            mode:
+                start_events: ball_started
+                priority: 100
+            """
+        Command.write_config_file(
+            os.path.join(machine_path, "modes", mode_name, "config", "{}.yaml".format(mode_name)), file_content)
+
+    @staticmethod
+    def write_config_file(path, config_file_content):
+        # create config file
+        with open(path, "w") as f:
+            f.write(config_file_content)

--- a/mpf/commands/create_config.py
+++ b/mpf/commands/create_config.py
@@ -1,17 +1,19 @@
 """Command to format yaml files."""
 
 import os
-from mpf.commands import MpfCommandLineParser
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.shortcuts import message_dialog
 from prompt_toolkit.styles import Style
 from prompt_toolkit.shortcuts import button_dialog
 from prompt_toolkit.shortcuts import input_dialog
+from mpf.commands import MpfCommandLineParser
+
 
 SUBCOMMAND = True
 
 
 class Command(MpfCommandLineParser):
+
     """Run a text unit test from cli."""
 
     def __init__(self, args, path):
@@ -32,7 +34,7 @@ class Command(MpfCommandLineParser):
         self.creation_loop()
 
     def creation_loop(self):
-
+        """Sets up the main creation loop."""
         selection = button_dialog(
             title='Selection',
             text='What would you like to create?',
@@ -63,7 +65,6 @@ class Command(MpfCommandLineParser):
 
     def create_mode(self):
         """Create a mode."""
-
         mode_name = input_dialog(
             title='Mode',
             text='Cool, got a name for your mode?',
@@ -76,7 +77,8 @@ class Command(MpfCommandLineParser):
             message_dialog(
                 title='Mode',
                 text=HTML(
-                    '<style fg="green">Success:</style> Created mode {}.\nDon\'t forget to add it to your mode list.'.format(
+                    ''''<style fg="green">Success:</style> Created mode {}.
+                    \nDon\'t forget to add it to your mode list.'''.format(
                         mode_name)),
                 style=self.example_style
             ).run()
@@ -97,7 +99,7 @@ class Command(MpfCommandLineParser):
             text='Please enter the name of your machine config:',
             style=self.example_style).run()
 
-        if config_name == None:
+        if config_name is None:
             quit()
 
         # create machine_config folder
@@ -110,7 +112,8 @@ class Command(MpfCommandLineParser):
             message_dialog(
                 title='Mode',
                 text=HTML(
-                    '<style fg="green">Success:</style> Created machine config {}.\nYou can now create modes and shows.'.format(
+                    '''<style fg="green">Success:</style> Created machine config {}.
+                    \nYou can now create modes and shows.'''.format(
                         config_name)),
                 style=self.example_style
             ).run()
@@ -118,14 +121,14 @@ class Command(MpfCommandLineParser):
             message_dialog(
                 title='Mode',
                 text=HTML(
-                    '<style fg="red">Error:</style> A machine config with this name exists already\nPlease pick another one'),
+                    '''<style fg="red">Error:</style> A machine config with this name exists already
+                    \nPlease pick another one')'''),
                 style=self.example_style
             ).run()
             self._create_machine_config()
 
     def create_show(self):
-        """Create a mode."""
-
+        """Create a show."""
         show_name = input_dialog(
             title='Mode',
             text='Cool, got a name for your show?',
@@ -157,9 +160,11 @@ class Command(MpfCommandLineParser):
             self._create_machine_config()
 
     def in_machine_folder(self):
+        """Checks if current directory is a machine folder."""
         return os.path.exists(os.path.join(self.current_path, "config"))
 
     def show_not_in_machine_folder_dialog(self):
+        """Shows error message if current directory is not a machine folder."""
         message_dialog(
             title='Wrong directory',
             text=HTML(
@@ -170,6 +175,7 @@ class Command(MpfCommandLineParser):
 
     @staticmethod
     def create_machine_config_structure(config_name, machine_path):
+        """Creates the basic hierarchy of a new machine folder including test and config files."""
         os.makedirs(machine_path)
         os.makedirs(os.path.join(machine_path, "config"))
         with open(os.path.join(machine_path, "config", "config.yaml"), "w") as f:
@@ -177,20 +183,25 @@ class Command(MpfCommandLineParser):
 
         # create test folder
         os.makedirs(os.path.join(machine_path, "tests"))
-        with open(os.path.join(machine_path, "tests", "test_{}.yaml".format(config_name)), "w"):
+
+        test_file_name = "test_{}.yaml".format(config_name)
+        with open(os.path.join(machine_path, "tests", test_file_name), "w"):
             pass
 
     @staticmethod
     def create_show_structure(show_name, shows_dir, machine_path):
+        """Creates the basic hierarchy of a new show folder."""
         if not os.path.exists(shows_dir):
             os.makedirs(shows_dir)
         # create shows file
         file_content = "#show_version=5"
-        config_path = os.path.join(machine_path, "shows", "{}.yaml".format(show_name))
+        show_file_name = "{}.yaml".format(show_name)
+        config_path = os.path.join(machine_path, "shows", show_file_name)
         Command.write_config_file(config_path, file_content)
 
     @staticmethod
     def create_mode_structure(mode_name, mode_path, machine_path):
+        """Creates the basic hierarchy of a new mode folder."""
         os.makedirs(mode_path)
         # create config folder
         os.makedirs(os.path.join(machine_path, "modes", mode_name, "config"))
@@ -206,6 +217,7 @@ class Command(MpfCommandLineParser):
 
     @staticmethod
     def write_config_file(path, config_file_content):
+        """Creates config files for machine folders or modes."""
         # create config file
         with open(path, "w") as f:
             f.write(config_file_content)

--- a/mpf/commands/create_config.py
+++ b/mpf/commands/create_config.py
@@ -193,10 +193,9 @@ class Command(MpfCommandLineParser):
         """Create the basic hierarchy of a new show folder."""
         if not os.path.exists(shows_dir):
             os.makedirs(shows_dir)
-        # create shows file
         file_content = "#show_version=5"
         show_file_name = "{}.yaml".format(show_name)
-        config_path = os.path.join(machine_path, "shows", show_file_name)
+        config_path = os.path.normpath(os.path.join(machine_path, "shows", show_file_name))
         Command.write_config_file(config_path, file_content)
 
     @staticmethod

--- a/mpf/tests/test_CommandCreateConfig.py
+++ b/mpf/tests/test_CommandCreateConfig.py
@@ -1,0 +1,38 @@
+"""Test Switch Position Mixin."""
+from unittest import TestCase
+from mpf.commands.create_config import Command
+from unittest.mock import call, patch, mock_open
+
+class TestCommandCreateConfig(TestCase):
+
+    @patch('os.makedirs')
+    def test_get_create_mode(self, os_makedirs):
+        with patch("builtins.open", mock_open()) as mock_file:
+            Command.create_mode_structure("testmode", "/home/test/modes", "/home/test/")
+            mock_file.assert_called_with("/home/test/modes/testmode/config/testmode.yaml", "w")
+            expected_calls = [call("/home/test/modes"), call("/home/test/modes/testmode/config")]
+            os_makedirs.assert_has_calls(expected_calls)
+
+    @patch('os.makedirs')
+    def test_get_create_machine_config(self, os_makedirs):
+        with patch("builtins.open", mock_open()) as mock_file:
+            Command.create_machine_config_structure("testmachine", "/home/testmachine")
+
+            with open("/home/testmachine/config/config.yaml", "w") as handle_config:
+                handle_config.write.assert_any_call("#config_version=5")
+
+            mock_file.assert_any_call("/home/testmachine/config/config.yaml", "w")
+            mock_file.assert_any_call("/home/testmachine/tests/test_testmachine.yaml", "w")
+
+            expected_calls = [call("/home/testmachine"), call("/home/testmachine/config"), call("/home/testmachine/tests")]
+            os_makedirs.assert_has_calls(expected_calls)
+
+    @patch('os.makedirs')
+    def test_get_create_shows(self, os_makedirs):
+        with patch("builtins.open", mock_open()) as mock_file:
+            Command.create_show_structure("testshow", "/home/test/shows", "/home/test/")
+            mock_file.assert_called_with("/home/test/shows/testshow.yaml", "w")
+            os_makedirs.assert_called_once_with("/home/test/shows")
+
+
+

--- a/mpf/tests/test_CommandCreateConfig.py
+++ b/mpf/tests/test_CommandCreateConfig.py
@@ -1,4 +1,5 @@
 """Test Switch Position Mixin."""
+import os
 from unittest import TestCase
 from mpf.commands.create_config import Command
 from unittest.mock import call, patch, mock_open
@@ -8,31 +9,32 @@ class TestCommandCreateConfig(TestCase):
     @patch('os.makedirs')
     def test_get_create_mode(self, os_makedirs):
         with patch("builtins.open", mock_open()) as mock_file:
-            Command.create_mode_structure("testmode", "/home/test/modes", "/home/test/")
-            mock_file.assert_called_with("/home/test/modes/testmode/config/testmode.yaml", "w")
-            expected_calls = [call("/home/test/modes"), call("/home/test/modes/testmode/config")]
+            Command.create_mode_structure("testmode", os.path.normpath("/home/test/modes"), os.path.normpath("/home/test/"))
+            mock_file.assert_called_with(os.path.normpath("/home/test/modes/testmode/config/testmode.yaml"), "w")
+            expected_calls = [call(os.path.normpath("/home/test/modes")), call(os.path.normpath("/home/test/modes/testmode/config"))]
             os_makedirs.assert_has_calls(expected_calls)
 
     @patch('os.makedirs')
     def test_get_create_machine_config(self, os_makedirs):
         with patch("builtins.open", mock_open()) as mock_file:
-            Command.create_machine_config_structure("testmachine", "/home/testmachine")
+            Command.create_machine_config_structure("testmachine", os.path.normpath("/home/testmachine"))
 
-            with open("/home/testmachine/config/config.yaml", "w") as handle_config:
+            with open(os.path.normpath("/home/testmachine/config/config.yaml"), "w") as handle_config:
                 handle_config.write.assert_any_call("#config_version=5")
 
-            mock_file.assert_any_call("/home/testmachine/config/config.yaml", "w")
-            mock_file.assert_any_call("/home/testmachine/tests/test_testmachine.yaml", "w")
+            mock_file.assert_any_call(os.path.normpath("/home/testmachine/config/config.yaml"), "w")
 
-            expected_calls = [call("/home/testmachine"), call("/home/testmachine/config"), call("/home/testmachine/tests")]
+            mock_file.assert_any_call(os.path.normpath("/home/testmachine/tests/test_testmachine.yaml"), "w")
+
+            expected_calls = [call(os.path.normpath("/home/testmachine")), call(os.path.normpath("/home/testmachine/config")), call(os.path.normpath("/home/testmachine/tests"))]
             os_makedirs.assert_has_calls(expected_calls)
 
     @patch('os.makedirs')
     def test_get_create_shows(self, os_makedirs):
         with patch("builtins.open", mock_open()) as mock_file:
-            Command.create_show_structure("testshow", "/home/test/shows", "/home/test/")
-            mock_file.assert_called_with("/home/test/shows/testshow.yaml", "w")
-            os_makedirs.assert_called_once_with("/home/test/shows")
+            Command.create_show_structure("testshow", os.path.normpath("/home/test/shows"), os.path.normpath("/home/test/"))
+            mock_file.assert_called_with(os.path.normpath("/home/test/shows/testshow.yaml"), "w")
+            os_makedirs.assert_called_once_with(os.path.normpath("/home/test/shows"))
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ community.''',
                       'asciimatics==1.11.0',
                       'terminaltables==3.1.0',
                       'psutil==5.7.0',
+                      'prompt_toolkit',
                       'pypiwin32==223;platform_system=="Windows"'],
 
     tests_require=[],


### PR DESCRIPTION
This would be the very basic functionality of the create_config commands based on prompt_toolkit dialogs. Currently creating machine folders, shows and modes is supported. Let me know what you think and what should be changed.
![overview](https://user-images.githubusercontent.com/9135882/79690265-dece8c80-8259-11ea-99f9-62cb132d5ee7.png)
![modename](https://user-images.githubusercontent.com/9135882/79690269-e2faaa00-8259-11ea-8f8c-f5417649d8f3.png)

 