### PR TITLE
Call mode_stop() before removing devices from mode

### DIFF
--- a/mpf/core/mode.py
+++ b/mpf/core/mode.py
@@ -366,12 +366,14 @@ class Mode(LogMixin):
 
     def _mode_stopped_callback(self, **kwargs) -> None:
         del kwargs
+
+        # Call the mode_stop() method before removing the devices
+        self.mode_stop(**self.mode_stop_kwargs)
+        self.mode_stop_kwargs = dict()
+
+        # Clean up the mode handlers and devices
         self._remove_mode_event_handlers()
         self._remove_mode_devices()
-
-        self.mode_stop(**self.mode_stop_kwargs)
-
-        self.mode_stop_kwargs = dict()
 
         for callback in self.stop_callbacks:
             callback()


### PR DESCRIPTION
This PR makes a minor change in the Mode shutdown behavior.

It moves the user-overridable class method `mode_stop()` to be called *before* the event handlers and devices are removed from the mode, instead of after.

With this change, the `mode_stop()` method can access devices in the mode including shots, counters, and timers, and trigger behavior based on their state. Before this change, those devices are unavailable.