### PR TITLE
New config option 'enabled' for displays

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -390,6 +390,7 @@ displays:
     default: single|bool|false
     round_anchor_x: single|str|center
     round_anchor_y: single|str|middle
+    enabled: single|bool|true
 display_light_player:
     __valid_in__: machine, mode, show
     __type__: config_player


### PR DESCRIPTION
This PR adds _config_spec.yaml_ validation for `displays: enabled` property as described in https://github.com/missionpinball/mpf-mc/pull/410