### PR TITLE
Convert auditor events to explicit list

### DIFF
--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -253,20 +253,20 @@ modes:
 
 auditor:
     save_events:
-        game_started
-        ball_ended
-        game_ended
+      -  game_started
+      -  ball_ended
+      -  game_ended
     num_player_top_records: 10
     audit:
-        shots
-        switches
-        events
-        player
+      -  shots
+      -  switches
+      -  events
+      -  player
     events:
-        game_started
-        game_ended
+      -  game_started
+      -  game_ended
     player:
-        score
+      -  score
 
 sound_system:
     tracks:


### PR DESCRIPTION
This PR updates the default config file's `auditor` section to explicitly format events as lists. The stricter list checking concatenates the events, and space-delimited events are no longer supported, yielding a crash:

```
  File "/Users/Anthony/Git/mpf/mpf/core/events.py", line 178, in add_handler
    event, condition, additional_priority = self.get_event_and_condition_from_string(event)
  File "/Users/Anthony/Git/mpf/mpf/core/events.py", line 89, in get_event_and_condition_from_string
    'please remedy "{}"'.format(event_string))
ValueError: Cannot handle events with spaces in the event name, please remedy "game_started game_ended"
```

By converting the config file to use dashes to indicate the list items, this crash is fixed.