### PR TITLE
Twitch Chat Events

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1814,9 +1814,12 @@ trinamics_steprocker:
 twitch_client:
     __valid_in__: machine
     __type__: config
-    user: single|str|
-    password: single|str|
-    channel: single|str|
+    user: single|str|None
+    password: single|str|None
+    channel: single|str|None
+    user_var: single|str|None
+    password_var: single|str|None
+    channel_var: single|str|None
 variable_player:
     __valid_in__: mode
     __type__: config_player

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1811,6 +1811,12 @@ trinamics_steprocker:
     __valid_in__: machine
     __type__: config
     port: single|str|
+twitch_client:
+    __valid_in__: machine
+    __type__: config
+    user: single|str|
+    password: single|str|
+    channel: single|str|
 variable_player:
     __valid_in__: mode
     __type__: config_player

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -92,6 +92,7 @@ mpf:
         - mpf.plugins.auditor.Auditor
         - mpf.plugins.info_lights.InfoLights
         - mpf.plugins.switch_player.SwitchPlayer
+        - mpf.plugins.twitch_bot.TwitchBot
 
     platforms:
         fadecandy: mpf.platforms.fadecandy.FadecandyHardwarePlatform

--- a/mpf/plugins/twitch/__init__.py
+++ b/mpf/plugins/twitch/__init__.py
@@ -1,0 +1,1 @@
+"""Contains twitch bot components."""

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -26,7 +26,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         server = 'irc.chat.twitch.tv'
         port = 6667
         self.log.info('Connecting to ' + server + ' on port ' + str(port) + '...')
-        irc.bot.SingleServerIRCBot.__init__(self, [(server, port, 'oauth:' + password)], username, username)
+        super().__init__(self, [(server, port, 'oauth:' + password)], username, username)
         # self.connection.add_global_handler("all_events", self.on_all_events, -100)
 
     def on_welcome(self, c, e):
@@ -114,7 +114,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
 
     def post_event_in_mpf(self, event, *args, **kwargs):
         """Post event in MPF via async loop to prevent race conditions."""
-        self.loop.call_soon_threadsafe(partial(self.machine.events.post, *args, **kwargs))
+        self.loop.call_soon_threadsafe(partial(self.machine.events.post, event, *args, **kwargs))
 
     def set_machine_variable_in_mpf(self, name, value):
         """Set machine var in MPF via async loop to prevent race conditions."""

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -4,10 +4,16 @@ import requests
 import logging
 import textwrap
 
+
 class TwitchClient(irc.bot.SingleServerIRCBot):
+
+    """Thread to process Twitch chat events"""
+
     TWITCH_PLAYS_ENABLED = False
 
     def __init__(self, machine, username, password, channel):
+        """Initialize Twitch Bot"""
+
         self.log = logging.getLogger('twitch_client') 
         self.machine = machine
         self.password = password
@@ -21,6 +27,8 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         # self.connection.add_global_handler("all_events", self.on_all_events, -100)
 
     def on_welcome(self, c, e):
+        """Called when IRC server is joined"""
+
         self.log.info('Joining ' + self.channel)
 
         # You must request specific capabilities before you can use them
@@ -30,6 +38,8 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         c.join(self.channel)
 
     def on_pubmsg(self, c, e):
+        """Called when a public message is posted in chat"""
+
         # If a chat message starts with ! or ?, try to run it as a command
         if e.arguments[0][:1] == '!' or e.arguments[0][:1] == '?':
             cmd = e.arguments[0].split(' ')[0][1:]
@@ -75,14 +85,20 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                 )
 
     def on_privmsg(self, c, e):
+        """Called when a private message is posted in chat"""
+
         user = e.source.split('!')[0]
         self.log.info('Private chat: [' + user + '] ' + e.arguments[0])
 
     def on_all_events(self, c, e):
+        """Called when any IRC event is posted"""
+
         message = 'All Events: ' + e
         self.log.info(message.replace(self.password, 'XXXXX'))
 
     def do_command(self, e, cmd):
+        """Handles a chat command (starts with ? or !)"""
+
         user = e.source.split('!')[0]
         self.log.info('Received command: [' + user + '] ' + cmd)
 
@@ -93,12 +109,18 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                 self.machine.events.post('twitch_flip_right', user=user)
 
     def is_connected(self):
+        """Returns true if the server is connected"""
+
         return self.connection.is_connected()
 
     def build_tag_dict(self, seq):
+        """Builds a Python dict from IRC chat tags"""
+
         return dict((d['key'], d['value']) for (index, d) in enumerate(seq))
 
     def split_message(self, message, min_lines):
+        """Splits up a string into lines broken on words"""
+
         lines = textwrap.wrap(message, 21)
         length = len(lines)
 

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -66,10 +66,25 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                     months=int(months),
                     subscriber_message=subscriber_message
                 )
+                '''event: twitch_subscription
+                desc: A chat user has subscribed or resubscribed on Twitch
+                args:
+                message: Chat message text
+                months: The number of months that the user has been a subscriber
+                subscriber_message: The message the user typed when subscribing
+                user: The chat user name who subscribed
+                '''
             elif bits is not None:
                 self.set_machine_variable_in_mpf('twitch_last_bits_user', user)
                 self.set_machine_variable_in_mpf('twitch_last_bits_amount', bits)
                 self.post_event_in_mpf('twitch_bit_donation', user=user, message=e.arguments[0], bits=int(bits))
+                '''event: twitch_bit_donation
+                desc: A chat user has donated bits on Twitch
+                args:
+                message: Chat message text
+                bits: The number of bits donated
+                user: The chat user name who subscribed
+                '''
             else:
                 length, lines = self.split_message(e.arguments[0], 6)
                 self.set_machine_variable_in_mpf('twitch_last_chat_user', user)
@@ -93,6 +108,19 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                     line_5=lines[4],
                     line_6=lines[5]
                 )
+                '''event: twitch_chat_message
+                desc: A chat message was received via Twitch
+                args:
+                line_count: The number of lines that the text splitter produced
+                line_1: Split line 1
+                line_2: Split line 2
+                line_3: Split line 3
+                line_4: Split line 4
+                line_5: Split line 5
+                line_6: Split line 6
+                message: Full chat message text
+                user: The chat user name who subscribed
+                '''
 
     def on_privmsg(self, c, e):
         """Framework will call when a private message is posted in chat."""

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -1,3 +1,5 @@
+"""IRC Chat Bot for monitoring a Twitch chatroom."""
+
 import sys
 import irc.bot
 import requests
@@ -13,7 +15,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
 
     def __init__(self, machine, username, password, channel):
         """Initialize Twitch Bot."""
-        self.log = logging.getLogger('twitch_client') 
+        self.log = logging.getLogger('twitch_client')
         self.machine = machine
         self.password = password
         self.channel = '#' + channel
@@ -26,7 +28,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         # self.connection.add_global_handler("all_events", self.on_all_events, -100)
 
     def on_welcome(self, c, e):
-        """Called when IRC server is joined."""
+        """Framework will call when IRC server is joined."""
         self.log.info('Joining ' + self.channel)
 
         # You must request specific capabilities before you can use them
@@ -36,7 +38,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         c.join(self.channel)
 
     def on_pubmsg(self, c, e):
-        """Called when a public message is posted in chat."""
+        """Framework will call when a public message is posted in chat."""
         # If a chat message starts with ! or ?, try to run it as a command
         if e.arguments[0][:1] == '!' or e.arguments[0][:1] == '?':
             cmd = e.arguments[0].split(' ')[0][1:]
@@ -52,7 +54,13 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
             if message_type == 'sub' or message_type == 'resub':
                 months = tags.get('msg-param-months', 1)
                 subscriber_message = tags.get('message', '')
-                self.machine.events.post('twitch_subscription', user=user, message=e.arguments[0], months=int(months), subscriber_message=subscriber_message)
+                self.machine.events.post(
+                    'twitch_subscription',
+                    user=user,
+                    message=e.arguments[0],
+                    months=int(months),
+                    subscriber_message=subscriber_message
+                )
             elif bits is not None:
                 self.machine.set_machine_var('twitch_last_bits_user', user)
                 self.machine.set_machine_var('twitch_last_bits_amount', bits)
@@ -82,17 +90,17 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                 )
 
     def on_privmsg(self, c, e):
-        """Called when a private message is posted in chat."""
+        """Framework will call when a private message is posted in chat."""
         user = e.source.split('!')[0]
         self.log.info('Private chat: [' + user + '] ' + e.arguments[0])
 
     def on_all_events(self, c, e):
-        """Called when any IRC event is posted."""
+        """Framework will call when any IRC event is posted."""
         message = 'All Events: ' + e
         self.log.info(message.replace(self.password, 'XXXXX'))
 
     def do_command(self, e, cmd):
-        """Handles a chat command (starts with ? or !)."""
+        """Handle a chat command (starts with ? or !)."""
         user = e.source.split('!')[0]
         self.log.info('Received command: [' + user + '] ' + cmd)
 
@@ -103,16 +111,15 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                 self.machine.events.post('twitch_flip_right', user=user)
 
     def is_connected(self):
-        """Returns true if the server is connected."""
+        """Return true if the server is connected."""
         return self.connection.is_connected()
 
     def build_tag_dict(self, seq):
-        """Builds a Python dict from IRC chat tags."""
-
+        """Build a Python dict from IRC chat tags."""
         return dict((d['key'], d['value']) for (index, d) in enumerate(seq))
 
     def split_message(self, message, min_lines):
-        """Splits up a string into lines broken on words."""
+        """Split up a string into lines broken on words."""
         lines = textwrap.wrap(message, 21)
         length = len(lines)
 

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -26,7 +26,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         server = 'irc.chat.twitch.tv'
         port = 6667
         self.log.info('Connecting to ' + server + ' on port ' + str(port) + '...')
-        super().__init__(self, [(server, port, 'oauth:' + password)], username, username)
+        super().__init__([(server, port, 'oauth:' + password)], username, username)
         # self.connection.add_global_handler("all_events", self.on_all_events, -100)
 
     def on_welcome(self, c, e):

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -7,13 +7,12 @@ import textwrap
 
 class TwitchClient(irc.bot.SingleServerIRCBot):
 
-    """Thread to process Twitch chat events"""
+    """Thread to process Twitch chat events."""
 
     TWITCH_PLAYS_ENABLED = False
 
     def __init__(self, machine, username, password, channel):
-        """Initialize Twitch Bot"""
-
+        """Initialize Twitch Bot."""
         self.log = logging.getLogger('twitch_client') 
         self.machine = machine
         self.password = password
@@ -27,8 +26,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         # self.connection.add_global_handler("all_events", self.on_all_events, -100)
 
     def on_welcome(self, c, e):
-        """Called when IRC server is joined"""
-
+        """Called when IRC server is joined."""
         self.log.info('Joining ' + self.channel)
 
         # You must request specific capabilities before you can use them
@@ -38,8 +36,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         c.join(self.channel)
 
     def on_pubmsg(self, c, e):
-        """Called when a public message is posted in chat"""
-
+        """Called when a public message is posted in chat."""
         # If a chat message starts with ! or ?, try to run it as a command
         if e.arguments[0][:1] == '!' or e.arguments[0][:1] == '?':
             cmd = e.arguments[0].split(' ')[0][1:]
@@ -85,20 +82,17 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                 )
 
     def on_privmsg(self, c, e):
-        """Called when a private message is posted in chat"""
-
+        """Called when a private message is posted in chat."""
         user = e.source.split('!')[0]
         self.log.info('Private chat: [' + user + '] ' + e.arguments[0])
 
     def on_all_events(self, c, e):
-        """Called when any IRC event is posted"""
-
+        """Called when any IRC event is posted."""
         message = 'All Events: ' + e
         self.log.info(message.replace(self.password, 'XXXXX'))
 
     def do_command(self, e, cmd):
-        """Handles a chat command (starts with ? or !)"""
-
+        """Handles a chat command (starts with ? or !)."""
         user = e.source.split('!')[0]
         self.log.info('Received command: [' + user + '] ' + cmd)
 
@@ -109,18 +103,16 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                 self.machine.events.post('twitch_flip_right', user=user)
 
     def is_connected(self):
-        """Returns true if the server is connected"""
-
+        """Returns true if the server is connected."""
         return self.connection.is_connected()
 
     def build_tag_dict(self, seq):
-        """Builds a Python dict from IRC chat tags"""
+        """Builds a Python dict from IRC chat tags."""
 
         return dict((d['key'], d['value']) for (index, d) in enumerate(seq))
 
     def split_message(self, message, min_lines):
-        """Splits up a string into lines broken on words"""
-
+        """Splits up a string into lines broken on words."""
         lines = textwrap.wrap(message, 21)
         length = len(lines)
 

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -62,20 +62,20 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                     subscriber_message=subscriber_message
                 )
             elif bits is not None:
-                self.machine.set_machine_var('twitch_last_bits_user', user)
-                self.machine.set_machine_var('twitch_last_bits_amount', bits)
+                self.machine.variables.set_machine_var('twitch_last_bits_user', user)
+                self.machine.variables.set_machine_var('twitch_last_bits_amount', bits)
                 self.machine.events.post('twitch_bit_donation', user=user, message=e.arguments[0], bits=int(bits))
             else:
                 length, lines = self.split_message(e.arguments[0], 6)
-                self.machine.set_machine_var('twitch_last_chat_user', user)
-                self.machine.set_machine_var('twitch_last_chat_message', e.arguments[0])
-                self.machine.set_machine_var('twitch_last_chat_message_line_count', length)
-                self.machine.set_machine_var('twitch_last_chat_message_line_1', lines[0])
-                self.machine.set_machine_var('twitch_last_chat_message_line_2', lines[1])
-                self.machine.set_machine_var('twitch_last_chat_message_line_3', lines[2])
-                self.machine.set_machine_var('twitch_last_chat_message_line_4', lines[3])
-                self.machine.set_machine_var('twitch_last_chat_message_line_5', lines[4])
-                self.machine.set_machine_var('twitch_last_chat_message_line_6', lines[5])
+                self.machine.variables.set_machine_var('twitch_last_chat_user', user)
+                self.machine.variables.set_machine_var('twitch_last_chat_message', e.arguments[0])
+                self.machine.variables.set_machine_var('twitch_last_chat_message_line_count', length)
+                self.machine.variables.set_machine_var('twitch_last_chat_message_line_1', lines[0])
+                self.machine.variables.set_machine_var('twitch_last_chat_message_line_2', lines[1])
+                self.machine.variables.set_machine_var('twitch_last_chat_message_line_3', lines[2])
+                self.machine.variables.set_machine_var('twitch_last_chat_message_line_4', lines[3])
+                self.machine.variables.set_machine_var('twitch_last_chat_message_line_5', lines[4])
+                self.machine.variables.set_machine_var('twitch_last_chat_message_line_6', lines[5])
                 self.machine.events.post(
                     'twitch_chat_message',
                     user=user,

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -77,7 +77,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
                 self.machine.set_machine_var('twitch_last_chat_message_line_5', lines[4])
                 self.machine.set_machine_var('twitch_last_chat_message_line_6', lines[5])
                 self.machine.events.post(
-                    'twitch_new_chat_message',
+                    'twitch_chat_message',
                     user=user,
                     message=e.arguments[0],
                     line_count=length,

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -1,0 +1,108 @@
+import sys
+import irc.bot
+import requests
+import logging
+import textwrap
+
+class TwitchClient(irc.bot.SingleServerIRCBot):
+    TWITCH_PLAYS_ENABLED = False
+
+    def __init__(self, machine, username, password, channel):
+        self.log = logging.getLogger('TwitchClient') 
+        self.machine = machine
+        self.password = password
+        self.channel = '#' + channel
+
+        # Create IRC bot connection
+        server = 'irc.chat.twitch.tv'
+        port = 6667
+        self.log.info('Connecting to ' + server + ' on port ' + str(port) + '...')
+        irc.bot.SingleServerIRCBot.__init__(self, [(server, port, 'oauth:' + password)], username, username)
+        # self.connection.add_global_handler("all_events", self.on_all_events, -100)
+
+    def on_welcome(self, c, e):
+        self.log.info('Joining ' + self.channel)
+
+        # You must request specific capabilities before you can use them
+        c.cap('REQ', ':twitch.tv/membership')
+        c.cap('REQ', ':twitch.tv/tags')
+        c.cap('REQ', ':twitch.tv/commands')
+        c.join(self.channel)
+
+    def on_pubmsg(self, c, e):
+        # If a chat message starts with ! or ?, try to run it as a command
+        if e.arguments[0][:1] == '!' or e.arguments[0][:1] == '?':
+            cmd = e.arguments[0].split(' ')[0][1:]
+            self.do_command(e, cmd.lower())
+        else:
+            user = e.source.split('!')[0]
+            message = 'Chat: [' + user + '] ' + e.arguments[0] + ' : ' + str(e)
+            self.log.info(message.replace(self.password, 'XXXXX'))
+            tags = self.build_tag_dict(e.tags)
+            bits = tags.get('bits')
+            message_type = tags.get('msg-id')
+            user = tags.get('display-name', user)
+            if message_type == 'sub' or message_type == 'resub':
+                months = tags.get('msg-param-months', 1)
+                subscriber_message = tags.get('message', '')
+                self.machine.events.post('twitch_subscription', user=user, message=e.arguments[0], months=int(months), subscriber_message=subscriber_message)
+            elif bits is not None:
+                self.machine.set_machine_var('twitch_last_bits_user', user)
+                self.machine.set_machine_var('twitch_last_bits_amount', bits)
+                self.machine.events.post('twitch_bit_donation', user=user, message=e.arguments[0], bits=int(bits))
+            else:
+                length, lines = self.split_message(e.arguments[0], 6)
+                self.machine.set_machine_var('twitch_last_chat_user', user)
+                self.machine.set_machine_var('twitch_last_chat_message', e.arguments[0])
+                self.machine.set_machine_var('twitch_last_chat_message_line_count', length)
+                self.machine.set_machine_var('twitch_last_chat_message_line_1', lines[0])
+                self.machine.set_machine_var('twitch_last_chat_message_line_2', lines[1])
+                self.machine.set_machine_var('twitch_last_chat_message_line_3', lines[2])
+                self.machine.set_machine_var('twitch_last_chat_message_line_4', lines[3])
+                self.machine.set_machine_var('twitch_last_chat_message_line_5', lines[4])
+                self.machine.set_machine_var('twitch_last_chat_message_line_6', lines[5])
+                self.machine.events.post(
+                    'twitch_new_chat_message',
+                    user=user,
+                    message=e.arguments[0],
+                    line_count=length,
+                    line_1=lines[0],
+                    line_2=lines[1],
+                    line_3=lines[2],
+                    line_4=lines[3],
+                    line_5=lines[4],
+                    line_6=lines[5]
+                )
+
+    def on_privmsg(self, c, e):
+        user = e.source.split('!')[0]
+        self.log.info('Private chat: [' + user + '] ' + e.arguments[0])
+
+    def on_all_events(self, c, e):
+        message = 'All Events: ' + e
+        self.log.info(message.replace(self.password, 'XXXXX'))
+
+    def do_command(self, e, cmd):
+        user = e.source.split('!')[0]
+        self.log.info('Received command: [' + user + '] ' + cmd)
+
+        if self.TWITCH_PLAYS_ENABLED:
+            if cmd == 'l':
+                self.machine.events.post('twitch_flip_left', user=user)
+            elif cmd == 'r':
+                self.machine.events.post('twitch_flip_right', user=user)
+
+    def is_connected(self):
+        return self.connection.is_connected()
+
+    def build_tag_dict(self, seq):
+        return dict((d['key'], d['value']) for (index, d) in enumerate(seq))
+
+    def split_message(self, message, min_lines):
+        lines = textwrap.wrap(message, 21)
+        length = len(lines)
+
+        if length < min_lines:
+            lines += [''] * (min_lines - len(lines))
+
+        return length, lines

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -1,8 +1,6 @@
 """IRC Chat Bot for monitoring a Twitch chatroom."""
 
-import sys
 import irc.bot
-import requests
 import logging
 import textwrap
 

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -26,7 +26,10 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
         server = 'irc.chat.twitch.tv'
         port = 6667
         self.log.info('Connecting to ' + server + ' on port ' + str(port) + '...')
-        super().__init__([(server, port, 'oauth:' + password)], username, username)
+        super().__init__([(
+            server, port,
+            (password if password.lower().startswith('oauth:') else ('oauth:' + password))
+        )], username, username)
         # self.connection.add_global_handler("all_events", self.on_all_events, -100)
 
     def on_welcome(self, c, e):

--- a/mpf/plugins/twitch/twitch_client.py
+++ b/mpf/plugins/twitch/twitch_client.py
@@ -8,7 +8,7 @@ class TwitchClient(irc.bot.SingleServerIRCBot):
     TWITCH_PLAYS_ENABLED = False
 
     def __init__(self, machine, username, password, channel):
-        self.log = logging.getLogger('TwitchClient') 
+        self.log = logging.getLogger('twitch_client') 
         self.machine = machine
         self.password = password
         self.channel = '#' + channel

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -1,7 +1,8 @@
 """MPF plugin which adds events from monitoring a Twitch chatroom."""
 import threading
-from .twitch.twitch_client import TwitchClient
 from mpf.core.logging import LogMixin
+
+from .twitch.twitch_client import TwitchClient
 
 MYPY = False
 if MYPY:   # pragma: no cover
@@ -29,7 +30,8 @@ class TwitchBot(LogMixin):
 
         self.log.info('Attempting to connect to Twitch')
         # THIS SHOULD BE MACHINE VARIABLES
-        self.client = TwitchClient(self.machine, self.config['user'], self.config['password'], self.config['channel'])
+        self.client = TwitchClient(self.machine, self.config['user'], self.config['password'], self.config['channel'],
+                                   self.machine.clock.loop)
         thread = threading.Thread(target=self.client.start, args=())
         thread.daemon = True
         thread.start()

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -39,4 +39,4 @@ class TwitchBot(LogMixin):
         if self.client.is_connected():
             self.info_log('Successful connection to Twitch')
         else:
-            self.info_log('Not Yet Connected')
+            self.info_log('Connecting...')

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -1,18 +1,22 @@
 """MPF plugin which adds events from monitoring a Twitch chatroom."""
-
-import logging
 import threading
 from .twitch.twitch_client import TwitchClient
+from mpf.core.logging import LogMixin
+
+MYPY = False
+if MYPY:   # pragma: no cover
+    from mpf.core.machine import MachineController  # pylint: disable-msg=cyclic-import,unused-import
 
 
-class TwitchBot:
+class TwitchBot(LogMixin):
 
     """Adds Twitch Chat Room events."""
 
     def __init__(self, machine):
         """Initialise Twitch client."""
-        self.machine = machine
-        self.log = logging.getLogger('twitch_client')
+        super().__init__()
+        self.machine = machine      # type: MachineController
+        self.configure_logging("twitch_client")
 
         if 'twitch_client' not in machine.config:
             self.log.debug('"twitch_client:" section not found in '
@@ -20,7 +24,8 @@ class TwitchBot:
                            'plugin will not be used.')
             return
 
-        self.config = self.machine.config['twitch_client']
+        self.config = self.machine.config_validator.validate_config(
+            "twitch_client", self.machine.config['twitch_client'])
 
         self.log.info('Attempting to connect to Twitch')
         # THIS SHOULD BE MACHINE VARIABLES

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -1,0 +1,32 @@
+"""MPF plugin which automatically plays back switch events from the config file."""
+
+import logging
+import os
+import threading
+from mpf.core.scriptlet import Scriptlet
+from .twitch.twitch_client import TwitchClient
+
+class TwitchBot:
+    def __init__(self, machine):
+        """Initialise Twitch client."""
+        self.log = logging.getLogger('twitch_client')
+
+        if 'twitch_client' not in machine.config:
+            machine.log.debug('"twitch_client:" section not found in '
+                              'machine configuration, so the Twitch Client'
+                              'plugin will not be used.')
+            return
+
+        self.config = self.machine.config['twitch_client']
+
+        self.log.info('Attempting to connect to Twitch')
+        self.client = TwitchClient(self.machine, self.config['user'], self.config['password'], self.config['channel'])
+        thread = threading.Thread(target=self.client.start, args=())
+        thread.daemon = True
+        thread.start()
+
+        if self.client.is_connected():
+            self.info_log('Successful connection to Twitch')
+        else:
+            self.info_log('Connection error')
+

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -34,9 +34,12 @@ class TwitchBot(LogMixin):
         password_var = self.config['password_var']
         channel_var = self.config['channel_var']
 
-        user = self.machine.variables.get_machine_var(user_var) if user_var != None else self.config['user']
-        password = self.machine.variables.get_machine_var(password_var) if password_var != None else self.config['password']
-        channel = self.machine.variables.get_machine_var(channel_var) if channel_var != None else self.config['channel']
+        user = self.machine.variables.
+            get_machine_var(user_var) if user_var is not None else self.config['user']
+        password = self.machine.variables.
+            get_machine_var(password_var) if password_var is not None else self.config['password']
+        channel = self.machine.variables.
+            get_machine_var(channel_var) if channel_var is not None else self.config['channel']
 
         self.client = TwitchClient(self.machine, user, password, channel,
                                    self.machine.clock.loop)

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -34,12 +34,17 @@ class TwitchBot(LogMixin):
         password_var = self.config['password_var']
         channel_var = self.config['channel_var']
 
-        user = self.machine.variables.
-            get_machine_var(user_var) if user_var is not None else self.config['user']
-        password = self.machine.variables.
-            get_machine_var(password_var) if password_var is not None else self.config['password']
-        channel = self.machine.variables.
-            get_machine_var(channel_var) if channel_var is not None else self.config['channel']
+        user = self.machine.variables.get_machine_var(
+            user_var
+        ) if user_var is not None else self.config['user']
+
+        password = self.machine.variables.get_machine_var(
+            password_var
+        ) if password_var is not None else self.config['password']
+
+        channel = self.machine.variables.get_machine_var(
+            channel_var
+        ) if channel_var is not None else self.config['channel']
 
         self.client = TwitchClient(self.machine, user, password, channel,
                                    self.machine.clock.loop)

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -29,8 +29,16 @@ class TwitchBot(LogMixin):
             "twitch_client", self.machine.config['twitch_client'])
 
         self.log.info('Attempting to connect to Twitch')
-        # THIS SHOULD BE MACHINE VARIABLES
-        self.client = TwitchClient(self.machine, self.config['user'], self.config['password'], self.config['channel'],
+
+        user_var = self.config['user_var']
+        password_var = self.config['password_var']
+        channel_var = self.config['channel_var']
+
+        user = self.machine.variables.get_machine_var(user_var) if user_var != None else self.config['user']
+        password = self.machine.variables.get_machine_var(password_var) if password_var != None else self.config['password']
+        channel = self.machine.variables.get_machine_var(channel_var) if channel_var != None else self.config['channel']
+
+        self.client = TwitchClient(self.machine, user, password, channel,
                                    self.machine.clock.loop)
         thread = threading.Thread(target=self.client.start, args=())
         thread.daemon = True

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -1,4 +1,4 @@
-"""MPF plugin which adds events from monitoring a Twitch chatroom."""
+"""MPF plugin which adds events from monitoring a Twitch chat room."""
 import threading
 from mpf.core.logging import LogMixin
 
@@ -11,7 +11,7 @@ if MYPY:   # pragma: no cover
 
 class TwitchBot(LogMixin):
 
-    """Adds Twitch Chat Room events."""
+    """Adds Twitch chat room events."""
 
     def __init__(self, machine):
         """Initialise Twitch client."""
@@ -39,4 +39,4 @@ class TwitchBot(LogMixin):
         if self.client.is_connected():
             self.info_log('Successful connection to Twitch')
         else:
-            self.info_log('Connection error')
+            self.info_log('Not Yet Connected')

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -7,7 +7,7 @@ from .twitch.twitch_client import TwitchClient
 
 class TwitchBot:
 
-    """Adds Twitch Chat Room events"""
+    """Adds Twitch Chat Room events."""
 
     def __init__(self, machine):
         """Initialise Twitch client."""

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -1,12 +1,14 @@
 """MPF plugin which adds events from monitoring a Twitch chatroom."""
 
 import logging
-import os
 import threading
-from mpf.core.scriptlet import Scriptlet
 from .twitch.twitch_client import TwitchClient
 
+
 class TwitchBot:
+
+    """Adds Twitch Chat Room events"""
+
     def __init__(self, machine):
         """Initialise Twitch client."""
         self.machine = machine
@@ -31,4 +33,3 @@ class TwitchBot:
             self.info_log('Successful connection to Twitch')
         else:
             self.info_log('Connection error')
-

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -9,12 +9,13 @@ from .twitch.twitch_client import TwitchClient
 class TwitchBot:
     def __init__(self, machine):
         """Initialise Twitch client."""
+        self.machine = machine
         self.log = logging.getLogger('twitch_client')
 
         if 'twitch_client' not in machine.config:
-            machine.log.debug('"twitch_client:" section not found in '
-                              'machine configuration, so the Twitch Client'
-                              'plugin will not be used.')
+            self.log.debug('"twitch_client:" section not found in '
+                           'machine configuration, so the Twitch Client'
+                           'plugin will not be used.')
             return
 
         self.config = self.machine.config['twitch_client']

--- a/mpf/plugins/twitch_bot.py
+++ b/mpf/plugins/twitch_bot.py
@@ -1,4 +1,4 @@
-"""MPF plugin which automatically plays back switch events from the config file."""
+"""MPF plugin which adds events from monitoring a Twitch chatroom."""
 
 import logging
 import os
@@ -20,6 +20,7 @@ class TwitchBot:
         self.config = self.machine.config['twitch_client']
 
         self.log.info('Attempting to connect to Twitch')
+        # THIS SHOULD BE MACHINE VARIABLES
         self.client = TwitchClient(self.machine, self.config['user'], self.config['password'], self.config['channel'])
         thread = threading.Thread(target=self.client.start, args=())
         thread.daemon = True

--- a/mpf/tests/machine_files/twitch_client/config/config.yaml
+++ b/mpf/tests/machine_files/twitch_client/config/config.yaml
@@ -1,0 +1,6 @@
+#config_version=5
+
+twitch_client:
+  user: jan
+  password: MPF
+  channel: MPF-rocks

--- a/mpf/tests/test_TwitchClient.py
+++ b/mpf/tests/test_TwitchClient.py
@@ -1,0 +1,29 @@
+import sys
+
+from mock import MagicMock
+from unittest.mock import patch
+
+from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
+
+
+class TestTwitchClient(MpfFakeGameTestCase):
+
+    def get_config_file(self):
+        return 'config.yaml'
+
+    def get_machine_path(self):
+        return 'tests/machine_files/twitch_client/'
+
+    def setUp(self):
+        self.machine_config_patches['mpf']['plugins'] = ['mpf.plugins.twitch_bot.TwitchBot']
+        sys.modules['irc'] = MagicMock()
+        sys.modules['irc.bot'] = MagicMock()
+        super().setUp()
+
+    def tearDown(self):
+        del sys.modules['irc']
+        del sys.modules['irc.bot']
+
+    def test_twitch_client(self):
+        """Test connect and event posting."""
+        self.assertEventCalled("twitch_connected")

--- a/mpf/tests/test_TwitchClient.py
+++ b/mpf/tests/test_TwitchClient.py
@@ -1,8 +1,6 @@
+from unittest.mock import MagicMock
+
 import sys
-
-from mock import MagicMock
-from unittest.mock import patch, PropertyMock
-
 from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
 
 
@@ -25,13 +23,13 @@ class MockEvent:
 
 class MockSingleServerIRCBot():
 
+    """Mock server."""
+
     def __init__(self, server_list, nickname, realname, reconnection_interval=None, recon=None, **connect_params):
         self.connection = MagicMock()
 
     def start(self):
         pass
-
-
 
 
 class TestTwitchClient(MpfFakeGameTestCase):

--- a/mpf/tests/test_TwitchClient.py
+++ b/mpf/tests/test_TwitchClient.py
@@ -1,9 +1,37 @@
 import sys
 
 from mock import MagicMock
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
+
+
+class MockEvent:
+
+    """Copy of the irc Events class."""
+
+    def __init__(self, type, source, target, arguments=None, tags=None):
+
+        self.type = type
+        self.source = source
+        self.target = target
+        if arguments is None:
+            arguments = []
+        self.arguments = arguments
+        if tags is None:
+            tags = []
+        self.tags = tags
+
+
+class MockSingleServerIRCBot():
+
+    def __init__(self, server_list, nickname, realname, reconnection_interval=None, recon=None, **connect_params):
+        self.connection = MagicMock()
+
+    def start(self):
+        pass
+
+
 
 
 class TestTwitchClient(MpfFakeGameTestCase):
@@ -18,6 +46,7 @@ class TestTwitchClient(MpfFakeGameTestCase):
         self.machine_config_patches['mpf']['plugins'] = ['mpf.plugins.twitch_bot.TwitchBot']
         sys.modules['irc'] = MagicMock()
         sys.modules['irc.bot'] = MagicMock()
+        sys.modules['irc'].bot.SingleServerIRCBot = MockSingleServerIRCBot
         super().setUp()
 
     def tearDown(self):
@@ -26,4 +55,17 @@ class TestTwitchClient(MpfFakeGameTestCase):
 
     def test_twitch_client(self):
         """Test connect and event posting."""
-        self.assertEventCalled("twitch_connected")
+        self.mock_event("twitch_chat_message")
+        tags = [
+            {"key": "msg-id", "value": None},
+            {"key": "bits", "value": None},
+            {"key": "display-name", "value": "Some User"},
+            {"key": "msg-param-months", "value": None},
+            {"key": "message", "value": None},
+        ]
+        event = MockEvent("pubmsg", "some_user", "bot", ["Hello Bot"], tags)
+        self.machine.plugins[0].client.on_pubmsg("some_channel", event)
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("twitch_chat_message")
+        self.assertMachineVarEqual("Some User", "twitch_last_chat_user")
+        self.assertMachineVarEqual("Hello Bot", "twitch_last_chat_message")

--- a/mpf/tests/test_TwitchClient.py
+++ b/mpf/tests/test_TwitchClient.py
@@ -51,7 +51,7 @@ class TestTwitchClient(MpfFakeGameTestCase):
         del sys.modules['irc']
         del sys.modules['irc.bot']
 
-    def test_twitch_client(self):
+    def test_twitch_chat(self):
         """Test connect and event posting."""
         self.mock_event("twitch_chat_message")
         tags = [
@@ -67,3 +67,50 @@ class TestTwitchClient(MpfFakeGameTestCase):
         self.assertEventCalled("twitch_chat_message")
         self.assertMachineVarEqual("Some User", "twitch_last_chat_user")
         self.assertMachineVarEqual("Hello Bot", "twitch_last_chat_message")
+
+    def test_twitch_bits(self):
+        """Test connect and event posting."""
+        self.mock_event("twitch_bit_donation")
+        tags = [
+            {"key": "msg-id", "value": None},
+            {"key": "bits", "value": 42},
+            {"key": "display-name", "value": "Some User"},
+            {"key": "msg-param-months", "value": None},
+            {"key": "message", "value": None},
+        ]
+        event = MockEvent("pubmsg", "some_user", "bot", ["Hello Bot"], tags)
+        self.machine.plugins[0].client.on_pubmsg("some_channel", event)
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("twitch_bit_donation")
+        self.assertMachineVarEqual("Some User", "twitch_last_bits_user")
+        self.assertMachineVarEqual(42, "twitch_last_bits_amount")
+
+    def test_twitch_sub(self):
+        """Test connect and event posting."""
+        self.mock_event("twitch_subscription")
+        tags = [
+            {"key": "msg-id", "value": "sub"},
+            {"key": "bits", "value": None},
+            {"key": "display-name", "value": "Some User"},
+            {"key": "msg-param-months", "value": 1},
+            {"key": "message", "value": "Sub message"},
+        ]
+        event = MockEvent("pubmsg", "some_user", "bot", ["Hello Bot"], tags)
+        self.machine.plugins[0].client.on_pubmsg("some_channel", event)
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("twitch_subscription")
+
+    def test_twitch_resub(self):
+        """Test connect and event posting."""
+        self.mock_event("twitch_subscription")
+        tags = [
+            {"key": "msg-id", "value": "resub"},
+            {"key": "bits", "value": None},
+            {"key": "display-name", "value": "Some User"},
+            {"key": "msg-param-months", "value": 42},
+            {"key": "message", "value": "Sub message"},
+        ]
+        event = MockEvent("pubmsg", "some_user", "bot", ["Hello Bot"], tags)
+        self.machine.plugins[0].client.on_pubmsg("some_channel", event)
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("twitch_subscription")

--- a/mpf/tests/test_TwitchClient.py
+++ b/mpf/tests/test_TwitchClient.py
@@ -42,13 +42,11 @@ class TestTwitchClient(MpfFakeGameTestCase):
 
     def setUp(self):
         self.machine_config_patches['mpf']['plugins'] = ['mpf.plugins.twitch_bot.TwitchBot']
-        sys.modules['irc'] = MagicMock()
         sys.modules['irc.bot'] = MagicMock()
-        sys.modules['irc'].bot.SingleServerIRCBot = MockSingleServerIRCBot
+        sys.modules['irc.bot'].SingleServerIRCBot = MockSingleServerIRCBot
         super().setUp()
 
     def tearDown(self):
-        del sys.modules['irc']
         del sys.modules['irc.bot']
 
     def test_twitch_chat(self):


### PR DESCRIPTION
This is a mostly direct drop in from my Twitch IRC client code. Some issues with this code that need to be resolved:

No tests. I haven't even tested this as an MPF plugin manually. (in my code it's a scriptlet)
The IRC thread may need to be started later in the machine startup
The IRC thread should be able to be configured with machine variables. Currently it's config section based. Checking in passwords is bad.
The IRC thread should be stopped and restarted when those variables change.
The IRC thread is never shut down gracefully on exit
Is this the proper way to do threading in MPF?
It requires the irc library
Password token needs to be generated here: https://twitchapps.com/tmi/  the OAuth login should probably be integrated into MPF somehow

What it should do:
1. Log on to Twitch chat
2. Monitor chat for messages and post the `twitch_chat_message` event
3. Monitor chat for bit donations and post the `twitch_bit_donation` event
4. Monitor chat for subscriptions and post the `twitch_subscription` event