### PR TITLE
Support multiple playfield launch targets via relay event

### DIFF
--- a/mpf/modes/game/code/game.py
+++ b/mpf/modes/game/code/game.py
@@ -384,7 +384,9 @@ class Game(AsyncMode):
             raise AssertionError("The game did not define default playfield. Did you add tags: default to one of your "
                                  "playfield?")
 
-        self.machine.playfield.add_ball(player_controlled=True)
+        # This relay event allows handlers to select a new target playfield for the ball
+        result = await self.machine.events.post_relay_async("ball_start_target", target=self.machine.playfield.name)
+        self.machine.playfields[result["target"]].add_ball(player_controlled=True)
 
     def ball_drained(self, balls=0, **kwargs):
         """One or more balls has drained.

--- a/mpf/tests/machine_files/game/config/config.yaml
+++ b/mpf/tests/machine_files/game/config/config.yaml
@@ -33,6 +33,8 @@ playfields:
         default_source_device: bd_launcher
         tags: default
         enable_ball_search: True
+    second_playfield:
+        default_source_device: bd_launcher
 
 ball_devices:
     bd_trough:
@@ -47,4 +49,5 @@ ball_devices:
         ball_switches: s_ball_switch_launcher
         debug: true
         confirm_eject_type: target
+        eject_targets: playfield, second_playfield
         eject_timeouts: 2s


### PR DESCRIPTION
### Summary

This PR adds support for selecting a playfield to target the launch of a new ball. It is useful for when a game has multiple playfields that can be targeted from the plunger device, and the game design requires dynamic selection of which playfield to target.

### Existing Behavior

The existing support for ball targeting is robust, with BallDevice and Playfield devices able to route balls as necessary to a desired target. Unfortunately the playfield device has no parallel to the ball_device's `request_ball_events:` setting, so there's no convenient way for the game logic to direct traffic to a specific playfield. The `playfield_transfers` config is reactionary and indicates _that_ a transfer has taken place, but cannot be used to _request_ a transfer.

This gap in playfield ball requests presents a challenge when starting a new game, because the Game code is hard-coded to request a ball to the default playfield. In a situation where a different playfield may be the desired target, calling `add_ball()` on that playfield will indeed deliver a ball there but the default playfield will still request its ball, leading to unintended multiballs.

### Proposed Solution

This PR injects a new relay event into the game's `_start_ball()` method where the game posts the event _ball_start_target_ with the argument `target=<default_playfield_name>`. A subscribed handler to this event can relay back a different playfield name, and the `_start_ball()` method will request the game to start with the requested target. 

If the game has no handlers subscribed to _ball_start_target_, the default playfield will be used with no behavior change.