### PR TITLE
Support conditional events and fallback for random_event_player

### DIFF
--- a/mpf/config_players/random_event_player.py
+++ b/mpf/config_players/random_event_player.py
@@ -46,12 +46,13 @@ class RandomEventPlayer(ConfigPlayer):
                 if settings['disable_random']:
                     self.machine.game.player[key].disable_random = True
 
-                self.machine.game.player[key].fallback_event = settings.get('fallback_event')
+                self.machine.game.player[key].fallback_value = settings.get('fallback_event')
 
             return self.machine.game.player[key]
 
         if key not in self._machine_wide_dict:
-            self._machine_wide_dict[key] = Randomizer(settings['events'], self.machine, template_type="event")
+            self._machine_wide_dict[key] = Randomizer(
+                settings['events'], self.machine, template_type="event")
 
             if settings['force_all']:
                 self._machine_wide_dict[key].force_all = True
@@ -62,7 +63,7 @@ class RandomEventPlayer(ConfigPlayer):
             if settings['disable_random']:
                 self._machine_wide_dict[key].disable_random = True
 
-            self._machine_wide_dict[key].fallback_event = settings.get('fallback_event')
+            self._machine_wide_dict[key].fallback_value = settings.get('fallback_event')
 
         return self._machine_wide_dict[key]
 

--- a/mpf/config_players/random_event_player.py
+++ b/mpf/config_players/random_event_player.py
@@ -72,7 +72,7 @@ class RandomEventPlayer(ConfigPlayer):
         del priority
         randomizer = self._get_randomizer(settings, context, calling_context)
         # With conditional events in randomizer, there may not be a next event
-        next_event = randomizer.get_next()
+        next_event = randomizer.get_next(kwargs)
         if next_event:
             self.machine.events.post(next_event, **kwargs)
 

--- a/mpf/config_players/random_event_player.py
+++ b/mpf/config_players/random_event_player.py
@@ -27,7 +27,8 @@ class RandomEventPlayer(ConfigPlayer):
         key = "random_{}.{}".format(context, calling_context)
         if settings['scope'] == "player":
             if not self.machine.game.player[key]:
-                self.machine.game.player[key] = Randomizer(settings['events'])
+                self.machine.game.player[key] = Randomizer(
+                    settings['events'], self.machine, template_type="event")
                 r'''player_var: random_(x).(y)
 
                 desc: Holds references to Randomizer settings that need to be
@@ -45,10 +46,12 @@ class RandomEventPlayer(ConfigPlayer):
                 if settings['disable_random']:
                     self.machine.game.player[key].disable_random = True
 
+                self.machine.game.player[key].fallback_event = settings.get('fallback_event')
+
             return self.machine.game.player[key]
 
         if key not in self._machine_wide_dict:
-            self._machine_wide_dict[key] = Randomizer(settings['events'])
+            self._machine_wide_dict[key] = Randomizer(settings['events'], self.machine, template_type="event")
 
             if settings['force_all']:
                 self._machine_wide_dict[key].force_all = True
@@ -59,13 +62,18 @@ class RandomEventPlayer(ConfigPlayer):
             if settings['disable_random']:
                 self._machine_wide_dict[key].disable_random = True
 
+            self._machine_wide_dict[key].fallback_event = settings.get('fallback_event')
+
         return self._machine_wide_dict[key]
 
     def play(self, settings, context, calling_context, priority=0, **kwargs):
         """Play a random event from list based on config."""
         del priority
         randomizer = self._get_randomizer(settings, context, calling_context)
-        self.machine.events.post(randomizer.get_next(), **kwargs)
+        # With conditional events in randomizer, there may not be a next event
+        next_event = randomizer.get_next()
+        if next_event:
+            self.machine.events.post(next_event, **kwargs)
 
     def validate_config_entry(self, settings, name):
         """Validate one entry of this player."""

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1164,6 +1164,7 @@ random_event_player:
     __valid_in__: machine, mode, show
     __type__: config_player
     events: ignore
+    fallback_event: single|str|None
     force_different: single|bool|true
     force_all: single|bool|true
     disable_random: single|bool|false

--- a/mpf/core/randomizer.py
+++ b/mpf/core/randomizer.py
@@ -9,7 +9,7 @@ class Randomizer:
 
     def __init__(self, items, machine=None, template_type=None):
         """Initialise Randomizer."""
-        self.fallback_event = None
+        self.fallback_value = None
         self.force_different = True
         self.force_all = False
         self.disable_random = False
@@ -88,9 +88,9 @@ class Randomizer:
                     conditional_nexts.append((event.name, weight))
             potential_nexts = conditional_nexts
 
-        # If no events were found due to all conditions failing, return the fallback
+        # If no values were found due to all conditions failing, return the fallback
         if not potential_nexts:
-            return self.fallback_event
+            return self.fallback_value
 
         self.data['current_item'] = self.pick_weighted_random(potential_nexts)
         self.data['items_sent'].add(self.data['current_item'])

--- a/mpf/core/randomizer.py
+++ b/mpf/core/randomizer.py
@@ -40,7 +40,7 @@ class Randomizer:
                 if machine and template_type:
                     this_item = self.generate_template(machine, template_type, this_item)
                 self.items.append((this_item, int(this_weight)))
-                self.items.sort(key = lambda x: x[0].name or x[0])
+                self.items.sort(key=lambda x: x[0].name or x[0])
         else:
             raise AssertionError("Invalid input for Randomizer")
 

--- a/mpf/core/randomizer.py
+++ b/mpf/core/randomizer.py
@@ -51,20 +51,21 @@ class Randomizer:
         """Return iterator."""
         return self
 
-    def __next__(self):
+    def __next__(self, conditional_args={}):
         """Return next."""
         if self.disable_random:
-            return self._next_not_random()
+            return self._next_not_random(conditional_args)
 
         potential_nexts = list()
+        items = self._get_items(conditional_args)
 
         if self.force_all:
             potential_nexts = [
-                x for x in self.items if x[0] not in self.data['items_sent']]
+                x for x in items if x[0] not in self.data['items_sent']]
 
         elif self.force_different:
             potential_nexts = [
-                x for x in self.items if x[0] is not self.data['current_item']]
+                x for x in items if x[0] is not self.data['current_item']]
 
         if not potential_nexts:
 
@@ -75,18 +76,10 @@ class Randomizer:
 
             # force different only works with more than 1 elements
             if self.force_different and len(self.items) > 1:
-                potential_nexts = [x for x in self.items if x[0] is not (
+                potential_nexts = [x for x in items if x[0] is not (
                     self.data['current_item'])]
             else:
-                potential_nexts = list(self.items)
-        if potential_nexts and self._template_type:
-            conditional_nexts = list()
-            for event, weight in potential_nexts:
-                if not event.condition:
-                    conditional_nexts.append((event.name or event, weight))
-                elif event.condition.evaluate({}):
-                    conditional_nexts.append((event.name, weight))
-            potential_nexts = conditional_nexts
+                potential_nexts = list(items)
 
         # If no values were found due to all conditions failing, return the fallback
         if not potential_nexts:
@@ -111,7 +104,7 @@ class Randomizer:
             self._loop = False
             self.force_all = True
 
-    def _next_not_random(self):
+    def _next_not_random(self, conditional_args):
         if self.data['current_item_index'] == len(self.items):
             if not self.loop:
                 raise StopIteration
@@ -119,7 +112,7 @@ class Randomizer:
             self.data['current_item_index'] = 0
 
         self.data['current_item'] = (
-            self.items[self.data['current_item_index']][0])
+            self._get_items(conditional_args)[self.data['current_item_index']][0])
 
         self.data['current_item_index'] += 1
 
@@ -139,11 +132,24 @@ class Randomizer:
 
         return self.__next__()
 
-    def get_next(self):
+    def get_next(self, conditional_args={}):
         """Return next item."""
-        return self.__next__()
+        return self.__next__(conditional_args)
 
-    def generate_template(self, machine, template_type, value):
+    def _get_items(self, conditional_args):
+        if self._template_type:
+            conditional_items = list()
+            for event, weight in self.items:
+                if not event.condition:
+                    conditional_items.append((event.name or event, weight))
+                elif event.condition.evaluate(conditional_args):
+                    conditional_items.append((event.name, weight))
+            return conditional_items
+        return self.items
+
+    @staticmethod
+    def generate_template(machine, template_type, value):
+        """ Convert a string with conditions into a conditional event template object """
         if template_type == "event":
             return machine.placeholder_manager.parse_conditional_template(value)
         # Add additional template_type support here, as needed

--- a/mpf/core/randomizer.py
+++ b/mpf/core/randomizer.py
@@ -40,7 +40,7 @@ class Randomizer:
                 if machine and template_type:
                     this_item = self.generate_template(machine, template_type, this_item)
                 self.items.append((this_item, int(this_weight)))
-                self.items.sort()
+                self.items.sort(key = lambda x: x[0].name or x[0])
         else:
             raise AssertionError("Invalid input for Randomizer")
 
@@ -51,8 +51,11 @@ class Randomizer:
         """Return iterator."""
         return self
 
-    def __next__(self, conditional_args={}):
+    def __next__(self, conditional_args=None):
         """Return next."""
+        if not conditional_args:
+            conditional_args = {}
+
         if self.disable_random:
             return self._next_not_random(conditional_args)
 
@@ -132,7 +135,7 @@ class Randomizer:
 
         return self.__next__()
 
-    def get_next(self, conditional_args={}):
+    def get_next(self, conditional_args=None):
         """Return next item."""
         return self.__next__(conditional_args)
 
@@ -149,7 +152,7 @@ class Randomizer:
 
     @staticmethod
     def generate_template(machine, template_type, value):
-        """ Convert a string with conditions into a conditional event template object """
+        """Convert a string with conditions into a conditional event template object."""
         if template_type == "event":
             return machine.placeholder_manager.parse_conditional_template(value)
         # Add additional template_type support here, as needed

--- a/mpf/tests/machine_files/event_players/config/test_random_event_player.yaml
+++ b/mpf/tests/machine_files/event_players/config/test_random_event_player.yaml
@@ -50,3 +50,10 @@ random_event_player:
       - event2
       - event3
       - event4
+  test_machine_conditional_random:
+    scope: machine
+    events:
+      - event1{False==True}
+      - event2{True==True}
+      - event3{event_arg=="foo"}
+      - event4{machine.settings.foo=="bar"}

--- a/mpf/tests/test_RandomEventPlayer.py
+++ b/mpf/tests/test_RandomEventPlayer.py
@@ -98,3 +98,30 @@ class TestRandomEventPlayerBase():
             self.runner.advance_time_and_run()
             self.runner.assertNotEqual(self.prevEvent, self.lastEvent)
             self.runner.assertEqual(self.lastEvent, self.events[expectedIdx])
+    
+    def _test_conditional_random(self):
+        self._reset()
+        
+        # Only one event is true
+        results = list()
+        for x in range(RANDOM_RUNS):
+            self.runner.post_event("test_{}_conditional_random".format(self.scope))
+            self.runner.advance_time_and_run()
+            self.assertEqual(RANDOM_RUNS, results.count('event1'))
+        
+        # Conditional event kwarg is true
+        results = list()
+        for x in range(RANDOM_RUNS):
+            self.runner.post_event("test_{}_conditional_random".format(self.scope), event_arg="foo")
+            self.runner.advance_time_and_run()
+            self.assertAlmostEqual(RANDOM_RUNS / 2, results.count('event1'), delta=3)
+            self.assertAlmostEqual(RANDOM_RUNS / 2, results.count('event3'), delta=3)
+
+        # Machine setting event is true
+        self.runner.machine.settings.set_setting_value("foo","bar")
+        results = list()
+        for x in range(RANDOM_RUNS):
+            self.runner.post_event("test_{}_conditional_random".format(self.scope))
+            self.runner.advance_time_and_run()
+            self.assertAlmostEqual(RANDOM_RUNS / 2, results.count('event1'), delta=3)
+            self.assertAlmostEqual(RANDOM_RUNS / 2, results.count('event4'), delta=3)

--- a/mpf/tests/test_Randomizer.py
+++ b/mpf/tests/test_Randomizer.py
@@ -187,3 +187,17 @@ class TestRandomizer(MpfTestCase):
                 self.assertEqual(items[i][0], result)
 
             self.assertEqual(3, x)
+
+    def test_fallback_value(self):
+
+        items = []
+
+        r = Randomizer(items)
+        r.fallback_value = "foo"
+
+        results = list()
+
+        for x in range(100):
+            results.append(next(r))
+
+        self.assertEqual(100, results.count('foo'))


### PR DESCRIPTION
This PR adds support for conditional events in `random_event_player` event lists.

For starters, the _Randomizer_ class now accepts `machine` and `template_type` as constructor arguments, and if provided, will generate conditional templates for the items in its randomization list. When fetching the next random item, if the items are conditional template instances, they will all be evaluated and only those that are true will be returned.

For flexibility, the _Randomizer_ class also gets a new config setting: `fallback_value`. If all the conditions failed and no items will be returned, the _Randomizer_ will return its fallback value if one is defined. If not, it will return `None`.

The _RandomEventPlayer_ is likewise updated to pass in the new constructor arguments and set a fallback event.

Tests forthcoming!