### PR TITLE
Bugfix for variable shows

### DIFF
--- a/mpf/config_players/variable_player.py
+++ b/mpf/config_players/variable_player.py
@@ -47,7 +47,8 @@ class VariablePlayer(ConfigPlayer):
             if s['condition'] and not s['condition'].evaluate(kwargs):
                 continue
 
-            block_item = var + ":" + calling_context
+            block_item = var + ":" + str(calling_context)
+
             if self._is_blocked(block_item, context, priority):
                 continue
             if s['block']:

--- a/mpf/tests/machine_files/shows/shows/test_variable_show.yaml
+++ b/mpf/tests/machine_files/shows/shows/test_variable_show.yaml
@@ -1,0 +1,11 @@
+#show_version=5
+- time: 0
+  variables:
+    foo:
+      action: set_machine
+      int: 0
+- time: 1
+  variables:
+    foo:
+      action: add_machine
+      int: 1

--- a/mpf/tests/test_Shows.py
+++ b/mpf/tests/test_Shows.py
@@ -873,3 +873,14 @@ class TestShows(MpfTestCase):
         self.post_event_with_params("play_show_with_condition_in_show", blue=True)
         self.advance_time_and_run()
         self.assertLightColor("led_01", "blue")
+
+    # Regression test for bug in standalone variable shows
+    def test_variable_show(self):
+        variable_show = self.machine.shows['test_variable_show'].play()
+        self.advance_time_and_run(.1)
+        # check that machine variable was set
+        self.assertEqual(self.machine.variables.get_machine_var('foo'), 0)
+        # advance to next show step
+        self.advance_time_and_run()
+        # check that machine variable was incremented
+        self.assertEqual(self.machine.variables.get_machine_var('foo'), 1)


### PR DESCRIPTION
Found a bug while trying to play a show that updates variables from a standalone show file.  The calling_context arg is passed as an integer [here](https://github.com/missionpinball/mpf/blob/dev/mpf/assets/show.py#L669) but `VariablePlayer.play` expects it to be a string.  I'm guessing this is typically meant to be equal to a mode name.