### PR TITLE
Block tilt warnings once game has tilted

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ their spare time, unpaid, for the love of pinball!
  * Kevin Lee Drum <kevinleedrum@gmail.com>
  * Sean Irby <sean.t.irby@gmail.com>
  * Mark Seiden <thearrrrrcade@gmail.com>
+ * Andrew Burch <andrewb@enteryourinitials.com>
 
 MPF is inspired by pyprocgame and skeletongame which were written by:
 

--- a/mpf/modes/tilt/code/tilt.py
+++ b/mpf/modes/tilt/code/tilt.py
@@ -118,7 +118,7 @@ class Tilt(Mode):
             not self.machine.game.player or
             self.machine.game.ending or
             self.machine.game.tilted):
-            return
+                return
 
         self.info_log("Tilt Warning")
 

--- a/mpf/modes/tilt/code/tilt.py
+++ b/mpf/modes/tilt/code/tilt.py
@@ -114,11 +114,9 @@ class Tilt(Mode):
         del kwargs
         self.last_tilt_warning_switch = self.machine.clock.get_time()
 
-        if (not self.machine.game or
-            not self.machine.game.player or
-            self.machine.game.ending or
-            self.machine.game.tilted):
-                return
+        if (not self.machine.game or not self.machine.game.player or
+                self.machine.game.ending or self.machine.game.tilted):
+            return
 
         self.info_log("Tilt Warning")
 

--- a/mpf/modes/tilt/code/tilt.py
+++ b/mpf/modes/tilt/code/tilt.py
@@ -114,10 +114,10 @@ class Tilt(Mode):
         del kwargs
         self.last_tilt_warning_switch = self.machine.clock.get_time()
 
-        if not self.machine.game or \
-           not self.machine.game.player or \
-           self.machine.game.ending  or \
-           self.machine.game.tilted:
+        if (not self.machine.game or
+            not self.machine.game.player or
+            self.machine.game.ending or
+            self.machine.game.tilted):
             return
 
         self.info_log("Tilt Warning")

--- a/mpf/modes/tilt/code/tilt.py
+++ b/mpf/modes/tilt/code/tilt.py
@@ -114,7 +114,10 @@ class Tilt(Mode):
         del kwargs
         self.last_tilt_warning_switch = self.machine.clock.get_time()
 
-        if not self.machine.game or not self.machine.game.player or self.machine.game.ending or self.machine.game.tilted:
+        if not self.machine.game or \
+           not self.machine.game.player or \
+           self.machine.game.ending  or \
+           self.machine.game.tilted:
             return
 
         self.info_log("Tilt Warning")

--- a/mpf/modes/tilt/code/tilt.py
+++ b/mpf/modes/tilt/code/tilt.py
@@ -114,7 +114,7 @@ class Tilt(Mode):
         del kwargs
         self.last_tilt_warning_switch = self.machine.clock.get_time()
 
-        if not self.machine.game or not self.machine.game.player or self.machine.game.ending:
+        if not self.machine.game or not self.machine.game.player or self.machine.game.ending or self.machine.game.tilted:
             return
 
         self.info_log("Tilt Warning")

--- a/mpf/tests/machine_files/tilt_defaults/config/config.yaml
+++ b/mpf/tests/machine_files/tilt_defaults/config/config.yaml
@@ -1,0 +1,60 @@
+#config_version=5
+
+modes:
+    - tilt
+
+playfields:
+    playfield:
+        default_source_device: bd_launcher
+        tags: default
+
+coils:
+    eject_coil1:
+        number:
+    eject_coil2:
+        number:
+    c_flipper:
+        number:
+        default_hold_power: 0.125
+
+switches:
+    s_start:
+        number:
+        tags: start
+    s_ball_switch1:
+        number:
+    s_ball_switch2:
+        number:
+    s_ball_switch_launcher:
+        number:
+    s_tilt:
+        number:
+        tags: tilt
+    s_tilt_warning:
+        number:
+        tags: tilt_warning
+    s_slam_tilt:
+        number:
+        tags: slam_tilt
+    s_flipper:
+        number:
+
+ball_devices:
+    bd_trough:
+        eject_coil: eject_coil1
+        ball_switches: s_ball_switch1, s_ball_switch2
+        debug: true
+        confirm_eject_type: target
+        eject_targets: bd_launcher
+        tags: trough, drain, home
+    bd_launcher:
+        eject_coil: eject_coil2
+        ball_switches: s_ball_switch_launcher
+        debug: true
+        confirm_eject_type: target
+        eject_timeouts: 6s, 10s
+
+flippers:
+    f_test:
+        main_coil: c_flipper
+        activation_switch: s_flipper

--- a/mpf/tests/test_Tilt.py
+++ b/mpf/tests/test_Tilt.py
@@ -1,5 +1,5 @@
 from mpf.tests.MpfGameTestCase import MpfGameTestCase
-from mpf.tests.MpfTestCase import test_config
+from mpf.tests.MpfTestCase import test_config, test_config_directory
 
 
 class TestTilt(MpfGameTestCase):
@@ -308,7 +308,7 @@ class TestTilt(MpfGameTestCase):
         self.assertPlayerVarEqual(1, "tilt_warnings")
         self.assertFalse(self._is_tilted)
 
-
+    @test_config_directory("tests/machine_files/tilt_defaults/")
     def test_carry_over_single_player(self):
         self._add_tilt_handler()
         self._prepare_trough()
@@ -331,15 +331,12 @@ class TestTilt(MpfGameTestCase):
         self.hit_and_release_switch("s_tilt_warning")
         self.advance_time_and_run(2)
         self.assertTrue(self._is_tilted)
-        self.assertPlayerVarEqual(3, "tilt_warnings")
+        self.assertPlayerVarEqual(0, "tilt_warnings")
 
         # tilt_warnings player var no longer increases because machine is tilted
         self.hit_and_release_switch("s_tilt_warning")
         self.advance_time_and_run(2)
-        self.assertPlayerVarEqual(3, "tilt_warnings")
-
-        # reset tilt warnings and ensure player var no longer increases until next ball
-        self.machine.game.player['tilt_warnings'] = 0
+        self.assertPlayerVarEqual(0, "tilt_warnings")
 
         self.hit_and_release_switch("s_tilt_warning")
         self.advance_time_and_run(2)
@@ -354,11 +351,11 @@ class TestTilt(MpfGameTestCase):
         self.advance_time_and_run(10)
         self.assertPlayerNumber(1)
 
-        self.assertPlayerVarEqual(0, "tilt_warnings")
         self._is_tilted = False
 
         self.assertBallNumber(2)
         self.assertBallsOnPlayfield(1)
+        self.assertPlayerVarEqual(0, "tilt_warnings")
 
         # generate tilt warning and ensure no carry over from previous ball
         self.hit_and_release_switch("s_tilt_warning")

--- a/mpf/tests/test_Tilt.py
+++ b/mpf/tests/test_Tilt.py
@@ -1,7 +1,8 @@
-from mpf.tests.MpfTestCase import MpfTestCase, test_config
+from mpf.tests.MpfGameTestCase import MpfGameTestCase
+from mpf.tests.MpfTestCase import test_config
 
 
-class TestTilt(MpfTestCase):
+class TestTilt(MpfGameTestCase):
 
     def get_config_file(self):
         return 'config.yaml'
@@ -16,21 +17,24 @@ class TestTilt(MpfTestCase):
         del kwargs
         self._is_tilted = True
 
-    @test_config("config_system_11_trough.yaml")
-    def test_tilt_in_outhole(self):
-        """Test that the ball does not stay in the outhole."""
+    def _prepare_trough(self):
+        self.machine.ball_controller.num_balls_known = 0
+        self.machine.switch_controller.process_switch('s_ball_switch1', 1)
+        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
+        self.advance_time_and_run(2)
+        self.assertEqual(2, self.machine.ball_devices["bd_trough"].balls)
+
+    def _add_tilt_handler(self):
         self._is_tilted = False
         self.machine.events.add_handler("tilt", self._tilted)
 
-        self.machine.ball_controller.num_balls_known = 0
-        self.hit_switch_and_run('s_ball_switch1', 0)
-        self.hit_switch_and_run('s_ball_switch2', 0)
-        self.advance_time_and_run(2)
+    @test_config("config_system_11_trough.yaml")
+    def test_tilt_in_outhole(self):
+        """Test that the ball does not stay in the outhole."""
+        self._add_tilt_handler()
 
-        self.assertEqual(None, self.machine.game)
-        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(2, self.machine.ball_devices["bd_trough"].balls)
-        self.hit_and_release_switch("s_start")
+        self._prepare_trough()
+        self.start_game(2)
         self.advance_time_and_run(10)
 
         self.assertBallsOnPlayfield(0)
@@ -64,20 +68,10 @@ class TestTilt(MpfTestCase):
     @test_config("config_mechanical_eject.yaml")
     def test_mechanical_eject(self):
         """Test that tilt triggers auto launch."""
-        self._is_tilted = False
-        self.machine.events.add_handler("tilt", self._tilted)
+        self._add_tilt_handler()
 
-        self.machine.ball_controller.num_balls_known = 0
-        self.machine.switch_controller.process_switch('s_ball_switch1', 1)
-        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
-        self.advance_time_and_run(2)
-
-        self.assertEqual(None, self.machine.game)
-        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(2, self.machine.ball_devices["bd_trough"].balls)
-        self.machine.switch_controller.process_switch('s_start', 1)
-        self.machine.switch_controller.process_switch('s_start', 0)
-        self.advance_time_and_run(10)
+        self._prepare_trough()
+        self.start_game(2)
 
         self.assertBallsOnPlayfield(0)
         self.assertAvailableBallsOnPlayfield(1)
@@ -102,20 +96,10 @@ class TestTilt(MpfTestCase):
         self.assertEqual(False, self.machine.game.tilted)
 
     def test_simple_tilt(self):
-        self._is_tilted = False
-        self.machine.events.add_handler("tilt", self._tilted)
+        self._add_tilt_handler()
 
-        self.machine.ball_controller.num_balls_known = 0
-        self.machine.switch_controller.process_switch('s_ball_switch1', 1)
-        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
-        self.advance_time_and_run(2)
-
-        self.assertEqual(None, self.machine.game)
-        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(2, self.machine.ball_devices["bd_trough"].balls)
-        self.machine.switch_controller.process_switch('s_start', 1)
-        self.machine.switch_controller.process_switch('s_start', 0)
-        self.advance_time_and_run(10)
+        self._prepare_trough()
+        self.start_game(2)
 
         # flipper actived
         self.assertTrue(self.machine.flippers["f_test"]._enabled)
@@ -149,23 +133,12 @@ class TestTilt(MpfTestCase):
         self.assertEqual(False, self.machine.game.tilted)
 
     def test_tilt_event(self):
-        self._is_tilted = False
-        self.machine.events.add_handler("tilt", self._tilted)
+        self._add_tilt_handler()
 
-        self.machine.ball_controller.num_balls_known = 0
-        self.machine.switch_controller.process_switch('s_ball_switch1', 1)
-        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
-        self.advance_time_and_run(2)
-
-        self.assertEqual(None, self.machine.game)
-        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(2, self.machine.ball_devices["bd_trough"].balls)
-        self.machine.switch_controller.process_switch('s_start', 1)
-        self.machine.switch_controller.process_switch('s_start', 0)
-        self.advance_time_and_run(10)
+        self._prepare_trough()
+        self.start_game(2)
 
         self.assertTrue(self.machine.mode_controller.is_active('tilt'))
-        self.assertNotEqual(None, self.machine.game)
 
         self.assertFalse(self._is_tilted)
         self.machine.events.post("tilt_event")
@@ -185,20 +158,10 @@ class TestTilt(MpfTestCase):
         self.assertEqual(False, self.machine.game.tilted)
 
     def test_simple_tilt_ball_not_on_pf_yet(self):
-        self._is_tilted = False
-        self.machine.events.add_handler("tilt", self._tilted)
+        self._add_tilt_handler()
 
-        self.machine.ball_controller.num_balls_known = 0
-        self.machine.switch_controller.process_switch('s_ball_switch1', 1)
-        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
-        self.advance_time_and_run(2)
-
-        self.assertEqual(None, self.machine.game)
-        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(2, self.machine.ball_devices["bd_trough"].balls)
-        self.machine.switch_controller.process_switch('s_start', 1)
-        self.machine.switch_controller.process_switch('s_start', 0)
-        self.advance_time_and_run(1)
+        self._prepare_trough()
+        self.start_game(2)
 
         self.assertTrue(self.machine.mode_controller.is_active('tilt'))
         self.assertNotEqual(None, self.machine.game)
@@ -217,23 +180,12 @@ class TestTilt(MpfTestCase):
         self.assertEqual(False, self.machine.game.tilted)
 
     def test_tilt_warning(self):
-        self._is_tilted = False
-        self.machine.events.add_handler("tilt", self._tilted)
+        self._add_tilt_handler()
 
-        self.machine.ball_controller.num_balls_known = 0
-        self.machine.switch_controller.process_switch('s_ball_switch1', 1)
-        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
-        self.advance_time_and_run(2)
-
-        self.assertEqual(None, self.machine.game)
-        self.assertEqual(2, self.machine.ball_controller.num_balls_known)
-        self.assertEqual(2, self.machine.ball_devices["bd_trough"].balls)
-        self.machine.switch_controller.process_switch('s_start', 1)
-        self.machine.switch_controller.process_switch('s_start', 0)
-        self.advance_time_and_run(10)
+        self._prepare_trough()
+        self.start_game(2)
 
         self.assertTrue(self.machine.mode_controller.is_active('tilt'))
-        self.assertNotEqual(None, self.machine.game)
 
         self.assertFalse(self._is_tilted)
 
@@ -272,13 +224,9 @@ class TestTilt(MpfTestCase):
         self.assertEqual(False, self.machine.game.tilted)
 
     def test_slam_tilt(self):
-        self._is_tilted = False
-        self.machine.events.add_handler("tilt", self._tilted)
+        self._add_tilt_handler()
 
-        self.machine.ball_controller.num_balls_known = 0
-        self.machine.switch_controller.process_switch('s_ball_switch1', 1)
-        self.machine.switch_controller.process_switch('s_ball_switch2', 1)
-        self.advance_time_and_run(2)
+        self._prepare_trough()
 
         self.assertEqual(None, self.machine.game)
         self.assertEqual(2, self.machine.ball_controller.num_balls_known)
@@ -310,3 +258,52 @@ class TestTilt(MpfTestCase):
         # test that it does not crash outside the game
         self.post_event("tilt_reset_warnings")
         self.advance_time_and_run()
+
+    def test_carry_over(self):
+        self._add_tilt_handler()
+        self._prepare_trough()
+        self.start_two_player_game()
+
+        self.advance_time_and_run(10)
+        self.assertBallsOnPlayfield(1)
+        self.assertPlayerVarEqual(0, "tilt_warnings")
+
+        # tilt machine
+        self.hit_and_release_switch("s_tilt_warning")
+        self.advance_time_and_run(2)
+        self.assertFalse(self._is_tilted)
+        self.assertPlayerVarEqual(1, "tilt_warnings")
+        self.hit_and_release_switch("s_tilt_warning")
+        self.advance_time_and_run(2)
+        self.assertFalse(self._is_tilted)
+        self.assertPlayerVarEqual(2, "tilt_warnings")
+
+        self.hit_and_release_switch("s_tilt_warning")
+        self.advance_time_and_run(2)
+        self.assertTrue(self._is_tilted)
+        self.assertPlayerVarEqual(3, "tilt_warnings")
+
+        # tilt_warnings player var no longer increases because machine is tilted
+        self.hit_and_release_switch("s_tilt_warning")
+        self.advance_time_and_run(2)
+        self.assertPlayerVarEqual(3, "tilt_warnings")
+        self.hit_and_release_switch("s_tilt_warning")
+        self.advance_time_and_run(2)
+        self.assertPlayerVarEqual(3, "tilt_warnings")
+        self.hit_and_release_switch("s_tilt_warning")
+        self.advance_time_and_run(2)
+        self.assertPlayerVarEqual(3, "tilt_warnings")
+        self.assertPlayerNumber(1)
+
+        self.drain_one_ball()
+        self.advance_time_and_run(10)
+        self.assertPlayerNumber(2)
+        self.assertPlayerVarEqual(0, "tilt_warnings")
+        self._is_tilted = False
+
+        self.assertBallsOnPlayfield(1)
+
+        self.hit_and_release_switch("s_tilt_warning")
+        self.advance_time_and_run(2)
+        self.assertPlayerVarEqual(1, "tilt_warnings")
+        self.assertFalse(self._is_tilted)


### PR DESCRIPTION
Any further tilt warnings that were triggered once the game tilted would affect the tilt warning count for the players next ball. This change will not trigger any further warnings once the game is in a tilted state and ensure their tilt warning count is at zero when the next ball begins.