### PR TITLE
Store and wrap exception message, add exception for show error

### DIFF
--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -167,27 +167,24 @@ class Show:
                 total_step_time = -1
 
             # Now process show step actions
-            try:
-                self._process_step_actions(step, actions)
-            except Exception as e:
-                raise type(e)("An error occurred while processing show {}: '{}'".format(self.name, e)) from e
-
+            self._process_step_actions(step, actions)
+            
             self.show_steps.append(actions)
 
         # Count how many total steps are in the show. We need this later
         # so we can know when we're at the end of a show
         self.total_steps = len(self.show_steps)
         if self.total_steps == 0:   # pragma: no cover
-            self._show_validation_error("Show is empty", 2)
+            self._show_validation_error('Show "{}" is empty', 2)
 
         self._get_tokens()
 
     def _show_validation_error(self, msg, error_code) -> "NoReturn":  # pragma: no cover
-        raise ConfigFileError("Show {}: {}".format(self.name, msg), error_code, "show", self.name)
+        raise ConfigFileError('"{}" >> {}'.format(self.name, msg), error_code, "show", self.name)
 
     def _process_step_actions(self, step, actions):
         if not isinstance(step, dict):
-            raise AssertionError("Steps in show {} need to be dicts.".format(self.name))
+            raise AssertionError('Steps in show "{}" need to be dicts.'.format(self.name))
         for key, value in step.items():
 
             # key: the section of the show, like 'leds'
@@ -195,16 +192,19 @@ class Show:
 
             # check to see if we know how to process this kind of entry
             if key in self.machine.show_controller.show_players.keys():
-                actions[key] = self.machine.show_controller.show_players[key].validate_config_entry(value, self.name)
+                try:
+                    actions[key] = self.machine.show_controller.show_players[key].validate_config_entry(value, self.name)
+                # If something in the show itself triggered a config error, bubble it up to preserve the logger and context
+                except ConfigFileError as e:
+                    raise ConfigFileError('Show "{}" >> {}'.format(self.name, e._message), e._error_no, e._logger_name, self.name) from e
 
             elif key not in ('duration', 'time'):   # pragma: no cover
                 for player in self.machine.show_controller.show_players.values():
                     if key == player.config_file_section or key == player.machine_collection_name or \
                             key + "s" == player.show_section:
-                        self._show_validation_error('Invalid section "{}:" found in show {}. '
-                                                    'Did you mean "{}:" instead?'.format(key, self.name,
+                        self._show_validation_error('Invalid section "{}:" found. Did you mean "{}:" instead?'.format(key,
                                                                                          player.show_section), 3)
-                self._show_validation_error('Invalid section "{}:" found in show {}'.format(key, self.name), 4)
+                self._show_validation_error('Invalid section "{}:" found.'.format(key), 4)
 
     def _get_tokens(self):
         self._walk_show(self.show_steps)

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -193,17 +193,20 @@ class Show:
             # check to see if we know how to process this kind of entry
             if key in self.machine.show_controller.show_players.keys():
                 try:
-                    actions[key] = self.machine.show_controller.show_players[key].validate_config_entry(value, self.name)
-                # If something in the show itself triggered a config error, bubble it up to preserve the logger and context
+                    actions[key] = \
+                        self.machine.show_controller.show_players[key].validate_config_entry(value, self.name)
+                # If something in the show triggered a config error, bubble it up to preserve logger and context
                 except ConfigFileError as e:
-                    raise ConfigFileError('Show "{}" >> {}'.format(self.name, e._message), e._error_no, e._logger_name, self.name) from e
+                    e.extend('Show "{}"'.format(self.name))
+                    raise e
 
             elif key not in ('duration', 'time'):   # pragma: no cover
                 for player in self.machine.show_controller.show_players.values():
                     if key == player.config_file_section or key == player.machine_collection_name or \
                             key + "s" == player.show_section:
-                        self._show_validation_error('Invalid section "{}:" found. Did you mean "{}:" instead?'.format(key,
-                                                                                         player.show_section), 3)
+                        self._show_validation_error(
+                            'Invalid section "{}:" found. Did you mean "{}:" instead?'.format(
+                                key, player.show_section), 3)
                 self._show_validation_error('Invalid section "{}:" found.'.format(key), 4)
 
     def _get_tokens(self):

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -167,7 +167,10 @@ class Show:
                 total_step_time = -1
 
             # Now process show step actions
-            self._process_step_actions(step, actions)
+            try:
+                self._process_step_actions(step, actions)
+            except Exception as e:
+                raise type(e)("An error occurred while processing show {}: '{}'".format(self.name, e)) from e
 
             self.show_steps.append(actions)
 

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -168,7 +168,7 @@ class Show:
 
             # Now process show step actions
             self._process_step_actions(step, actions)
-            
+
             self.show_steps.append(actions)
 
         # Count how many total steps are in the show. We need this later

--- a/mpf/config_players/device_config_player.py
+++ b/mpf/config_players/device_config_player.py
@@ -50,8 +50,8 @@ class DeviceConfigPlayer(ConfigPlayer, metaclass=abc.ABCMeta):
                 validated_config.update(
                     self._validate_config_item(device, device_settings))
             except ConfigFileError as e:
-                raise ConfigFileError("Failed to load config player {}:{} {}".format(
-                    name, self.show_section, settings), 1, self.log.name) from e
+                raise ConfigFileError("Failed to load config player {}:{} {} >> {}".format(
+                    name, self.show_section, settings, e._message), 1, self.log.name) from e
 
         return validated_config
 

--- a/mpf/config_players/device_config_player.py
+++ b/mpf/config_players/device_config_player.py
@@ -50,8 +50,9 @@ class DeviceConfigPlayer(ConfigPlayer, metaclass=abc.ABCMeta):
                 validated_config.update(
                     self._validate_config_item(device, device_settings))
             except ConfigFileError as e:
-                raise ConfigFileError("Failed to load config player {}:{} {} >> {}".format(
-                    name, self.show_section, settings, e._message), 1, self.log.name) from e
+                e.extend("Failed to load config player {}:{} with settings {}".format(
+                    name, self.show_section, settings))
+                raise e
 
         return validated_config
 

--- a/mpf/core/events.py
+++ b/mpf/core/events.py
@@ -682,7 +682,7 @@ class EventManager(MpfController):
             try:
                 result = handler.callback(**merged_kwargs)
             except Exception as e:
-                raise Exception("Exception while processing {} for event {}".format(handler, event)) from e
+                raise Exception("Exception while processing {} for event {}. {}".format(handler, event, e)) from e
 
             # If whatever handler we called returns False, we stop
             # processing the remaining handlers for boolean or queue events

--- a/mpf/exceptions/base_error.py
+++ b/mpf/exceptions/base_error.py
@@ -27,6 +27,12 @@ class BaseError(AssertionError):
         """Return long name."""
         raise NotImplementedError
 
+    def extend(self, message):
+        """Chain a new message onto an existing error.
+           Maintains the original error's logger, context, and error_no."""
+        self._message = "{} >> {}".format(message, self._message)
+        super().__init__(self._message)
+
     def __str__(self):
         """Return nice string."""
         error_slug = "{}-{}-{}".format(self.get_short_name(), self._url_name.replace(" ", "_"), self._error_no)

--- a/mpf/exceptions/base_error.py
+++ b/mpf/exceptions/base_error.py
@@ -12,6 +12,7 @@ class BaseError(AssertionError):
         self._logger_name = logger_name
         self._error_no = error_no
         self._context = context
+        self._message = message
         if url_name:
             self._url_name = url_name
         else:

--- a/mpf/exceptions/base_error.py
+++ b/mpf/exceptions/base_error.py
@@ -28,8 +28,7 @@ class BaseError(AssertionError):
         raise NotImplementedError
 
     def extend(self, message):
-        """Chain a new message onto an existing error.
-           Maintains the original error's logger, context, and error_no."""
+        """Chain a new message onto an existing error, keeping the original error's logger, context, and error_no."""
         self._message = "{} >> {}".format(message, self._message)
         super().__init__(self._message)
 

--- a/mpf/tests/test_ConfigErrors.py
+++ b/mpf/tests/test_ConfigErrors.py
@@ -17,9 +17,8 @@ class TestConfigErrors(MpfTestCase):
         with self.assertRaises(AssertionError) as e:
             super().setUp()
             self.post_event("play_broken_show")
-
         self.assertEqual(str(e.exception),
-                         'Config File Error in show: Show broken_show: Invalid section "light_player:" '
-                         'found in show broken_show. Did you mean "lights:" instead? Context: broken_show '
+                         'Config File Error in show: "broken_show" >> Invalid section "light_player:" '
+                         'found. Did you mean "lights:" instead? Context: broken_show '
                          'Error Code: CFE-show-3 ({})'.format(log_url.format("CFE-show-3")))
         self.loop.close()


### PR DESCRIPTION
**Same as https://github.com/missionpinball/mpf-mc/pull/408**

I've been trying to improve the exception handling of MPF/MC as I work—whenever I get a crash that requires me to scroll through the callstack or look in the logs, I update the Exception chain to try and get the meaningful error into the final callstack message.

This PR also stores the initial message in the exception, so other wrappers (especially in config file and MC) can prepend their errors to the original and give a chain to identify the file >> block >> value that caused the error.

I think we should do a 50.4 release soon, so making a PR for the changes I've got so far.