### PR TITLE
Fix error related to show pools

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ their spare time, unpaid, for the love of pinball!
  * Sean Irby <sean.t.irby@gmail.com>
  * Mark Seiden <thearrrrrcade@gmail.com>
  * Andrew Burch <andrewb@enteryourinitials.com>
+ * Avery Tummons
 
 MPF is inspired by pyprocgame and skeletongame which were written by:
 

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -32,10 +32,10 @@ class ShowPool(AssetPool):
         return '<ShowPool: {}>'.format(self.name)
 
     # pylint: disable-msg=too-many-arguments
-    def play_with_config(self, show_config: ShowConfig, start_time=None, start_callback=None, stop_callback=None,
+    def play_with_config(self, show_config: ShowConfig, start_time=None, start_running=True, start_callback=None, stop_callback=None,
                          start_step=None) -> "RunningShow":
         """Play asset from pool with config."""
-        return self.asset.play_with_config(show_config, start_time, start_callback, stop_callback, start_step)
+        return self.asset.play_with_config(show_config, start_time, start_running, start_callback, stop_callback, start_step)
 
     # pylint: disable-msg=too-many-arguments
     # pylint: disable-msg=too-many-locals

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -32,10 +32,11 @@ class ShowPool(AssetPool):
         return '<ShowPool: {}>'.format(self.name)
 
     # pylint: disable-msg=too-many-arguments
-    def play_with_config(self, show_config: ShowConfig, start_time=None, start_running=True, start_callback=None, stop_callback=None,
-                         start_step=None) -> "RunningShow":
+    def play_with_config(self, show_config: ShowConfig, start_time=None, start_running=True, start_callback=None,
+                         stop_callback=None, start_step=None) -> "RunningShow":
         """Play asset from pool with config."""
-        return self.asset.play_with_config(show_config, start_time, start_running, start_callback, stop_callback, start_step)
+        return self.asset.play_with_config(show_config, start_time, start_running, start_callback, stop_callback,
+                                           start_step)
 
     # pylint: disable-msg=too-many-arguments
     # pylint: disable-msg=too-many-locals

--- a/mpf/tests/machine_files/shows/config/test_show_pools.yaml
+++ b/mpf/tests/machine_files/shows/config/test_show_pools.yaml
@@ -166,6 +166,8 @@ show_player:
         color: blue
         color1: green
         color2: yellow
+  stop_pool_random:
+    pool_random: stop
   play_pool_sequence:
     pool_sequence:
       show_tokens:

--- a/mpf/tests/machine_files/shows/config/test_show_pools.yaml
+++ b/mpf/tests/machine_files/shows/config/test_show_pools.yaml
@@ -1,0 +1,192 @@
+#config_version=5
+
+lights:
+    led_01:
+        number: 0
+        tags: tag1, row0
+    led_02:
+        number: 1
+        tags: tag1, row0
+    led_03:
+        number: 2
+        tags: row1
+    led_04:
+        number: 3
+        tags: row2
+    light_01:
+        number: 0
+        label: Test 0
+        tags: tag1
+        subtype: matrix
+        debug: True
+    light_02:
+        number: 1
+        label: Test 1
+        tags: tag1
+        subtype: matrix
+        debug: True
+    light_03:
+        number: 2
+        label: Test 1
+        fade_ms: 1s
+        subtype: matrix
+        debug: True
+    gi_01:
+        number: 0
+        subtype: gi
+    flasher_01:
+        platform: drivers
+        number: flasher_01
+
+coils:
+    coil_01:
+        number: 1
+        default_pulse_ms: 30
+    flasher_01:
+        number: 2
+        label: Test flasher
+        default_pulse_ms: 40
+        max_hold_power: 1.0
+
+shows:
+  leds_name_token:
+    - time: 0
+      lights:
+        (leds): red
+  leds_single_color:
+    - time: 0
+      lights:
+        led_01: (color)
+  leds_color_token:
+    - time: 0
+      lights:
+        led_01: (color1)
+    - time: +1
+      lights:
+        led_02: (color2)
+    - time: +1
+  leds_extended:
+    - time: 0
+      lights:
+        (leds):
+          color: red
+          fade: 1s
+  lights_basic:
+    - time: 0
+      lights:
+        (lights): ff
+  multiple_tokens:
+    - time: 0
+      lights:
+        (leds): blue
+        (lights): ff
+  show_assoc_tokens:
+    - time: 0
+      lights:
+        (line1num): (line1color)
+  show_with_time_and_duration:
+    - time: +1s
+    - time: 5s
+    - time: +1s
+      duration: 1s
+    - lights:
+        led_02: red
+    - time: 10s
+      duration: 3s
+  leds_color_token_and_fade:
+    - time: 0
+      lights:
+        led_01: (color1)
+    - time: +1
+      lights:
+        led_02: (color2)-f900ms
+    - time: +1
+  manual_advance:
+    - duration: -1
+      lights:
+        (leds): red
+    - duration: -1
+      lights:
+        (leds): lime
+    - duration: -1
+      lights:
+        (leds): blue
+  event_show:
+    - duration: 1
+      events:
+        - step1
+    - duration: 1
+      events:
+        - step2
+    - duration: 1
+      events:
+        - step3
+
+show_pools:
+  pool_random:
+    shows:
+      - leds_name_token
+      - leds_single_color
+      - leds_color_token
+      - leds_extended
+    type: random
+  pool_sequence:
+    shows:
+      - multiple_tokens
+      - show_assoc_tokens
+      - leds_color_token_and_fade
+    type: sequence
+  pool_rfn:
+    shows:
+      - lights_basic
+      - show_with_time_and_duration
+      - manual_advance
+      - event_show
+    type: random_force_next
+  pool_rfa:
+    shows:
+      - leds_name_token
+      - leds_single_color
+      - leds_color_token
+      - leds_extended
+      - multiple_tokens
+      - show_assoc_tokens
+      - leds_color_token_and_fade
+      - lights_basic
+      - show_with_time_and_duration
+      - manual_advance
+      - event_show
+    type: random_force_all
+
+show_player:
+  play_pool_random:
+    pool_random:
+      show_tokens:
+        leds: led_01
+        color: blue
+        color1: green
+        color2: yellow
+  play_pool_sequence:
+    pool_sequence:
+      show_tokens:
+        leds: led_01
+        lights: light_01
+        line1num: led_01
+        line1color: red
+        color1: violet
+        color2: orange
+  play_pool_rfn:
+    pool_rfn:
+      show_tokens:
+        lights: light_01
+        leds: led_01
+  play_pool_rfa:
+    pool_rfa:
+      show_tokens:
+        leds: led_01
+        color: blue
+        color1: green
+        color2: yellow
+        lights: light_01
+        line1num: led_01
+        line1color: red

--- a/mpf/tests/test_ShowPools.py
+++ b/mpf/tests/test_ShowPools.py
@@ -1,0 +1,57 @@
+"""Test show pools."""
+from mpf.tests.MpfTestCase import MpfTestCase, patch
+
+
+class TestShowPools(MpfTestCase):
+
+    def get_config_file(self):
+        return 'test_show_pools.yaml'
+
+    def get_machine_path(self):
+        return 'tests/machine_files/shows/'
+
+    def test_pool_random(self):
+        with patch("mpf.core.assets.random.randint") as rand:
+            rand.return_value = 1
+            self.post_event("play_pool_random")
+            rand.assert_called_with(1, 4)
+        self.assertIn("pool_random", self.machine.show_player.instances["_global"]["show_player"])
+
+        self.assertEqual("leds_name_token",
+                         self.machine.show_player.instances["_global"]["show_player"]["pool_random"].name)
+
+        self.post_event("stop_pool_random")
+        self.assertNotIn("pool_random", self.machine.show_player.instances["_global"]["show_player"])
+
+        with patch("mpf.core.assets.random.randint") as rand:
+            rand.return_value = 2
+            self.post_event("play_pool_random")
+            rand.assert_called_with(1, 4)
+        self.assertIn("pool_random", self.machine.show_player.instances["_global"]["show_player"])
+
+        self.assertEqual("leds_single_color",
+                         self.machine.show_player.instances["_global"]["show_player"]["pool_random"].name)
+
+        self.post_event("stop_pool_random")
+        self.assertNotIn("pool_random", self.machine.show_player.instances["_global"]["show_player"])
+
+        with patch("mpf.core.assets.random.randint") as rand:
+            rand.return_value = 3
+            self.post_event("play_pool_random")
+            rand.assert_called_with(1, 4)
+        self.assertIn("pool_random", self.machine.show_player.instances["_global"]["show_player"])
+
+        self.assertEqual("leds_color_token",
+                         self.machine.show_player.instances["_global"]["show_player"]["pool_random"].name)
+
+        self.post_event("stop_pool_random")
+        self.assertNotIn("pool_random", self.machine.show_player.instances["_global"]["show_player"])
+
+        with patch("mpf.core.assets.random.randint") as rand:
+            rand.return_value = 4
+            self.post_event("play_pool_random")
+            rand.assert_called_with(1, 4)
+        self.assertIn("pool_random", self.machine.show_player.instances["_global"]["show_player"])
+
+        self.assertEqual("leds_extended",
+                         self.machine.show_player.instances["_global"]["show_player"]["pool_random"].name)


### PR DESCRIPTION
Set the param when def show pools, and returning show pools to include
start_running=True, and start_running value returned.  This allows the
show pool to run, as it previously threw an error that the param was
missing.  Now if the show_player sets start_running to false, it
behaves.  But defaults, like show_player, to start running.