### PR TITLE
Support block_on_flipper_cancel for Carousels

### DIFF
--- a/mpf/config_players/flasher_player.py
+++ b/mpf/config_players/flasher_player.py
@@ -33,7 +33,7 @@ class FlasherPlayer(DeviceConfigPlayer):
                 self._flash(flasher, duration_ms=s['ms'], key=context)
 
     def _flash(self, light, duration_ms, key):
-        light.color("white", fade_ms=0, key=key)
+        light.color("on", fade_ms=0, key=key)
         self.delay.add(duration_ms, self._remove_flash, light=light, key=key)
 
     @staticmethod

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -2005,6 +2005,7 @@ widgets:
         select_event: single|event_handler|sw_start
         abort_event: single|event_handler|sw_esc
         force_complete_event: single|event_handler|None
+        block_on_flipper_cancel: single|bool|false
         bold: single|bool_or_token|false
         italic: single|bool_or_token|false
         number_grouping: single|bool_or_token|false

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -2005,7 +2005,8 @@ widgets:
         select_event: single|event_handler|sw_start
         abort_event: single|event_handler|sw_esc
         force_complete_event: single|event_handler|None
-        block_on_flipper_cancel: single|bool|false
+        block_events: list|event_handler|None
+        release_events: list|event_handler|None
         bold: single|bool_or_token|false
         italic: single|bool_or_token|false
         number_grouping: single|bool_or_token|false

--- a/mpf/modes/carousel/code/carousel.py
+++ b/mpf/modes/carousel/code/carousel.py
@@ -80,7 +80,7 @@ class Carousel(Mode):
             self._register_handlers(
                 ["both_flippers_inactive", "flipper_cradle_release"],
                 self._block_disable)
-            
+
     def _register_handlers(self, events, handler):
         for event in events:
             self.add_mode_event_handler(event, handler)

--- a/mpf/modes/carousel/code/carousel.py
+++ b/mpf/modes/carousel/code/carousel.py
@@ -76,8 +76,6 @@ class Carousel(Mode):
 
         # If set to block next/prev on flipper cancel, set those event handlers
         if self._block_events:
-            if not self._release_events:
-                raise AssertionError("Carousels with block_events require at least one release_events")
             # This rudimentary implementation will block on any block_event
             # and release on any release_event. If future requirements need to
             # track *which* block_event blocked and *only* release on the

--- a/mpf/modes/carousel/code/carousel.py
+++ b/mpf/modes/carousel/code/carousel.py
@@ -41,7 +41,6 @@ class Carousel(Mode):
         self._highlighted_item_index = 0
         self._block_events = Util.string_to_event_list(mode_settings.get("block_events", ""))
         self._release_events = Util.string_to_event_list(mode_settings.get("release_events", ""))
-        self._is_blocking = False
 
         if not self._all_items:
             raise AssertionError("Specify at least one item to select from")
@@ -66,6 +65,7 @@ class Carousel(Mode):
 
         super().mode_start(**kwargs)
         self._done = False
+        self._is_blocking = False
 
         self._register_handlers(self._next_item_events, self._next_item)
         self._register_handlers(self._previous_item_events, self._previous_item)
@@ -81,9 +81,9 @@ class Carousel(Mode):
             # track *which* block_event blocked and *only* release on the
             # corresponding release_event, additional work will be needed.
             for event in self._block_events:
-                self.add_mode_event_handler(event, self._block_enable)
+                self.add_mode_event_handler(event, self._block_enable, priority=100)
             for event in self._release_events:
-                self.add_mode_event_handler(event, self._block_disable)
+                self.add_mode_event_handler(event, self._block_disable, priority=100)
 
     def _register_handlers(self, events, handler):
         for event in events:

--- a/mpf/tests/machine_files/carousel/config/config.yaml
+++ b/mpf/tests/machine_files/carousel/config/config.yaml
@@ -4,6 +4,7 @@ modes:
     - carousel
     - second_carousel
     - conditional_carousel
+    - blocking_carousel
 
 machine:
     min_balls: 0

--- a/mpf/tests/machine_files/carousel/modes/blocking_carousel/config/blocking_carousel.yaml
+++ b/mpf/tests/machine_files/carousel/modes/blocking_carousel/config/blocking_carousel.yaml
@@ -1,0 +1,12 @@
+#config_version=5
+mode:
+  start_events: start_mode4
+  stop_events: stop_mode4, carousel_item_selected
+  code: mpf.modes.carousel.code.carousel.Carousel
+
+mode_settings:
+  selectable_items: item1, item2, item3
+  select_item_events: select_item
+  next_item_events: s_flipper_right_inactive
+  previous_item_events: s_flipper_left_inactive
+  block_on_flipper_cancel: true

--- a/mpf/tests/machine_files/carousel/modes/blocking_carousel/config/blocking_carousel.yaml
+++ b/mpf/tests/machine_files/carousel/modes/blocking_carousel/config/blocking_carousel.yaml
@@ -9,4 +9,5 @@ mode_settings:
   select_item_events: select_item
   next_item_events: s_flipper_right_inactive
   previous_item_events: s_flipper_left_inactive
-  block_on_flipper_cancel: true
+  block_events: flipper_cancel
+  release_events: both_flippers_inactive

--- a/mpf/tests/test_CarouselMode.py
+++ b/mpf/tests/test_CarouselMode.py
@@ -23,6 +23,36 @@ class TestCarouselMode(MpfTestCase):
         self.advance_time_and_run()
         self.assertIsNone(self.machine.game)
 
+    def testBlockingCarousel(self):
+        self.mock_event("blocking_carousel_item1_highlighted")
+        self.mock_event("blocking_carousel_item2_highlighted")
+        self.mock_event("blocking_carousel_item3_highlighted")
+        self.mock_event("flipper_cancel")
+        
+        self._start_game()
+        self.post_event("start_mode4")
+
+        self.assertIn(self.machine.modes["blocking_carousel"], self.machine.mode_controller.active_modes)
+        self.assertEqual(1, self._events["blocking_carousel_item1_highlighted"])
+        self.assertEqual(0, self._events["blocking_carousel_item2_highlighted"]) 
+        self.post_event("s_flipper_right_active")
+        self.post_event("s_flipper_right_inactive")
+        self.assertEqual(1, self._events["blocking_carousel_item2_highlighted"])
+        self.assertEqual(0, self._events["blocking_carousel_item3_highlighted"]) 
+        self.assertEqual(0, self._events["flipper_cancel"]) 
+        self.post_event("s_flipper_right_active")
+        self.post_event("s_flipper_left_active")
+        self.post_event("flipper_cancel")
+        self.post_event("s_flipper_right_inactive")
+        self.post_event("s_flipper_left_inactive")
+        self.assertEqual(1, self._events["flipper_cancel"])
+        self.assertEqual(1, self._events["blocking_carousel_item1_highlighted"])
+        self.assertEqual(1, self._events["blocking_carousel_item2_highlighted"]) 
+        self.assertEqual(0, self._events["blocking_carousel_item3_highlighted"]) 
+        self.post_event("both_flippers_inactive")
+        self.post_event("s_flipper_right_inactive")
+        self.assertEqual(1, self._events["blocking_carousel_item3_highlighted"]) 
+
     def testConditionalCarousel(self):
         self.mock_event("conditional_carousel_item1_highlighted")
         self.mock_event("conditional_carousel_item2_highlighted")

--- a/mpf/tests/test_CarouselMode.py
+++ b/mpf/tests/test_CarouselMode.py
@@ -53,6 +53,15 @@ class TestCarouselMode(MpfTestCase):
         self.post_event("s_flipper_right_inactive")
         self.assertEqual(1, self._events["blocking_carousel_item3_highlighted"]) 
 
+        # Restart the mode to ensure that the block is cleared
+        self.post_event("flipper_cancel")
+        self.post_event("stop_mode4")
+        self.advance_time_and_run()
+        self.post_event("start_mode4")
+        self.post_event("s_flipper_right_inactive")
+        self.assertEqual(2, self._events["blocking_carousel_item2_highlighted"], 
+            "item2_highlighted should be called when a blocked mode restarts") 
+
     def testConditionalCarousel(self):
         self.mock_event("conditional_carousel_item1_highlighted")
         self.mock_event("conditional_carousel_item2_highlighted")


### PR DESCRIPTION
### Summary

This PR adds a new mode setting to carousel modes, called `block_events`.

If provided, this setting will prevent the carousel from moving to next/previous items after a blocking event is posted. Next/previous will only unblock after a release event is posted.

```
mode_settings:
  select_item_events: flipper_cancel
  next_item_events: s_flipper_right_inactive
  previous_item_events: s_flipper_left_inactive
  block_events: flipper_cancel
  release_events: both_flippers_inactive
```

### Use Cases
* When using the carousel to pick an item with sound or slide effects on change, selecting an item will trigger the next/prev sound after the selection because the mode is still active when the flippers are released.
* When nesting one carousel inside another (i.e. a submenu), selecting an item in the submenu will trigger a next/prev in the main menu, because the release event occurs after the submenu closes

In both of these cases, setting `block_events` on _flipper_cancel_ will prevent the carousel from rotating after the selection is made. Only after both flippers are released will the block be released, and a subsequent flipper press+release will trigger the carousel.

**Also** this PR adds config_spec support for implementing the same functionality on the TextInput widget in MC.