### PR TITLE
Config spec 'persist_frame' for image assets

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -76,6 +76,7 @@ assets:
         descriptor: ignore
     images: # no image-specific config items
         __allow_others__:
+        persist_frame: single|bool|false
     shows:  # no show-specific config items
         __allow_others__:
     sounds:


### PR DESCRIPTION
This PR adds config spec for `persist_frame` on image assets, to enable the frame persistence of https://github.com/missionpinball/mpf-mc/pull/416