### PR TITLE
Allow shot.jump() calls to force a show refresh

### DIFF
--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -403,7 +403,7 @@ class Shot(EnableDisableMixin, ModeDevice):
     def _release_delay(self, switch):
         self.active_delays.remove(switch)
 
-    def jump(self, state, force=True):
+    def jump(self, state, force=True, force_show=False):
         """Jump to a certain state in the active shot profile.
 
         Args:
@@ -423,8 +423,7 @@ class Shot(EnableDisableMixin, ModeDevice):
             return
 
         current_state = self._get_state()
-
-        if state == current_state:
+        if state == current_state and not force_show:
             self.debug_log("Shot is already in the jump destination state")
             return
 

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -409,7 +409,9 @@ class Shot(EnableDisableMixin, ModeDevice):
         Args:
             state: int of the state number you want to jump to. Note that states
                 are zero-based, so the first state is 0.
-            force: if try also jumps if disabled
+            force: if true, will jump even if the shot is disabled
+            force_show: if true, will update the profile show even if the jumped
+                state index is the same as before the jump
 
         """
         self.debug_log("Received jump request. State: %s, Force: %s", state, force)

--- a/mpf/tests/machine_files/shots/modes/mode2/config/mode2.yaml
+++ b/mpf/tests/machine_files/shots/modes/mode2/config/mode2.yaml
@@ -27,6 +27,8 @@ shots:
     show_tokens:
       leds: (machine.leds)
     profile: show_tokens_profile
+  mode2_shot_changing_profile:
+    profile: changing_profile_one
 
 shows:
   show_with_tokens:
@@ -84,6 +86,20 @@ shot_profiles:
         show: rainbow
         start_step: 6
         manual_advance: True
+  changing_profile_one:
+    states:
+      - name: first
+        show: show_with_tokens
+        show_tokens:
+          leds: led_20
+          color: yellow
+  changing_profile_two:
+    states:
+      - name: first
+        show: show_with_tokens
+        show_tokens:
+          leds: led_20
+          color: purple
   mode2_shot_26:
     states:
     - name: mode2_one

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -922,16 +922,18 @@ class TestShots(MpfTestCase):
         """Test jumping shots and shot_profiles."""
         self.start_game()
         self.machine.modes["mode2"].start()
-
         shot = self.machine.device_manager.collections["shots"]["mode2_shot_changing_profile"]
-        # Changing the profile has no immediate effect
+        
+        # Initial color of the light for this profile
         self.assertLightColor("led_20", "yellow")
 
         # Change the profile and jump without force_show
         shot.config['profile'] = self.machine.device_manager.collections["shot_profiles"]['changing_profile_two']
         shot.jump(0)
+        # State is the same, no color change
         self.assertLightColor("led_20", "yellow")
 
         # Jump and force_show
         shot.jump(0, True, True)
+        # Should see the color of the new profile at the same state
         self.assertLightColor("led_20", "purple")

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -917,3 +917,21 @@ class TestShots(MpfTestCase):
         self.post_event("mode2_shot_show_tokens_advance")
         self.assertLightColor("led_29", "blue")
         self.assertEqual("three", self.machine.shots["mode2_shot_show_tokens"].state_name)
+
+    def test_jump(self):
+        """Test jumping shots and shot_profiles."""
+        self.start_game()
+        self.machine.modes["mode2"].start()
+
+        shot = self.machine.device_manager.collections["shots"]["mode2_shot_changing_profile"]
+        # Changing the profile has no immediate effect
+        self.assertLightColor("led_20", "yellow")
+
+        # Change the profile and jump without force_show
+        shot.config['profile'] = self.machine.device_manager.collections["shot_profiles"]['changing_profile_two']
+        shot.jump(0)
+        self.assertLightColor("led_20", "yellow")
+
+        # Jump and force_show
+        shot.jump(0, True, True)
+        self.assertLightColor("led_20", "purple")


### PR DESCRIPTION
This PR adds a new parameter to `shot.jump()` that allows the call to force an update of the shot profile show. This fixes a behavior that occurs when a shot's profile is programmatically changed and jumped to a new state while the shot is running. 

In most cases this works fine, but there's a gap because the shot uses the index of the profile's state to determine whether to call `self._update_show()`. In the case where the desired state of the new profile is the same as the state of the old profile, logic will prevent the show from updating and the previous profile's show will remain running.

This PR adds an override parameter `force_show` that instructs the Shot to call `self._update_show()` even if the previous profile state is the same as the new profile state.