### PR TITLE
Segment Display Transitions

### DIFF
--- a/mpf/config_players/segment_display_player.py
+++ b/mpf/config_players/segment_display_player.py
@@ -26,6 +26,7 @@ class SegmentDisplayPlayer(DeviceConfigPlayer):
         super().__init__(machine)
         self.delay = DelayManager(self.machine)
 
+    # pylint: disable=too-many-branches
     def play(self, settings, context, calling_context, priority=0, **kwargs):
         """Show text on display."""
         del kwargs
@@ -83,16 +84,17 @@ class SegmentDisplayPlayer(DeviceConfigPlayer):
         flashing = config.get('flashing', None)
         if flashing == "off":
             return FlashingType.NO_FLASH
-        elif flashing == "all":
+        if flashing == "all":
             return FlashingType.FLASH_ALL
-        elif flashing == "match":
+        if flashing == "match":
             return FlashingType.FLASH_MATCH
-        elif flashing == "mask":
+        if flashing == "mask":
             return FlashingType.FLASH_MASK
-        else:
-            return None
+
+        return None
 
     def _remove(self, instance_dict, key, display):
+        """Remove an instance by key."""
         if key in instance_dict[display]:
             display.remove_text_by_key(key)
             if instance_dict[display][key] is not True:

--- a/mpf/config_players/segment_display_player.py
+++ b/mpf/config_players/segment_display_player.py
@@ -45,15 +45,14 @@ class SegmentDisplayPlayer(DeviceConfigPlayer):
             if action == "add":
                 # add text
                 s = display.transition_manager.validate_config(s)
-                display.add_text(TextStackEntry(text=s['text'],
-                                                color=s['color'],
-                                                flashing=self._get_flashing_type(s),
-                                                flash_mask=s['flash_mask'],
-                                                transition=display.transition_manager.get_transition(s['transition']),
-                                                transition_out=display.transition_manager.get_transition(
-                                                    s['transition_out']),
-                                                priority=priority + s['priority'],
-                                                key=key))
+                display.add_text_entry(TextStackEntry(text=s['text'],
+                                                      color=s['color'],
+                                                      flashing=self._get_flashing_type(s),
+                                                      flash_mask=s['flash_mask'],
+                                                      transition=s['transition'],
+                                                      transition_out=s['transition_out'],
+                                                      priority=priority + s['priority'],
+                                                      key=key))
 
                 if s['expire']:
                     instance_dict[display][key] = self.delay.add(

--- a/mpf/config_players/segment_display_player.py
+++ b/mpf/config_players/segment_display_player.py
@@ -8,7 +8,8 @@ from mpf.platforms.interfaces.segment_display_platform_interface import Flashing
 MYPY = False
 if MYPY:   # pragma: no cover
     from typing import Dict     # pylint: disable-msg=cyclic-import,unused-import
-    from mpf.devices.segment_display.segment_display import SegmentDisplay  # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.devices.segment_display.segment_display import \
+        SegmentDisplay  # pylint: disable-msg=cyclic-import,unused-import
 
 
 class SegmentDisplayPlayer(DeviceConfigPlayer):

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1301,6 +1301,7 @@ segment_displays:
     size: single|int|7
     integrated_dots: single|bool|false
     integrated_commas: single|bool|false
+    default_transition_update_hz: single|float_or_token|30
     platform_settings: single|dict|None
     platform: single|str|None
 light_segment_displays_device:

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1301,6 +1301,7 @@ segment_displays:
     size: single|int|7
     integrated_dots: single|bool|false
     integrated_commas: single|bool|false
+    initial_color: list|color|white
     default_transition_update_hz: single|float_or_token|30
     platform_settings: single|dict|None
     platform: single|str|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -2058,7 +2058,7 @@ widgets:
         padding: single|int_or_token|20
         background_color: single|kivycolor|000000ff
         segment_off_color: single|kivycolor|4b4c4aff
-        segment_on_color: single|kivycolor|dd8217ff
+        segment_on_color: list|kivycolor|dd8217ff
         segment_width: single|float_or_token|0.16
         segment_interval: single|float_or_token|0.05
         bevel_width: single|float_or_token|0.06

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1297,6 +1297,9 @@ segment_displays:
     __valid_in__: machine
     __type__: device
     number: single|str|
+    size: single|int|7
+    integrated_dots: single|bool|false
+    integrated_commas: single|bool|false
     platform_settings: single|dict|None
     platform: single|str|None
 light_segment_displays_device:

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1308,9 +1308,28 @@ segment_display_player:
     priority: single|int_or_token|0
     text: single|str|None
     color: list|color|None
-    action: single|enum(add,remove,flash,no_flash,flash_match,set_color)|add
+    action: single|enum(add,remove,flash,no_flash,flash_match,flash_mask,set_color)|add
+    transition: ignore
+    transition_out: ignore
+    flashing: single|enum(off,all,match,mask,not_set)|not_set
+    flash_mask: single|str|None
     key: single|str|None
     expire: single|ms_or_token|None
+segment_display_transitions:
+    none:
+        type: single|str|
+    push:
+        type: single|str|
+        direction: single|enum(right,left,split_out,split_in)|right
+    cover:
+        type: single|str|
+        direction: single|enum(right,left)|right
+    uncover:
+        type: single|str|
+        direction: single|enum(right,left)|right
+    wipe:
+        type: single|str|
+        direction: single|enum(right,left,split)|right
 servo_controllers:
     __valid_in__: machine
     __type__: config

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1326,16 +1326,28 @@ segment_display_transitions:
         type: single|str|
     push:
         type: single|str|
-        direction: single|enum(right,left,split_out,split_in)|right
+        direction: single|enum(right,left)|right
+        text: single|str|None
+        text_color: list|color|None
     cover:
         type: single|str|
         direction: single|enum(right,left)|right
+        text: single|str|None
+        text_color: list|color|None
     uncover:
         type: single|str|
         direction: single|enum(right,left)|right
+        text: single|str|None
+        text_color: list|color|None
     wipe:
         type: single|str|
-        direction: single|enum(right,left,split)|right
+        direction: single|enum(right,left)|right
+        text: single|str|None
+        text_color: list|color|None
+    split:
+        type: single|str|
+        mode: single|enum(push,wipe)|push
+        direction: single|enum(in,out)|out
 servo_controllers:
     __valid_in__: machine
     __type__: config

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -50,7 +50,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.drop_target import DropTarget, DropTargetBank  # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.logic_blocks import Accrual, Sequence, Counter     # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.devices.servo import Servo     # pylint: disable-msg=cyclic-import,unused-import
-    from mpf.devices.segment_display import SegmentDisplay      # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.devices.segment_display.segment_display import SegmentDisplay      # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.shot_group import ShotGroup    # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.shot import Shot   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.motor import Motor     # pylint: disable-msg=cyclic-import,unused-import

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -50,7 +50,8 @@ if MYPY:   # pragma: no cover
     from mpf.devices.drop_target import DropTarget, DropTargetBank  # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.logic_blocks import Accrual, Sequence, Counter     # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.devices.servo import Servo     # pylint: disable-msg=cyclic-import,unused-import
-    from mpf.devices.segment_display.segment_display import SegmentDisplay      # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.devices.segment_display.segment_display import \
+        SegmentDisplay  # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.shot_group import ShotGroup    # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.shot import Shot   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.motor import Motor     # pylint: disable-msg=cyclic-import,unused-import

--- a/mpf/core/utility_functions.py
+++ b/mpf/core/utility_functions.py
@@ -185,6 +185,16 @@ class Util:
         return final_list
 
     @staticmethod
+    def flatten_list(incoming_list):
+        """Convert a list of nested lists and/or values into a single one-dimensional list."""
+        for item in incoming_list:
+            if isinstance(item, Iterable) and not isinstance(item, str):
+                for inner_item in Util.flatten_list(item):
+                    yield inner_item
+            else:
+                yield item
+
+    @staticmethod
     def dict_merge(a, b, combine_lists=True, deepcopy_both=True) -> dict:
         """Recursively merge dictionaries.
 

--- a/mpf/core/utility_functions.py
+++ b/mpf/core/utility_functions.py
@@ -1,10 +1,11 @@
 """Contains the Util class which includes many utility functions."""
+from collections import Iterable as IterableCollection
 from copy import deepcopy
 import re
 from fractions import Fraction
 from functools import reduce, lru_cache
 
-from typing import Dict, Iterable, List, Tuple, Callable, Any, Union
+from typing import Dict, List, Tuple, Callable, Any, Union, Iterable
 import asyncio
 from ruamel.yaml.compat import ordereddict
 
@@ -188,7 +189,7 @@ class Util:
     def flatten_list(incoming_list):
         """Convert a list of nested lists and/or values into a single one-dimensional list."""
         for item in incoming_list:
-            if isinstance(item, Iterable) and not isinstance(item, str):
+            if isinstance(item, IterableCollection) and not isinstance(item, str):
                 for inner_item in Util.flatten_list(item):
                     yield inner_item
             else:

--- a/mpf/devices/segment_display/__init__.py
+++ b/mpf/devices/segment_display/__init__.py
@@ -1,0 +1,1 @@
+"""Segment display device module."""

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -220,7 +220,7 @@ class SegmentDisplay(SystemWideDevice):
             self._current_placeholder_changed()
 
     def _current_placeholder_changed(self, *args, **kwargs) -> None:
-        """Current placeholder changed callback function."""
+        """Placeholder changed callback function."""
         del args
         del kwargs
         new_text, future = self._current_placeholder.evaluate_and_subscribe({})

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -37,22 +37,23 @@ class SegmentDisplay(SystemWideDevice):
         if not self.transition_manager:
             self.transition_manager = TransitionManager(machine)
 
-        self.hw_display = None                  # type: Optional[SegmentDisplayPlatformInterface]
-        self.platform = None                    # type: Optional[SegmentDisplayPlatform]
-        self.size = 7                           # type: int
-        self.integrated_dots = False            # type: bool
-        self.integrated_commas = False          # type: bool
-        self.text = ""                          # type: Optional[str]
-        self.color = None                       # type: Optional[RGBColor]
-        self.flashing = FlashingType.NO_FLASH   # type: FlashingType
-        self.flash_mask = ""                    # type: Optional[str]
-        self.platform_options = None            # type: Optional[dict]
-        self.virtual_connector = None           # type: Optional[VirtualSegmentDisplayConnector]
-        self._text_stack = {}                   # type: Dict[str:TextStackEntry]
-        self._current_placeholder = None        # type: Optional[TextTemplate]
-        self._current_text_stack_entry = None   # type: Optional[TextStackEntry]
-        self._transition_update_task = None     # type: Optional[PeriodicTask]
-        self._current_transition = None         # type: Optional[Iterator]
+        self.hw_display = None                      # type: Optional[SegmentDisplayPlatformInterface]
+        self.platform = None                        # type: Optional[SegmentDisplayPlatform]
+        self.size = 7                               # type: int
+        self.integrated_dots = False                # type: bool
+        self.integrated_commas = False              # type: bool
+        self.default_transition_update_hz = 30.0    # type: float
+        self.text = ""                              # type: Optional[str]
+        self.color = None                           # type: Optional[RGBColor]
+        self.flashing = FlashingType.NO_FLASH       # type: FlashingType
+        self.flash_mask = ""                        # type: Optional[str]
+        self.platform_options = None                # type: Optional[dict]
+        self.virtual_connector = None               # type: Optional[VirtualSegmentDisplayConnector]
+        self._text_stack = {}                       # type: Dict[str:TextStackEntry]
+        self._current_placeholder = None            # type: Optional[TextTemplate]
+        self._current_text_stack_entry = None       # type: Optional[TextStackEntry]
+        self._transition_update_task = None         # type: Optional[PeriodicTask]
+        self._current_transition = None             # type: Optional[Iterator]
 
     async def _initialize(self):
         """Initialise display."""
@@ -67,6 +68,7 @@ class SegmentDisplay(SystemWideDevice):
         self.size = self.config['size']
         self.integrated_dots = self.config['integrated_dots']
         self.integrated_commas = self.config['integrated_commas']
+        self.default_transition_update_hz = self.config['default_transition_update_hz']
 
         # configure hardware
         try:
@@ -214,7 +216,8 @@ class SegmentDisplay(SystemWideDevice):
             else:
                 previous_text = ""
 
-            self._start_transition(transition, previous_text, top_text_stack_entry.text)
+            self._start_transition(transition, previous_text, top_text_stack_entry.text,
+                                   self.default_transition_update_hz)
         else:
             self._current_placeholder = TextTemplate(self.machine, top_text_stack_entry.text)
             self._current_placeholder_changed()

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -81,7 +81,6 @@ class SegmentDisplay(SystemWideDevice):
                                  "See error above.".format(self.name)) from ex
 
         self.set_color(self.config['initial_color'])
-        self.add_text_entry(self.empty_text_stack_entry)
 
     def add_virtual_connector(self, virtual_connector):
         """Add a virtual connector instance to connect this segment display to the MPF-MC for virtual displays."""

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -220,7 +220,7 @@ class SegmentDisplay(SystemWideDevice):
             self._current_placeholder_changed()
 
     def _current_placeholder_changed(self, *args, **kwargs) -> None:
-        """Placeholder changed callback function."""
+        """Update display when a placeholder changes (callback function)."""
         del args
         del kwargs
         new_text, future = self._current_placeholder.evaluate_and_subscribe({})

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -1,6 +1,6 @@
 """Physical segment displays."""
 from collections import OrderedDict
-from typing import Optional, Dict, Iterator, List
+from typing import Optional, Dict, List
 
 from mpf.core.clock import PeriodicTask
 from mpf.core.rgb_color import RGBColor
@@ -145,6 +145,7 @@ class SegmentDisplay(SystemWideDevice):
             else:
                 self._update_stack()
 
+    # pylint: disable=too-many-arguments
     def _start_transition(self, transition: TransitionBase, current_text: str, new_text: str,
                           current_colors: Optional[List[RGBColor]] = None, new_colors: Optional[List[RGBColor]] = None,
                           update_hz: float = 30.0):
@@ -159,6 +160,7 @@ class SegmentDisplay(SystemWideDevice):
         self._transition_update_task = self.machine.clock.schedule_interval(self._update_transition, 1 / update_hz)
 
     def _update_transition(self):
+        """Update the current transition (callback function from transition interval clock)."""
         try:
             transition_text = next(self._current_transition)
             transition_colors = SegmentDisplayText.get_colors(transition_text)
@@ -168,6 +170,7 @@ class SegmentDisplay(SystemWideDevice):
             self._stop_transition()
 
     def _stop_transition(self):
+        """Stop the current transition."""
         if self._transition_update_task:
             self._transition_update_task.cancel()
             self._transition_update_task = None

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -75,6 +75,7 @@ class SegmentDisplay(SystemWideDevice):
             raise AssertionError("Error in platform while configuring segment display {}. "
                                  "See error above.".format(self.name)) from e
 
+
     def add_virtual_connector(self, virtual_connector):
         """Add a virtual connector instance to connect this segment display to the MPF-MC for virtual displays."""
         self.virtual_connector = virtual_connector
@@ -135,7 +136,10 @@ class SegmentDisplay(SystemWideDevice):
         """Remove entry from text stack."""
         if key in self._text_stack:
             del self._text_stack[key]
-        self._update_stack()
+            if not self._text_stack:
+                self.add_text("", -10000, "empty")
+            else:
+                self._update_stack()
 
     def _start_transition(self, transition: TransitionBase, current_text: str, new_text: str, update_hz: float = 30.0):
         """Start the specified transition."""
@@ -158,7 +162,7 @@ class SegmentDisplay(SystemWideDevice):
 
         if self._current_transition:
             self._current_transition = None
-            if self._current_text_stack_entry:
+            if self._current_text_stack_entry and len(self._current_text_stack_entry.text) > 0:
                 self._current_placeholder = TextTemplate(self.machine, self._current_text_stack_entry.text)
                 self._current_placeholder_changed()
             else:
@@ -186,7 +190,7 @@ class SegmentDisplay(SystemWideDevice):
         # get top entry (highest priority)
         top_text_stack_entry = next(iter(self._text_stack.values()))
         previous_text_stack_entry = self._current_text_stack_entry
-        self._current_text_stack_entry_entry = top_text_stack_entry
+        self._current_text_stack_entry = top_text_stack_entry
 
         # determine if the new key is different than the previous key (out transitions are only applied
         # when changing keys)

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -20,6 +20,7 @@ if MYPY:   # pragma: no cover
     from mpf.core.platform import SegmentDisplayPlatform    # pylint: disable-msg=cyclic-import,unused-import; # noqa
 
 
+# pylint: disable=too-many-instance-attributes
 @DeviceMonitor("text")
 class SegmentDisplay(SystemWideDevice):
 
@@ -71,10 +72,9 @@ class SegmentDisplay(SystemWideDevice):
         try:
             self.hw_display = await self.platform.configure_segment_display(self.config['number'],
                                                                             self.config['platform_settings'])
-        except AssertionError as e:
+        except AssertionError as ex:
             raise AssertionError("Error in platform while configuring segment display {}. "
-                                 "See error above.".format(self.name)) from e
-
+                                 "See error above.".format(self.name)) from ex
 
     def add_virtual_connector(self, virtual_connector):
         """Add a virtual connector instance to connect this segment display to the MPF-MC for virtual displays."""

--- a/mpf/devices/segment_display/segment_display_text.py
+++ b/mpf/devices/segment_display/segment_display_text.py
@@ -1,3 +1,5 @@
+"""Specialized text support classes for segment displays."""
+
 from collections import namedtuple
 
 DisplayCharacter = namedtuple("DisplayCharacter", ["char_code", "dot", "comma"])
@@ -33,10 +35,10 @@ class SegmentDisplayText(list):
         # ensure list is the same size as the segment display (cut off on left or right justify characters)
         current_length = len(self)
         if current_length > display_size:
-            for index in range(current_length - display_size):
+            for _ in range(current_length - display_size):
                 self.pop(0)
         elif current_length < display_size:
-            for index in range(display_size - current_length):
+            for _ in range(display_size - current_length):
                 self.insert(0, DisplayCharacter(self.SPACE_CODE, False, False))
 
     @staticmethod
@@ -51,4 +53,3 @@ class SegmentDisplayText(list):
                 text += ","
 
         return text
-

--- a/mpf/devices/segment_display/segment_display_text.py
+++ b/mpf/devices/segment_display/segment_display_text.py
@@ -39,10 +39,11 @@ class SegmentDisplayText(list):
             for index in range(display_size - current_length):
                 self.insert(0, DisplayCharacter(self.SPACE_CODE, False, False))
 
-    def to_str(self):
+    @staticmethod
+    def convert_to_str(display_character_list: list):
         """Convert back to normal text string"""
         text = ""
-        for display_character in self:
+        for display_character in display_character_list:
             text += chr(display_character.char_code)
             if display_character.dot:
                 text += "."

--- a/mpf/devices/segment_display/segment_display_text.py
+++ b/mpf/devices/segment_display/segment_display_text.py
@@ -1,0 +1,53 @@
+from collections import namedtuple
+
+DisplayCharacter = namedtuple("DisplayCharacter", ["char_code", "dot", "comma"])
+
+
+class SegmentDisplayText(list):
+
+    """A list of characters with specialized functions for segment displays. Use for display text effects."""
+
+    DOT_CODE = ord(".")
+    COMMA_CODE = ord(",")
+    SPACE_CODE = ord(" ")
+
+    def __init__(self, text: str, display_size: int, collapse_dots: bool, collapse_commas: bool) -> None:
+        super().__init__()
+
+        char_has_dot = False
+        char_has_comma = False
+
+        for char in reversed(text):
+            char_code = ord(char)
+            if collapse_dots and char_code == self.DOT_CODE:
+                char_has_dot = True
+                continue
+            if collapse_commas and char_code == self.COMMA_CODE:
+                char_has_comma = True
+                continue
+
+            self.insert(0, DisplayCharacter(char_code, char_has_dot, char_has_comma))
+            char_has_dot = False
+            char_has_comma = False
+
+        # ensure list is the same size as the segment display (cut off on left or right justify characters)
+        current_length = len(self)
+        if current_length > display_size:
+            for index in range(current_length - display_size):
+                self.pop(0)
+        elif current_length < display_size:
+            for index in range(display_size - current_length):
+                self.insert(0, DisplayCharacter(self.SPACE_CODE, False, False))
+
+    def to_str(self):
+        """Convert back to normal text string"""
+        text = ""
+        for display_character in self:
+            text += chr(display_character.char_code)
+            if display_character.dot:
+                text += "."
+            if display_character.comma:
+                text += ","
+
+        return text
+

--- a/mpf/devices/segment_display/segment_display_text.py
+++ b/mpf/devices/segment_display/segment_display_text.py
@@ -1,8 +1,11 @@
 """Specialized text support classes for segment displays."""
 
 from collections import namedtuple
+from typing import Optional, List
 
-DisplayCharacter = namedtuple("DisplayCharacter", ["char_code", "dot", "comma"])
+from mpf.core.rgb_color import RGBColor
+
+DisplayCharacter = namedtuple("DisplayCharacter", ["char_code", "dot", "comma", "color"])
 
 
 class SegmentDisplayText(list):
@@ -13,12 +16,24 @@ class SegmentDisplayText(list):
     COMMA_CODE = ord(",")
     SPACE_CODE = ord(" ")
 
-    def __init__(self, text: str, display_size: int, collapse_dots: bool, collapse_commas: bool) -> None:
+    def __init__(self, text: str, display_size: int, collapse_dots: bool, collapse_commas: bool,
+                 colors: Optional[List[RGBColor]] = None) -> None:
         """Class initializer."""
         super().__init__()
 
         char_has_dot = False
         char_has_comma = False
+
+        if colors:
+            char_colors = colors[:]
+            default_color = colors[0]  # the default color is the color of the first character
+
+            # when fewer colors are supplied than text, extend the last color to the end of the text
+            if len(char_colors) < len(text):
+                char_colors.extend([colors[-1]] * (len(text) - len(char_colors)))
+        else:
+            char_colors = [None] * len(text)
+            default_color = None
 
         for char in reversed(text):
             char_code = ord(char)
@@ -29,7 +44,7 @@ class SegmentDisplayText(list):
                 char_has_comma = True
                 continue
 
-            self.insert(0, DisplayCharacter(char_code, char_has_dot, char_has_comma))
+            self.insert(0, DisplayCharacter(char_code, char_has_dot, char_has_comma, char_colors.pop()))
             char_has_dot = False
             char_has_comma = False
 
@@ -40,7 +55,7 @@ class SegmentDisplayText(list):
                 self.pop(0)
         elif current_length < display_size:
             for _ in range(display_size - current_length):
-                self.insert(0, DisplayCharacter(self.SPACE_CODE, False, False))
+                self.insert(0, DisplayCharacter(self.SPACE_CODE, False, False, default_color))
 
     @staticmethod
     def convert_to_str(display_character_list: list):
@@ -54,3 +69,11 @@ class SegmentDisplayText(list):
                 text += ","
 
         return text
+
+    @staticmethod
+    def get_colors(display_character_list: list):
+        """Get the list of colors for each character (if set)."""
+        # if any colors are set to None, return None
+        if any([not display_character.color for display_character in display_character_list]):
+            return None
+        return [display_character.color for display_character in display_character_list]

--- a/mpf/devices/segment_display/segment_display_text.py
+++ b/mpf/devices/segment_display/segment_display_text.py
@@ -14,6 +14,7 @@ class SegmentDisplayText(list):
     SPACE_CODE = ord(" ")
 
     def __init__(self, text: str, display_size: int, collapse_dots: bool, collapse_commas: bool) -> None:
+        """Class initializer."""
         super().__init__()
 
         char_has_dot = False
@@ -43,7 +44,7 @@ class SegmentDisplayText(list):
 
     @staticmethod
     def convert_to_str(display_character_list: list):
-        """Convert back to normal text string"""
+        """Convert back to normal text string."""
         text = ""
         for display_character in display_character_list:
             text += chr(display_character.char_code)

--- a/mpf/devices/segment_display/segment_display_text.py
+++ b/mpf/devices/segment_display/segment_display_text.py
@@ -16,6 +16,7 @@ class SegmentDisplayText(list):
     COMMA_CODE = ord(",")
     SPACE_CODE = ord(" ")
 
+    # pylint: disable=too-many-arguments
     def __init__(self, text: str, display_size: int, collapse_dots: bool, collapse_commas: bool,
                  colors: Optional[List[RGBColor]] = None) -> None:
         """Class initializer."""

--- a/mpf/devices/segment_display/text_stack_entry.py
+++ b/mpf/devices/segment_display/text_stack_entry.py
@@ -1,0 +1,21 @@
+from typing import Optional, List
+
+from mpf.core.rgb_color import RGBColor
+from mpf.devices.segment_display.transitions import TransitionBase
+from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
+
+
+class TextStackEntry:
+
+    def __init__(self, text: str, color: Optional[List[RGBColor]],
+                 flashing: Optional[FlashingType], flash_mask: Optional[str],
+                 transition: Optional[TransitionBase], transition_out: Optional[TransitionBase],
+                 priority: int = 0, key: str = None):
+        self.text = text
+        self.colors = color
+        self.flashing = flashing
+        self.flash_mask = flash_mask
+        self.transition = transition
+        self.transition_out = transition_out
+        self.priority = priority
+        self.key = key

--- a/mpf/devices/segment_display/text_stack_entry.py
+++ b/mpf/devices/segment_display/text_stack_entry.py
@@ -1,7 +1,6 @@
 from typing import Optional, List
 
 from mpf.core.rgb_color import RGBColor
-from mpf.devices.segment_display.transitions import TransitionBase
 from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
 
 
@@ -9,7 +8,7 @@ class TextStackEntry:
 
     def __init__(self, text: str, color: Optional[List[RGBColor]],
                  flashing: Optional[FlashingType], flash_mask: Optional[str],
-                 transition: Optional[TransitionBase], transition_out: Optional[TransitionBase],
+                 transition: Optional[dict], transition_out: Optional[dict],
                  priority: int = 0, key: str = None):
         self.text = text
         self.colors = color

--- a/mpf/devices/segment_display/text_stack_entry.py
+++ b/mpf/devices/segment_display/text_stack_entry.py
@@ -8,12 +8,14 @@ from mpf.platforms.interfaces.segment_display_platform_interface import Flashing
 
 # pylint: disable=too-many-instance-attributes,too-many-arguments,too-few-public-methods
 class TextStackEntry:
+
     """An entry in the text stack for a segment display."""
 
     def __init__(self, text: str, color: Optional[List[RGBColor]],
                  flashing: Optional[FlashingType], flash_mask: Optional[str],
                  transition: Optional[dict], transition_out: Optional[dict],
                  priority: int = 0, key: str = None):
+        """Class initializer."""
         self.text = text
         self.colors = color
         self.flashing = flashing

--- a/mpf/devices/segment_display/text_stack_entry.py
+++ b/mpf/devices/segment_display/text_stack_entry.py
@@ -12,8 +12,8 @@ class TextStackEntry:
     """An entry in the text stack for a segment display."""
 
     def __init__(self, text: str, color: Optional[List[RGBColor]],
-                 flashing: Optional[FlashingType], flash_mask: Optional[str],
-                 transition: Optional[dict], transition_out: Optional[dict],
+                 flashing: Optional[FlashingType] = None, flash_mask: Optional[str] = None,
+                 transition: Optional[dict] = None, transition_out: Optional[dict] = None,
                  priority: int = 0, key: str = None):
         """Class initializer."""
         self.text = text

--- a/mpf/devices/segment_display/text_stack_entry.py
+++ b/mpf/devices/segment_display/text_stack_entry.py
@@ -1,10 +1,14 @@
+"""Text stack entry support class for segment displays."""
+
 from typing import Optional, List
 
 from mpf.core.rgb_color import RGBColor
 from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
 
 
+# pylint: disable=too-many-instance-attributes,too-many-arguments,too-few-public-methods
 class TextStackEntry:
+    """An entry in the text stack for a segment display."""
 
     def __init__(self, text: str, color: Optional[List[RGBColor]],
                  flashing: Optional[FlashingType], flash_mask: Optional[str],
@@ -18,3 +22,7 @@ class TextStackEntry:
         self.transition_out = transition_out
         self.priority = priority
         self.key = key
+
+    def __repr__(self):
+        """Return str representation."""
+        return '<TextStackEntry: {} (priority: {}, key: {}) >'.format(self.text, self.priority, self.key)

--- a/mpf/devices/segment_display/transition_manager.py
+++ b/mpf/devices/segment_display/transition_manager.py
@@ -15,21 +15,24 @@ class TransitionManager:
         self._register_transitions()
 
     def register_transition(self, name, transition_cls):
+        """Register a text transition."""
         self._transitions[name] = transition_cls
 
     def _register_transitions(self):
+        """Register the built-in text transitions."""
         self.register_transition('push', PushTransition)
         self.register_transition('cover', CoverTransition)
         self.register_transition('uncover', UncoverTransition)
         self.register_transition('wipe', WipeTransition)
 
     def get_transition(self, output_length: int, collapse_dots: bool, collapse_commas: bool, transition_config=None):
+        """Create a transition instance based on the specified configuration."""
         if transition_config:
             config = transition_config.copy()
             config.pop('type')
             return self._transitions[transition_config['type']](output_length, collapse_dots, collapse_commas, config)
-        else:
-            return None
+
+        return None
 
     def validate_config(self, config):
         """Validate segment display transition config."""

--- a/mpf/devices/segment_display/transition_manager.py
+++ b/mpf/devices/segment_display/transition_manager.py
@@ -36,7 +36,6 @@ class TransitionManager:
 
     def validate_config(self, config):
         """Validate segment display transition config."""
-
         if 'transition' in config and config['transition']:
             if not isinstance(config['transition'], dict):
                 config['transition'] = dict(type=config['transition'])

--- a/mpf/devices/segment_display/transition_manager.py
+++ b/mpf/devices/segment_display/transition_manager.py
@@ -1,0 +1,70 @@
+"""Manager for segment display text transitions."""
+
+from mpf.devices.segment_display.transitions import (PushTransition, CoverTransition,
+                                                     UncoverTransition, WipeTransition)
+
+
+class TransitionManager:
+
+    """Manages segment display text transitions."""
+
+    def __init__(self, machine) -> None:
+        """Initialize manager."""
+        self.machine = machine
+        self._transitions = dict()
+        self._register_transitions()
+
+    def register_transition(self, name, transition_cls):
+        self._transitions[name] = transition_cls
+
+    def _register_transitions(self):
+        self.register_transition('push', PushTransition)
+        self.register_transition('cover', CoverTransition)
+        self.register_transition('uncover', UncoverTransition)
+        self.register_transition('wipe', WipeTransition)
+
+    def get_transition(self, current_text: str, new_text: str, output_length: int,
+                       collapse_dots: bool, collapse_commas: bool, transition_config=None):
+        if transition_config:
+            # The kivy shader transitions can't accept unexpected kwargs
+            config = transition_config.copy()
+            config.pop('type')
+            return self._transitions[transition_config['type']](current_text, new_text, output_length, collapse_dots,
+                                                                collapse_commas, config)
+        else:
+            return None
+
+    def validate_transitions(self, config):
+
+        if 'transition' in config:
+            if not isinstance(config['transition'], dict):
+                config['transition'] = dict(type=config['transition'])
+
+            try:
+                config['transition'] = (
+                    self.machine.config_validator.validate_config(
+                        'segment_display_transitions:{}'.format(config['transition']['type']),
+                        config['transition']))
+
+            except KeyError:
+                raise ValueError('transition: section of config requires a "type:" setting')
+        else:
+            config['transition'] = None
+
+        if 'transition_out' in config:
+            if not isinstance(config['transition_out'], dict):
+                config['transition_out'] = dict(type=config['transition_out'])
+
+            try:
+                config['transition_out'] = (
+                    self.machine.config_validator.validate_config(
+                        'segment_display_transitions:{}'.format(
+                            config['transition_out']['type']),
+                        config['transition_out']))
+
+            except KeyError:
+                raise ValueError('transition_out: section of config requires a "type:" setting')
+        else:
+            config['transition_out'] = None
+
+        return config

--- a/mpf/devices/segment_display/transition_manager.py
+++ b/mpf/devices/segment_display/transition_manager.py
@@ -23,20 +23,18 @@ class TransitionManager:
         self.register_transition('uncover', UncoverTransition)
         self.register_transition('wipe', WipeTransition)
 
-    def get_transition(self, current_text: str, new_text: str, output_length: int,
-                       collapse_dots: bool, collapse_commas: bool, transition_config=None):
+    def get_transition(self, output_length: int, collapse_dots: bool, collapse_commas: bool, transition_config=None):
         if transition_config:
-            # The kivy shader transitions can't accept unexpected kwargs
             config = transition_config.copy()
             config.pop('type')
-            return self._transitions[transition_config['type']](current_text, new_text, output_length, collapse_dots,
-                                                                collapse_commas, config)
+            return self._transitions[transition_config['type']](output_length, collapse_dots, collapse_commas, config)
         else:
             return None
 
-    def validate_transitions(self, config):
+    def validate_config(self, config):
+        """Validate segment display transition config."""
 
-        if 'transition' in config:
+        if 'transition' in config and config['transition']:
             if not isinstance(config['transition'], dict):
                 config['transition'] = dict(type=config['transition'])
 
@@ -51,7 +49,7 @@ class TransitionManager:
         else:
             config['transition'] = None
 
-        if 'transition_out' in config:
+        if 'transition_out' in config and config['transition_out']:
             if not isinstance(config['transition_out'], dict):
                 config['transition_out'] = dict(type=config['transition_out'])
 

--- a/mpf/devices/segment_display/transition_manager.py
+++ b/mpf/devices/segment_display/transition_manager.py
@@ -1,7 +1,7 @@
 """Manager for segment display text transitions."""
 
 from mpf.devices.segment_display.transitions import (PushTransition, CoverTransition,
-                                                     UncoverTransition, WipeTransition)
+                                                     UncoverTransition, WipeTransition, SplitTransition)
 
 
 class TransitionManager:
@@ -24,6 +24,7 @@ class TransitionManager:
         self.register_transition('cover', CoverTransition)
         self.register_transition('uncover', UncoverTransition)
         self.register_transition('wipe', WipeTransition)
+        self.register_transition('split', SplitTransition)
 
     def get_transition(self, output_length: int, collapse_dots: bool, collapse_commas: bool, transition_config=None):
         """Create a transition instance based on the specified configuration."""

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -1,6 +1,5 @@
 """Text transitions used for segment displays."""
 import abc
-from typing import List
 
 from mpf.core.placeholder_manager import TextTemplate
 from mpf.devices.segment_display.segment_display_text import SegmentDisplayText
@@ -34,7 +33,10 @@ class TransitionBase(metaclass=abc.ABCMeta):
 
 class TransitionRunner:
 
+    """Class to run/execute transitions using an iterator."""
+
     def __init__(self, machine, transition: TransitionBase, current_text: str, new_text: str):
+        """Class initializer."""
         self.machine = machine
         self.transition = transition
         self.step = 0
@@ -42,9 +44,11 @@ class TransitionRunner:
         self.new_placeholder = TextTemplate(self.machine, new_text)
 
     def __iter__(self):
+        """Returns an iterator"""
         return self
 
     def __next__(self):
+        """Evaluate and return the next transition step."""
         if self.step >= self.transition.get_step_count():
             raise StopIteration
 
@@ -58,9 +62,6 @@ class TransitionRunner:
 class NoTransition(TransitionBase):
 
     """Segment display no transition effect."""
-
-    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
-        super().__init__(output_length, collapse_dots, collapse_commas, config)
 
     def get_step_count(self):
         """Return the total number of steps required for the transition"""
@@ -104,15 +105,15 @@ class PushTransition(TransitionBase):
             temp_list.extend(current_display_text)
             return temp_list[self.output_length - (step + 1):2 * self.output_length - (step + 1)]
 
-        elif self.direction == 'left':
+        if self.direction == 'left':
             temp_list = current_display_text
             temp_list.extend(new_display_text)
             return temp_list[step + 1:step + 1 + self.output_length]
 
-        elif self.direction == 'split_out':
+        if self.direction == 'split_out':
             if step == self.get_step_count() - 1:
                 return new_display_text
-            
+
             characters = int(self.output_length / 2)
             split_point = characters
             if characters * 2 == self.output_length:
@@ -126,7 +127,7 @@ class PushTransition(TransitionBase):
             temp_text.extend(current_display_text[split_point:split_point + characters])
             return temp_text
 
-        elif self.direction == 'split_in':
+        if self.direction == 'split_in':
             if step == self.get_step_count() - 1:
                 return new_display_text
 
@@ -140,9 +141,8 @@ class PushTransition(TransitionBase):
             temp_text.extend(current_display_text[characters:characters + (self.output_length - 2 * characters)])
             temp_text.extend(new_display_text[split_point:split_point + characters])
             return temp_text
-        
-        else:
-            raise AssertionError("Transition uses an unknown direction value")
+
+        raise AssertionError("Transition uses an unknown direction value")
 
 
 class CoverTransition(TransitionBase):
@@ -171,13 +171,12 @@ class CoverTransition(TransitionBase):
             temp_text.extend(current_display_text[step + 1:])
             return temp_text
 
-        elif self.direction == 'left':
+        if self.direction == 'left':
             temp_text = current_display_text[:self.output_length - (step + 1)]
             temp_text.extend(new_display_text[:step + 1])
             return temp_text
 
-        else:
-            raise AssertionError("Transition uses an unknown direction value")
+        raise AssertionError("Transition uses an unknown direction value")
 
 
 class UncoverTransition(TransitionBase):
@@ -206,13 +205,12 @@ class UncoverTransition(TransitionBase):
             temp_text.extend(current_display_text[:self.output_length - (step + 1)])
             return temp_text
 
-        elif self.direction == 'left':
+        if self.direction == 'left':
             temp_text = current_display_text[step + 1:]
             temp_text.extend(new_display_text[-(step + 1):])
             return temp_text
 
-        else:
-            raise AssertionError("Transition uses an unknown direction value")
+        raise AssertionError("Transition uses an unknown direction value")
 
 
 class WipeTransition(TransitionBase):
@@ -244,12 +242,12 @@ class WipeTransition(TransitionBase):
             temp_text.extend(current_display_text[step + 1:])
             return temp_text
 
-        elif self.direction == 'left':
+        if self.direction == 'left':
             temp_text = current_display_text[:self.output_length - (step + 1)]
             temp_text.extend(new_display_text[-(step + 1):])
             return temp_text
 
-        elif self.direction == 'split':
+        if self.direction == 'split':
             if step == self.get_step_count() - 1:
                 return new_display_text
 
@@ -263,5 +261,4 @@ class WipeTransition(TransitionBase):
             temp_text.extend(current_display_text[-characters:])
             return temp_text
 
-        else:
-            raise AssertionError("Transition uses an unknown direction value")
+        raise AssertionError("Transition uses an unknown direction value")

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -135,8 +135,8 @@ class PushTransition(TransitionBase):
             temp_list.extend(transition_text)
             temp_list.extend(current_display_text)
             return temp_list[
-                   self.output_length + len(self.text) - (step + 1):2 * self.output_length + len(self.text) - (
-                               step + 1)]
+                self.output_length + len(self.text) - (step + 1):2 * self.output_length + len(
+                    self.text) - (step + 1)]
 
         if self.direction == 'left':
             temp_list = current_display_text
@@ -262,7 +262,7 @@ class UncoverTransition(TransitionBase):
 
             if step < len(self.text):
                 temp_text = current_extended_display_text[
-                            len(self.text) - step - 1:len(self.text) - step - 1 + self.output_length]
+                    len(self.text) - step - 1:len(self.text) - step - 1 + self.output_length]
             else:
                 temp_text = new_display_text[:step - len(self.text) + 1]
                 temp_text.extend(current_extended_display_text[:self.output_length - len(temp_text)])
@@ -301,7 +301,7 @@ class WipeTransition(TransitionBase):
         """Return the total number of steps required for the transition."""
         return self.output_length + len(self.text)
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-branches,too-many-return-statements
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
                             new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:
@@ -369,7 +369,7 @@ class SplitTransition(TransitionBase):
         """Return the total number of steps required for the transition."""
         return int((self.output_length + 1) / 2)
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-branches,too-many-return-statements
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
                             new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -10,7 +10,7 @@ class TransitionBase(metaclass=abc.ABCMeta):
     """Base class for text transitions in segment displays."""
 
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
-        """Initialize the transition"""
+        """Initialize the transition."""
         self.output_length = output_length
         self.config = config
         self.collapse_dots = collapse_dots
@@ -22,7 +22,7 @@ class TransitionBase(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_step_count(self):
-        """Return the total number of steps required for the transition"""
+        """Return the total number of steps required for the transition."""
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -44,7 +44,7 @@ class TransitionRunner:
         self.new_placeholder = TextTemplate(self.machine, new_text)
 
     def __iter__(self):
-        """Returns an iterator"""
+        """Return an iterator."""
         return self
 
     def __next__(self):
@@ -64,7 +64,7 @@ class NoTransition(TransitionBase):
     """Segment display no transition effect."""
 
     def get_step_count(self):
-        """Return the total number of steps required for the transition"""
+        """Return the total number of steps required for the transition."""
         return 1
 
     def get_transition_step(self, step: int, current_text: str,
@@ -81,11 +81,12 @@ class PushTransition(TransitionBase):
     """Segment display push transition effect."""
 
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        """Class initializer."""
         self.direction = 'right'
         super().__init__(output_length, collapse_dots, collapse_commas, config)
 
     def get_step_count(self):
-        """Return the total number of steps required for the transition"""
+        """Return the total number of steps required for the transition."""
         if self.direction in ['split_out', 'split_in']:
             return int((self.output_length + 1) / 2)
 
@@ -150,11 +151,12 @@ class CoverTransition(TransitionBase):
     """Segment display cover transition effect."""
 
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        """Class initializer."""
         self.direction = 'right'
         super().__init__(output_length, collapse_dots, collapse_commas, config)
 
     def get_step_count(self):
-        """Return the total number of steps required for the transition"""
+        """Return the total number of steps required for the transition."""
         return self.output_length
 
     def get_transition_step(self, step: int, current_text: str, new_text: str) -> SegmentDisplayText:
@@ -184,11 +186,12 @@ class UncoverTransition(TransitionBase):
     """Segment display uncover transition effect."""
 
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        """Class initializer."""
         self.direction = 'right'
         super().__init__(output_length, collapse_dots, collapse_commas, config)
 
     def get_step_count(self):
-        """Return the total number of steps required for the transition"""
+        """Return the total number of steps required for the transition."""
         return self.output_length
 
     def get_transition_step(self, step: int, current_text: str, new_text: str) -> SegmentDisplayText:
@@ -218,11 +221,12 @@ class WipeTransition(TransitionBase):
     """Segment display wipe transition effect."""
 
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        """Class initializer."""
         self.direction = 'right'
         super().__init__(output_length, collapse_dots, collapse_commas, config)
 
     def get_step_count(self):
-        """Return the total number of steps required for the transition"""
+        """Return the total number of steps required for the transition."""
         if self.direction == 'split':
             return int((self.output_length + 1) / 2)
 

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -2,6 +2,7 @@
 import abc
 from typing import List
 
+from mpf.core.placeholder_manager import TextTemplate
 from mpf.devices.segment_display.segment_display_text import SegmentDisplayText
 
 
@@ -9,216 +10,258 @@ class TransitionBase(metaclass=abc.ABCMeta):
 
     """Base class for text transitions in segment displays."""
 
-    # String of the config section name
-    config_section = None   # type: str
-
-    def __init__(self, current_text: str, new_text: str, output_length: int, collapse_dots: bool,
-                 collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         """Initialize the transition"""
-        self.current_text = SegmentDisplayText(current_text, output_length, collapse_dots, collapse_commas)
-        self.new_text = SegmentDisplayText(new_text, output_length, collapse_dots, collapse_commas)
         self.output_length = output_length
         self.config = config
-        self.transition_steps = []  # type: List[SegmentDisplayText]
+        self.collapse_dots = collapse_dots
+        self.collapse_commas = collapse_commas
 
         for key, value in config.items():
             if hasattr(self, key):
                 setattr(self, key, value)
 
-        self.transition_steps = self.calculate_transition_steps(self.current_text, self.new_text)
+    @abc.abstractmethod
+    def get_step_count(self):
+        """Return the total number of steps required for the transition"""
+        raise NotImplementedError
 
     @abc.abstractmethod
-    def calculate_transition_steps(self, current_text: SegmentDisplayText,
-                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+    def get_transition_step(self, step: int, current_text: str, new_text: str) -> SegmentDisplayText:
         """Calculate all the steps in the transition."""
         raise NotImplementedError
+
+
+class TransitionRunner:
+
+    def __init__(self, machine, transition: TransitionBase, current_text: str, new_text: str):
+        self.machine = machine
+        self.transition = transition
+        self.step = 0
+        self.current_placeholder = TextTemplate(self.machine, current_text)
+        self.new_placeholder = TextTemplate(self.machine, new_text)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.step >= self.transition.get_step_count():
+            raise StopIteration
+
+        transition_step = self.transition.get_transition_step(self.step,
+                                                              self.current_placeholder.evaluate({}),
+                                                              self.new_placeholder.evaluate({}))
+        self.step += 1
+        return transition_step
 
 
 class NoTransition(TransitionBase):
 
     """Segment display no transition effect."""
 
-    config_section = 'text_transition_none'
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        super().__init__(output_length, collapse_dots, collapse_commas, config)
 
-    def __init__(self, current_text: str, new_text: str, output_length: int,
-                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
-        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+    def get_step_count(self):
+        """Return the total number of steps required for the transition"""
+        return 1
 
-    def calculate_transition_steps(self, current_text: SegmentDisplayText,
-                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+    def get_transition_step(self, step: int, current_text: str,
+                            new_text: str) -> SegmentDisplayText:
         """Calculate all the steps in the transition."""
-        return [new_text]
+        if step < 0 or step >= self.get_step_count():
+            raise AssertionError("Step is out of range")
+
+        return SegmentDisplayText(new_text, self.output_length, self.collapse_dots, self.collapse_commas)
 
 
 class PushTransition(TransitionBase):
 
     """Segment display push transition effect."""
 
-    config_section = 'text_transition_push'
-
-    def __init__(self, current_text: str, new_text: str, output_length: int,
-                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         self.direction = 'right'
-        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, config)
 
-    def calculate_transition_steps(self, current_text: SegmentDisplayText,
-                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+    def get_step_count(self):
+        """Return the total number of steps required for the transition"""
+        if self.direction in ['split_out', 'split_in']:
+            return int((self.output_length + 1) / 2)
+
+        return self.output_length
+
+    def get_transition_step(self, step: int, current_text: str, new_text: str) -> SegmentDisplayText:
         """Calculate all the steps in the transition."""
-        display_length = len(current_text)
-        transition_steps = []
+        if step < 0 or step >= self.get_step_count():
+            raise AssertionError("Step is out of range")
+
+        current_display_text = SegmentDisplayText(current_text, self.output_length, self.collapse_dots,
+                                                  self.collapse_commas)
+        new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots, self.collapse_commas)
 
         if self.direction == 'right':
-            temp_list = new_text
-            temp_list.extend(current_text)
-
-            for index in range(1, display_length + 1):
-                transition_steps.append(temp_list[display_length - index:2 * display_length - index])
+            temp_list = new_display_text
+            temp_list.extend(current_display_text)
+            return temp_list[self.output_length - (step + 1):2 * self.output_length - (step + 1)]
 
         elif self.direction == 'left':
-            temp_list = current_text
-            temp_list.extend(new_text)
-
-            for index in range(1, display_length + 1):
-                transition_steps.append(temp_list[index:index + display_length])
+            temp_list = current_display_text
+            temp_list.extend(new_display_text)
+            return temp_list[step + 1:step + 1 + self.output_length]
 
         elif self.direction == 'split_out':
-            characters = int(display_length / 2)
+            if step == self.get_step_count() - 1:
+                return new_display_text
+            
+            characters = int(self.output_length / 2)
             split_point = characters
-            if characters * 2 == display_length:
+            if characters * 2 == self.output_length:
                 characters -= 1
             else:
                 split_point += 1
 
-            while characters > 0:
-                temp_text = current_text[split_point - characters:split_point]
-                temp_text.extend(new_text[characters:characters + (display_length - 2 * characters)])
-                temp_text.extend(current_text[split_point:split_point + characters])
-                transition_steps.append(temp_text)
-                characters -= 1
-
-            transition_steps.append(new_text)
+            characters -= step
+            temp_text = current_display_text[split_point - characters:split_point]
+            temp_text.extend(new_display_text[characters:characters + (self.output_length - 2 * characters)])
+            temp_text.extend(current_display_text[split_point:split_point + characters])
+            return temp_text
 
         elif self.direction == 'split_in':
-            split_point = int(display_length / 2)
+            if step == self.get_step_count() - 1:
+                return new_display_text
+
+            split_point = int(self.output_length / 2)
             characters = 1
-            if split_point * 2 < display_length:
+            if split_point * 2 < self.output_length:
                 split_point += 1
 
-            while characters <= split_point:
-                temp_text = new_text[split_point - characters:split_point]
-                temp_text.extend(current_text[characters:characters + (display_length - 2 * characters)])
-                temp_text.extend(new_text[split_point:split_point + characters])
-                transition_steps.append(temp_text)
-                characters += 1
-
-        return transition_steps
+            characters += step
+            temp_text = new_display_text[split_point - characters:split_point]
+            temp_text.extend(current_display_text[characters:characters + (self.output_length - 2 * characters)])
+            temp_text.extend(new_display_text[split_point:split_point + characters])
+            return temp_text
+        
+        else:
+            raise AssertionError("Transition uses an unknown direction value")
 
 
 class CoverTransition(TransitionBase):
 
     """Segment display cover transition effect."""
 
-    config_section = 'text_transition_cover'
-
-    def __init__(self, current_text: str, new_text: str, output_length: int,
-                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         self.direction = 'right'
-        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, config)
 
-    def calculate_transition_steps(self, current_text: SegmentDisplayText,
-                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+    def get_step_count(self):
+        """Return the total number of steps required for the transition"""
+        return self.output_length
+
+    def get_transition_step(self, step: int, current_text: str, new_text: str) -> SegmentDisplayText:
         """Calculate all the steps in the transition."""
-        display_length = len(current_text)
-        transition_steps = []
+        if step < 0 or step >= self.get_step_count():
+            raise AssertionError("Step is out of range")
+
+        current_display_text = SegmentDisplayText(current_text, self.output_length, self.collapse_dots,
+                                                  self.collapse_commas)
+        new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots, self.collapse_commas)
 
         if self.direction == 'right':
-            for index in range(display_length):
-                temp_text = new_text[-(index + 1):]
-                temp_text.extend(current_text[index + 1:])
-                transition_steps.append(temp_text)
+            temp_text = new_display_text[-(step + 1):]
+            temp_text.extend(current_display_text[step + 1:])
+            return temp_text
 
         elif self.direction == 'left':
-            for index in range(1, display_length + 1):
-                temp_text = current_text[:display_length - index]
-                temp_text.extend(new_text[:index])
-                transition_steps.append(temp_text)
+            temp_text = current_display_text[:self.output_length - (step + 1)]
+            temp_text.extend(new_display_text[:step + 1])
+            return temp_text
 
-        return transition_steps
+        else:
+            raise AssertionError("Transition uses an unknown direction value")
 
 
 class UncoverTransition(TransitionBase):
 
     """Segment display uncover transition effect."""
 
-    config_section = 'text_transition_uncover'
-
-    def __init__(self, current_text: str, new_text: str, output_length: int,
-                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         self.direction = 'right'
-        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, config)
 
-    def calculate_transition_steps(self, current_text: SegmentDisplayText,
-                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+    def get_step_count(self):
+        """Return the total number of steps required for the transition"""
+        return self.output_length
+
+    def get_transition_step(self, step: int, current_text: str, new_text: str) -> SegmentDisplayText:
         """Calculate all the steps in the transition."""
-        display_length = len(current_text)
-        transition_steps = []
+        if step < 0 or step >= self.get_step_count():
+            raise AssertionError("Step is out of range")
+
+        current_display_text = SegmentDisplayText(current_text, self.output_length, self.collapse_dots,
+                                                  self.collapse_commas)
+        new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots, self.collapse_commas)
 
         if self.direction == 'right':
-            for index in range(1, display_length + 1):
-                temp_text = new_text[:index]
-                temp_text.extend(current_text[:display_length - index])
-                transition_steps.append(temp_text)
+            temp_text = new_display_text[:step + 1]
+            temp_text.extend(current_display_text[:self.output_length - (step + 1)])
+            return temp_text
 
         elif self.direction == 'left':
-            for index in range(1, display_length + 1):
-                temp_text = current_text[index:]
-                temp_text.extend(new_text[-index:])
-                transition_steps.append(temp_text)
+            temp_text = current_display_text[step + 1:]
+            temp_text.extend(new_display_text[-(step + 1):])
+            return temp_text
 
-        return transition_steps
+        else:
+            raise AssertionError("Transition uses an unknown direction value")
 
 
 class WipeTransition(TransitionBase):
 
     """Segment display wipe transition effect."""
 
-    config_section = 'text_transition_wipe'
-
-    def __init__(self, current_text: str, new_text: str, output_length: int,
-                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         self.direction = 'right'
-        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, config)
 
-    def calculate_transition_steps(self, current_text: SegmentDisplayText,
-                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+    def get_step_count(self):
+        """Return the total number of steps required for the transition"""
+        if self.direction == 'split':
+            return int((self.output_length + 1) / 2)
+
+        return self.output_length
+
+    def get_transition_step(self, step: int, current_text: str, new_text: str) -> SegmentDisplayText:
         """Calculate all the steps in the transition."""
-        display_length = len(current_text)
-        transition_steps = []
+        if step < 0 or step >= self.get_step_count():
+            raise AssertionError("Step is out of range")
+
+        current_display_text = SegmentDisplayText(current_text, self.output_length, self.collapse_dots,
+                                                  self.collapse_commas)
+        new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots, self.collapse_commas)
 
         if self.direction == 'right':
-            for index in range(1, display_length + 1):
-                temp_text = new_text[:index]
-                temp_text.extend(current_text[index:])
-                transition_steps.append(temp_text)
+            temp_text = new_display_text[:step + 1]
+            temp_text.extend(current_display_text[step + 1:])
+            return temp_text
 
         elif self.direction == 'left':
-            for index in range(1, display_length + 1):
-                temp_text = current_text[:display_length - index]
-                temp_text.extend(new_text[-index:])
-                transition_steps.append(temp_text)
+            temp_text = current_display_text[:self.output_length - (step + 1)]
+            temp_text.extend(new_display_text[-(step + 1):])
+            return temp_text
 
         elif self.direction == 'split':
-            characters = int(display_length / 2)
-            if characters * 2 == display_length:
+            if step == self.get_step_count() - 1:
+                return new_display_text
+
+            characters = int(self.output_length / 2)
+            if characters * 2 == self.output_length:
                 characters -= 1
 
-            while characters > 0:
-                temp_text = current_text[:characters]
-                temp_text.extend(new_text[characters:characters + (display_length - 2 * characters)])
-                temp_text.extend(current_text[-characters:])
-                transition_steps.append(temp_text)
-                characters -= 1
+            characters -= step
+            temp_text = current_display_text[:characters]
+            temp_text.extend(new_display_text[characters:characters + (self.output_length - 2 * characters)])
+            temp_text.extend(current_display_text[-characters:])
+            return temp_text
 
-            transition_steps.append(new_text)
-
-        return transition_steps
+        else:
+            raise AssertionError("Transition uses an unknown direction value")

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -96,14 +96,16 @@ class PushTransition(TransitionBase):
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
+        self.text = None
+        self.text_color = None
         super().__init__(output_length, collapse_dots, collapse_commas, config)
+
+        if self.text is None:
+            self.text = ''
 
     def get_step_count(self):
         """Return the total number of steps required for the transition."""
-        if self.direction in ['split_out', 'split_in']:
-            return int((self.output_length + 1) / 2)
-
-        return self.output_length
+        return self.output_length + len(self.text)
 
     # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
@@ -118,47 +120,29 @@ class PushTransition(TransitionBase):
         new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots,
                                               self.collapse_commas, new_colors)
 
+        if self.text:
+            if new_colors and not self.text_color:
+                text_color = [new_colors[0]]
+            else:
+                text_color = self.text_color
+            transition_text = SegmentDisplayText(self.text, len(self.text), self.collapse_dots,
+                                                 self.collapse_commas, text_color)
+        else:
+            transition_text = []
+
         if self.direction == 'right':
             temp_list = new_display_text
+            temp_list.extend(transition_text)
             temp_list.extend(current_display_text)
-            return temp_list[self.output_length - (step + 1):2 * self.output_length - (step + 1)]
+            return temp_list[
+                   self.output_length + len(self.text) - (step + 1):2 * self.output_length + len(self.text) - (
+                               step + 1)]
 
         if self.direction == 'left':
             temp_list = current_display_text
+            temp_list.extend(transition_text)
             temp_list.extend(new_display_text)
             return temp_list[step + 1:step + 1 + self.output_length]
-
-        if self.direction == 'split_out':
-            if step == self.get_step_count() - 1:
-                return new_display_text
-
-            characters = int(self.output_length / 2)
-            split_point = characters
-            if characters * 2 == self.output_length:
-                characters -= 1
-            else:
-                split_point += 1
-
-            characters -= step
-            temp_text = current_display_text[split_point - characters:split_point]
-            temp_text.extend(new_display_text[characters:characters + (self.output_length - 2 * characters)])
-            temp_text.extend(current_display_text[split_point:split_point + characters])
-            return temp_text
-
-        if self.direction == 'split_in':
-            if step == self.get_step_count() - 1:
-                return new_display_text
-
-            split_point = int(self.output_length / 2)
-            characters = 1
-            if split_point * 2 < self.output_length:
-                split_point += 1
-
-            characters += step
-            temp_text = new_display_text[split_point - characters:split_point]
-            temp_text.extend(current_display_text[characters:characters + (self.output_length - 2 * characters)])
-            temp_text.extend(new_display_text[split_point:split_point + characters])
-            return temp_text
 
         raise AssertionError("Transition uses an unknown direction value")
 
@@ -170,11 +154,16 @@ class CoverTransition(TransitionBase):
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
+        self.text = None
+        self.text_color = None
         super().__init__(output_length, collapse_dots, collapse_commas, config)
+
+        if self.text is None:
+            self.text = ''
 
     def get_step_count(self):
         """Return the total number of steps required for the transition."""
-        return self.output_length
+        return self.output_length + len(self.text)
 
     # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
@@ -189,14 +178,38 @@ class CoverTransition(TransitionBase):
         new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots,
                                               self.collapse_commas, new_colors)
 
+        if self.text:
+            if new_colors and not self.text_color:
+                text_color = [new_colors[0]]
+            else:
+                text_color = self.text_color
+            transition_text = SegmentDisplayText(self.text, len(self.text), self.collapse_dots,
+                                                 self.collapse_commas, text_color)
+        else:
+            transition_text = []
+
         if self.direction == 'right':
-            temp_text = new_display_text[-(step + 1):]
-            temp_text.extend(current_display_text[step + 1:])
+            new_extended_display_text = new_display_text
+            new_extended_display_text.extend(transition_text)
+
+            if step < self.output_length:
+                temp_text = new_extended_display_text[-(step + 1):]
+                temp_text.extend(current_display_text[step + 1:])
+            else:
+                temp_text = new_display_text[-(step + 1):-(step + 1) + self.output_length]
+
             return temp_text
 
         if self.direction == 'left':
-            temp_text = current_display_text[:self.output_length - (step + 1)]
-            temp_text.extend(new_display_text[:step + 1])
+            new_extended_display_text = transition_text
+            new_extended_display_text.extend(new_display_text)
+
+            if step < self.output_length:
+                temp_text = current_display_text[:self.output_length - (step + 1)]
+                temp_text.extend(new_extended_display_text[:step + 1])
+            else:
+                temp_text = new_extended_display_text[step - self.output_length + 1:step + 1]
+
             return temp_text
 
         raise AssertionError("Transition uses an unknown direction value")
@@ -209,11 +222,16 @@ class UncoverTransition(TransitionBase):
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
+        self.text = None
+        self.text_color = None
         super().__init__(output_length, collapse_dots, collapse_commas, config)
+
+        if self.text is None:
+            self.text = ''
 
     def get_step_count(self):
         """Return the total number of steps required for the transition."""
-        return self.output_length
+        return self.output_length + len(self.text)
 
     # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
@@ -228,14 +246,38 @@ class UncoverTransition(TransitionBase):
         new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots,
                                               self.collapse_commas, new_colors)
 
+        if self.text:
+            if new_colors and not self.text_color:
+                text_color = [new_colors[0]]
+            else:
+                text_color = self.text_color
+            transition_text = SegmentDisplayText(self.text, len(self.text), self.collapse_dots,
+                                                 self.collapse_commas, text_color)
+        else:
+            transition_text = []
+
         if self.direction == 'right':
-            temp_text = new_display_text[:step + 1]
-            temp_text.extend(current_display_text[:self.output_length - (step + 1)])
+            current_extended_display_text = transition_text
+            current_extended_display_text.extend(current_display_text)
+
+            if step < len(self.text):
+                temp_text = current_extended_display_text[
+                            len(self.text) - step - 1:len(self.text) - step - 1 + self.output_length]
+            else:
+                temp_text = new_display_text[:step - len(self.text) + 1]
+                temp_text.extend(current_extended_display_text[:self.output_length - len(temp_text)])
+
             return temp_text
 
         if self.direction == 'left':
-            temp_text = current_display_text[step + 1:]
-            temp_text.extend(new_display_text[-(step + 1):])
+            current_extended_display_text = current_display_text
+            current_extended_display_text.extend(transition_text)
+
+            if step < len(self.text):
+                temp_text = current_extended_display_text[step + 1:step + 1 + self.output_length]
+            else:
+                temp_text = current_display_text[step + 1:]
+                temp_text.extend(new_display_text[-(self.output_length - len(temp_text)):])
             return temp_text
 
         raise AssertionError("Transition uses an unknown direction value")
@@ -248,14 +290,16 @@ class WipeTransition(TransitionBase):
     def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
+        self.text = None
+        self.text_color = None
         super().__init__(output_length, collapse_dots, collapse_commas, config)
+
+        if self.text is None:
+            self.text = ''
 
     def get_step_count(self):
         """Return the total number of steps required for the transition."""
-        if self.direction == 'split':
-            return int((self.output_length + 1) / 2)
-
-        return self.output_length
+        return self.output_length + len(self.text)
 
     # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
@@ -270,28 +314,133 @@ class WipeTransition(TransitionBase):
         new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots,
                                               self.collapse_commas, new_colors)
 
+        if self.text:
+            if new_colors and not self.text_color:
+                text_color = [new_colors[0]]
+            else:
+                text_color = self.text_color
+            transition_text = SegmentDisplayText(self.text, len(self.text), self.collapse_dots,
+                                                 self.collapse_commas, text_color)
+        else:
+            transition_text = []
+
         if self.direction == 'right':
-            temp_text = new_display_text[:step + 1]
-            temp_text.extend(current_display_text[step + 1:])
+            if step < len(self.text):
+                temp_text = transition_text[-(step + 1):]
+                temp_text.extend(current_display_text[step + 1:])
+            elif step < self.output_length:
+                temp_text = new_display_text[:step - len(self.text) + 1]
+                temp_text.extend(transition_text)
+                temp_text.extend(current_display_text[len(temp_text):])
+            else:
+                temp_text = new_display_text[:step - len(self.text) + 1]
+                temp_text.extend(transition_text[:self.output_length - len(temp_text)])
             return temp_text
 
         if self.direction == 'left':
-            temp_text = current_display_text[:self.output_length - (step + 1)]
-            temp_text.extend(new_display_text[-(step + 1):])
-            return temp_text
-
-        if self.direction == 'split':
-            if step == self.get_step_count() - 1:
-                return new_display_text
-
-            characters = int(self.output_length / 2)
-            if characters * 2 == self.output_length:
-                characters -= 1
-
-            characters -= step
-            temp_text = current_display_text[:characters]
-            temp_text.extend(new_display_text[characters:characters + (self.output_length - 2 * characters)])
-            temp_text.extend(current_display_text[-characters:])
+            if step < len(self.text):
+                temp_text = current_display_text[:self.output_length - (step + 1)]
+                temp_text.extend(transition_text[:step + 1])
+            elif step < self.output_length:
+                temp_text = current_display_text[:self.output_length - (step + 1)]
+                temp_text.extend(transition_text)
+                temp_text.extend(new_display_text[len(temp_text):])
+            elif step < self.output_length + len(self.text) - 1:
+                temp_text = transition_text[step - (self.output_length + len(self.text)) + 1:]
+                temp_text.extend(new_display_text[-(self.output_length - len(temp_text)):])
+            else:
+                temp_text = new_display_text
             return temp_text
 
         raise AssertionError("Transition uses an unknown direction value")
+
+
+class SplitTransition(TransitionBase):
+
+    """Segment display split transition effect."""
+
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        """Class initializer."""
+        self.direction = 'out'
+        self.mode = 'push'
+        super().__init__(output_length, collapse_dots, collapse_commas, config)
+
+    def get_step_count(self):
+        """Return the total number of steps required for the transition."""
+        return int((self.output_length + 1) / 2)
+
+    # pylint: disable=too-many-arguments
+    def get_transition_step(self, step: int, current_text: str, new_text: str,
+                            current_colors: Optional[List[RGBColor]] = None,
+                            new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:
+        """Calculate all the steps in the transition."""
+        if step < 0 or step >= self.get_step_count():
+            raise AssertionError("Step is out of range")
+
+        current_display_text = SegmentDisplayText(current_text, self.output_length, self.collapse_dots,
+                                                  self.collapse_commas, current_colors)
+        new_display_text = SegmentDisplayText(new_text, self.output_length, self.collapse_dots,
+                                              self.collapse_commas, new_colors)
+
+        if self.mode == 'push':
+            if self.direction == 'out':
+                if step == self.get_step_count() - 1:
+                    return new_display_text
+
+                characters = int(self.output_length / 2)
+                split_point = characters
+                if characters * 2 == self.output_length:
+                    characters -= 1
+                else:
+                    split_point += 1
+
+                characters -= step
+                temp_text = current_display_text[split_point - characters:split_point]
+                temp_text.extend(new_display_text[characters:characters + (self.output_length - 2 * characters)])
+                temp_text.extend(current_display_text[split_point:split_point + characters])
+                return temp_text
+
+            if self.direction == 'in':
+                if step == self.get_step_count() - 1:
+                    return new_display_text
+
+                split_point = int(self.output_length / 2)
+                characters = 1
+                if split_point * 2 < self.output_length:
+                    split_point += 1
+
+                characters += step
+                temp_text = new_display_text[split_point - characters:split_point]
+                temp_text.extend(current_display_text[characters:characters + (self.output_length - 2 * characters)])
+                temp_text.extend(new_display_text[split_point:split_point + characters])
+                return temp_text
+
+            raise AssertionError("Transition uses an unknown direction value")
+
+        if self.mode == 'wipe':
+            if self.direction == 'out':
+                if step == self.get_step_count() - 1:
+                    return new_display_text
+
+                characters = int(self.output_length / 2)
+                if characters * 2 == self.output_length:
+                    characters -= 1
+
+                characters -= step
+                temp_text = current_display_text[:characters]
+                temp_text.extend(new_display_text[characters:characters + (self.output_length - 2 * characters)])
+                temp_text.extend(current_display_text[-characters:])
+                return temp_text
+
+            if self.direction == 'in':
+                if step == self.get_step_count() - 1:
+                    return new_display_text
+
+                temp_text = new_display_text[:step + 1]
+                temp_text.extend(current_display_text[step + 1:step + 1 + (self.output_length - 2 * len(temp_text))])
+                temp_text.extend(new_display_text[-(step + 1):])
+                return temp_text
+
+            raise AssertionError("Transition uses an unknown direction value")
+
+        raise AssertionError("Transition uses an unknown mode value")

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -1,0 +1,224 @@
+"""Text transitions used for segment displays."""
+import abc
+from typing import List
+
+from mpf.devices.segment_display.segment_display_text import SegmentDisplayText
+
+
+class TransitionBase(metaclass=abc.ABCMeta):
+
+    """Base class for text transitions in segment displays."""
+
+    # String of the config section name
+    config_section = None   # type: str
+
+    def __init__(self, current_text: str, new_text: str, output_length: int, collapse_dots: bool,
+                 collapse_commas: bool, config: dict) -> None:
+        """Initialize the transition"""
+        self.current_text = SegmentDisplayText(current_text, output_length, collapse_dots, collapse_commas)
+        self.new_text = SegmentDisplayText(new_text, output_length, collapse_dots, collapse_commas)
+        self.output_length = output_length
+        self.config = config
+        self.transition_steps = []  # type: List[SegmentDisplayText]
+
+        for key, value in config.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+
+        self.transition_steps = self.calculate_transition_steps(self.current_text, self.new_text)
+
+    @abc.abstractmethod
+    def calculate_transition_steps(self, current_text: SegmentDisplayText,
+                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+        """Calculate all the steps in the transition."""
+        raise NotImplementedError
+
+
+class NoTransition(TransitionBase):
+
+    """Segment display no transition effect."""
+
+    config_section = 'text_transition_none'
+
+    def __init__(self, current_text: str, new_text: str, output_length: int,
+                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+
+    def calculate_transition_steps(self, current_text: SegmentDisplayText,
+                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+        """Calculate all the steps in the transition."""
+        return [new_text]
+
+
+class PushTransition(TransitionBase):
+
+    """Segment display push transition effect."""
+
+    config_section = 'text_transition_push'
+
+    def __init__(self, current_text: str, new_text: str, output_length: int,
+                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        self.direction = 'right'
+        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+
+    def calculate_transition_steps(self, current_text: SegmentDisplayText,
+                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+        """Calculate all the steps in the transition."""
+        display_length = len(current_text)
+        transition_steps = []
+
+        if self.direction == 'right':
+            temp_list = new_text
+            temp_list.extend(current_text)
+
+            for index in range(1, display_length + 1):
+                transition_steps.append(temp_list[display_length - index:2 * display_length - index])
+
+        elif self.direction == 'left':
+            temp_list = current_text
+            temp_list.extend(new_text)
+
+            for index in range(1, display_length + 1):
+                transition_steps.append(temp_list[index:index + display_length])
+
+        elif self.direction == 'split_out':
+            characters = int(display_length / 2)
+            split_point = characters
+            if characters * 2 == display_length:
+                characters -= 1
+            else:
+                split_point += 1
+
+            while characters > 0:
+                temp_text = current_text[split_point - characters:split_point]
+                temp_text.extend(new_text[characters:characters + (display_length - 2 * characters)])
+                temp_text.extend(current_text[split_point:split_point + characters])
+                transition_steps.append(temp_text)
+                characters -= 1
+
+            transition_steps.append(new_text)
+
+        elif self.direction == 'split_in':
+            split_point = int(display_length / 2)
+            characters = 1
+            if split_point * 2 < display_length:
+                split_point += 1
+
+            while characters <= split_point:
+                temp_text = new_text[split_point - characters:split_point]
+                temp_text.extend(current_text[characters:characters + (display_length - 2 * characters)])
+                temp_text.extend(new_text[split_point:split_point + characters])
+                transition_steps.append(temp_text)
+                characters += 1
+
+        return transition_steps
+
+
+class CoverTransition(TransitionBase):
+
+    """Segment display cover transition effect."""
+
+    config_section = 'text_transition_cover'
+
+    def __init__(self, current_text: str, new_text: str, output_length: int,
+                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        self.direction = 'right'
+        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+
+    def calculate_transition_steps(self, current_text: SegmentDisplayText,
+                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+        """Calculate all the steps in the transition."""
+        display_length = len(current_text)
+        transition_steps = []
+
+        if self.direction == 'right':
+            for index in range(display_length):
+                temp_text = new_text[-(index + 1):]
+                temp_text.extend(current_text[index + 1:])
+                transition_steps.append(temp_text)
+
+        elif self.direction == 'left':
+            for index in range(1, display_length + 1):
+                temp_text = current_text[:display_length - index]
+                temp_text.extend(new_text[:index])
+                transition_steps.append(temp_text)
+
+        return transition_steps
+
+
+class UncoverTransition(TransitionBase):
+
+    """Segment display uncover transition effect."""
+
+    config_section = 'text_transition_uncover'
+
+    def __init__(self, current_text: str, new_text: str, output_length: int,
+                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        self.direction = 'right'
+        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+
+    def calculate_transition_steps(self, current_text: SegmentDisplayText,
+                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+        """Calculate all the steps in the transition."""
+        display_length = len(current_text)
+        transition_steps = []
+
+        if self.direction == 'right':
+            for index in range(1, display_length + 1):
+                temp_text = new_text[:index]
+                temp_text.extend(current_text[:display_length - index])
+                transition_steps.append(temp_text)
+
+        elif self.direction == 'left':
+            for index in range(1, display_length + 1):
+                temp_text = current_text[index:]
+                temp_text.extend(new_text[-index:])
+                transition_steps.append(temp_text)
+
+        return transition_steps
+
+
+class WipeTransition(TransitionBase):
+
+    """Segment display wipe transition effect."""
+
+    config_section = 'text_transition_wipe'
+
+    def __init__(self, current_text: str, new_text: str, output_length: int,
+                 collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+        self.direction = 'right'
+        super().__init__(current_text, new_text, output_length, collapse_dots, collapse_commas, config)
+
+    def calculate_transition_steps(self, current_text: SegmentDisplayText,
+                                   new_text: SegmentDisplayText) -> List[SegmentDisplayText]:
+        """Calculate all the steps in the transition."""
+        display_length = len(current_text)
+        transition_steps = []
+
+        if self.direction == 'right':
+            for index in range(1, display_length + 1):
+                temp_text = new_text[:index]
+                temp_text.extend(current_text[index:])
+                transition_steps.append(temp_text)
+
+        elif self.direction == 'left':
+            for index in range(1, display_length + 1):
+                temp_text = current_text[:display_length - index]
+                temp_text.extend(new_text[-index:])
+                transition_steps.append(temp_text)
+
+        elif self.direction == 'split':
+            characters = int(display_length / 2)
+            if characters * 2 == display_length:
+                characters -= 1
+
+            while characters > 0:
+                temp_text = current_text[:characters]
+                temp_text.extend(new_text[characters:characters + (display_length - 2 * characters)])
+                temp_text.extend(current_text[-characters:])
+                transition_steps.append(temp_text)
+                characters -= 1
+
+            transition_steps.append(new_text)
+
+        return transition_steps

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -27,6 +27,7 @@ class TransitionBase(metaclass=abc.ABCMeta):
         """Return the total number of steps required for the transition."""
         raise NotImplementedError
 
+    # pylint: disable=too-many-arguments
     @abc.abstractmethod
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
@@ -39,6 +40,7 @@ class TransitionRunner:
 
     """Class to run/execute transitions using an iterator."""
 
+    # pylint: disable=too-many-arguments
     def __init__(self, machine, transition: TransitionBase, current_text: str, new_text: str,
                  current_colors: Optional[List[RGBColor]] = None,
                  new_colors: Optional[List[RGBColor]] = None) -> None:
@@ -76,6 +78,7 @@ class NoTransition(TransitionBase):
         """Return the total number of steps required for the transition."""
         return 1
 
+    # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
                             new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:
@@ -102,6 +105,7 @@ class PushTransition(TransitionBase):
 
         return self.output_length
 
+    # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
                             new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:
@@ -172,6 +176,7 @@ class CoverTransition(TransitionBase):
         """Return the total number of steps required for the transition."""
         return self.output_length
 
+    # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
                             new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:
@@ -210,6 +215,7 @@ class UncoverTransition(TransitionBase):
         """Return the total number of steps required for the transition."""
         return self.output_length
 
+    # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
                             new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:
@@ -251,6 +257,7 @@ class WipeTransition(TransitionBase):
 
         return self.output_length
 
+    # pylint: disable=too-many-arguments
     def get_transition_step(self, step: int, current_text: str, new_text: str,
                             current_colors: Optional[List[RGBColor]] = None,
                             new_colors: Optional[List[RGBColor]] = None) -> SegmentDisplayText:

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -80,7 +80,7 @@ mpf:
         accruals: mpf.devices.logic_blocks.Accrual
         sequences: mpf.devices.logic_blocks.Sequence
         timers: mpf.devices.timer.Timer
-        segment_displays: mpf.devices.segment_display.SegmentDisplay
+        segment_displays: mpf.devices.segment_display.segment_display.SegmentDisplay
         sequence_shots: mpf.devices.sequence_shot.SequenceShot
         hardware_sound_systems: mpf.devices.hardware_sound_system.HardwareSoundSystem
         steppers: mpf.devices.stepper.Stepper

--- a/mpf/platforms/fast/fast_segment_display.py
+++ b/mpf/platforms/fast/fast_segment_display.py
@@ -21,8 +21,10 @@ class FASTSegmentDisplay(SegmentDisplayPlatformInterface):
         self.serial = communicator
         self.hex_id = Util.int_to_hex_string(index * 7)
 
-    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH) -> None:
+    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH, flash_mask: str = "") -> None:
         """Set digits to display."""
+        del flashing
+        del flash_mask
         self.serial.send(('PA:{},{}').format(
             self.hex_id, text[0:7]))
 

--- a/mpf/platforms/fast/fast_segment_display.py
+++ b/mpf/platforms/fast/fast_segment_display.py
@@ -1,6 +1,6 @@
 """Segment display on the FAST platform."""
 
-from typing import List
+from typing import List, Optional
 
 from mpf.core.utility_functions import Util
 from mpf.core.rgb_color import RGBColor
@@ -21,12 +21,15 @@ class FASTSegmentDisplay(SegmentDisplayPlatformInterface):
         self.serial = communicator
         self.hex_id = Util.int_to_hex_string(index * 7)
 
-    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH, flash_mask: str = "") -> None:
+    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH, flash_mask: str = "",
+                 colors: Optional[List[RGBColor]] = None) -> None:
         """Set digits to display."""
         del flashing
         del flash_mask
         self.serial.send(('PA:{},{}').format(
             self.hex_id, text[0:7]))
+        if colors:
+            self.set_color(colors)
 
     def set_color(self, colors: List[RGBColor]) -> None:
         """Set display color."""

--- a/mpf/platforms/interfaces/segment_display_platform_interface.py
+++ b/mpf/platforms/interfaces/segment_display_platform_interface.py
@@ -81,12 +81,14 @@ class SegmentDisplaySoftwareFlashPlatformInterface(SegmentDisplayPlatformInterfa
         """Set a text to the display."""
         self._text = text
         self._flashing = flashing
+
         if flashing == FlashingType.NO_FLASH:
             self._flash_on = True
+        elif flashing == FlashingType.FLASH_MASK:
+            self._flash_mask = flash_mask.rjust(len(text))
+
         if flashing == FlashingType.NO_FLASH or self._flash_on or not text:
             self._set_text(text)
-        if flashing == FlashingType.FLASH_MASK:
-            self._flash_mask = flash_mask.rjust(len(text))
 
     @abc.abstractmethod
     def _set_text(self, text: str) -> None:

--- a/mpf/platforms/interfaces/segment_display_platform_interface.py
+++ b/mpf/platforms/interfaces/segment_display_platform_interface.py
@@ -1,7 +1,9 @@
 """Support for physical segment displays."""
 import abc
-from typing import Any
+from typing import Any, List, Optional
 from enum import Enum
+
+from mpf.core.rgb_color import RGBColor
 
 
 class FlashingType(Enum):
@@ -25,7 +27,8 @@ class SegmentDisplayPlatformInterface(metaclass=abc.ABCMeta):
         self.number = number
 
     @abc.abstractmethod
-    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
+    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH, flash_mask: str = "",
+                 colors: Optional[List[RGBColor]] = None) -> None:
         """Set a text to the display.
 
         This text will be right aligned in case the text is shorter than the display.
@@ -34,7 +37,7 @@ class SegmentDisplayPlatformInterface(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_color(self, colors: Any) -> None:
+    def set_color(self, colors: List[RGBColor]) -> None:
         """Set the color(s) of the display."""
         raise NotImplementedError
 
@@ -77,7 +80,8 @@ class SegmentDisplaySoftwareFlashPlatformInterface(SegmentDisplayPlatformInterfa
             else:
                 self._set_text("")
 
-    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
+    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH, flash_mask: str = "",
+                 colors: Optional[List[RGBColor]] = None) -> None:
         """Set a text to the display."""
         self._text = text
         self._flashing = flashing
@@ -89,6 +93,9 @@ class SegmentDisplaySoftwareFlashPlatformInterface(SegmentDisplayPlatformInterfa
 
         if flashing == FlashingType.NO_FLASH or self._flash_on or not text:
             self._set_text(text)
+
+        if colors:
+            self.set_color(colors)
 
     @abc.abstractmethod
     def _set_text(self, text: str) -> None:

--- a/mpf/platforms/interfaces/segment_display_platform_interface.py
+++ b/mpf/platforms/interfaces/segment_display_platform_interface.py
@@ -11,6 +11,7 @@ class FlashingType(Enum):
     NO_FLASH = False
     FLASH_ALL = True
     FLASH_MATCH = "match"
+    FLASH_MASK = "mask"
 
 
 class SegmentDisplayPlatformInterface(metaclass=abc.ABCMeta):
@@ -24,7 +25,7 @@ class SegmentDisplayPlatformInterface(metaclass=abc.ABCMeta):
         self.number = number
 
     @abc.abstractmethod
-    def set_text(self, text: str, flashing: FlashingType) -> None:
+    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
         """Set a text to the display.
 
         This text will be right aligned in case the text is shorter than the display.
@@ -42,13 +43,14 @@ class SegmentDisplaySoftwareFlashPlatformInterface(SegmentDisplayPlatformInterfa
 
     """SegmentDisplayPlatformInterface with software emulation for flashing."""
 
-    __slots__ = ["_flash_on", "_flashing", "_text"]
+    __slots__ = ["_flash_on", "_flashing", "_flash_mask", "_text"]
 
     def __init__(self, number: Any) -> None:
         """Remember the number."""
         super().__init__(number)
         self._flash_on = True
         self._flashing = FlashingType.NO_FLASH      # type: FlashingType
+        self._flash_mask = ""
         self._text = ""
 
     def set_software_flash(self, state):
@@ -68,10 +70,14 @@ class SegmentDisplaySoftwareFlashPlatformInterface(SegmentDisplayPlatformInterfa
             if self._flashing == FlashingType.FLASH_MATCH:
                 # blank the last two chars
                 self._set_text(self._text[0:-2] + "  ")
+            elif self._flashing == FlashingType.FLASH_MASK:
+                # use the flash_mask to determine which characters to blank
+                self._set_text(
+                    "".join(char if mask != "F" else " " for char, mask in zip(self._text, self._flash_mask)))
             else:
                 self._set_text("")
 
-    def set_text(self, text: str, flashing: FlashingType) -> None:
+    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
         """Set a text to the display."""
         self._text = text
         self._flashing = flashing
@@ -79,6 +85,8 @@ class SegmentDisplaySoftwareFlashPlatformInterface(SegmentDisplayPlatformInterfa
             self._flash_on = True
         if flashing == FlashingType.NO_FLASH or self._flash_on or not text:
             self._set_text(text)
+        if flashing == FlashingType.FLASH_MASK:
+            self._flash_mask = flash_mask.rjust(len(text))
 
     @abc.abstractmethod
     def _set_text(self, text: str) -> None:

--- a/mpf/platforms/lisy/lisy.py
+++ b/mpf/platforms/lisy/lisy.py
@@ -236,7 +236,7 @@ class LisyDisplay(SegmentDisplaySoftwareFlashPlatformInterface):
 
     def set_color(self, colors: List[RGBColor]) -> None:
         """Set the color(s) of the display."""
-        raise NotImplementedError
+        # not supported currently
 
 
 class LisySound(HardwareSoundPlatformInterface):

--- a/mpf/platforms/mypinballs/mypinballs.py
+++ b/mpf/platforms/mypinballs/mypinballs.py
@@ -1,7 +1,8 @@
 """Mypinballs hardware platform."""
 import re
-from typing import Any
+from typing import Any, List, Optional
 
+from mpf.core.rgb_color import RGBColor
 from mpf.platforms.interfaces.segment_display_platform_interface import SegmentDisplayPlatformInterface, FlashingType
 
 from mpf.core.platform import SegmentDisplayPlatform
@@ -19,9 +20,11 @@ class MyPinballsSegmentDisplay(SegmentDisplayPlatformInterface):
         # clear the display
         self.set_text("", FlashingType.NO_FLASH)
 
-    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = ""):
+    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH, flash_mask: str = "",
+                 colors: Optional[List[RGBColor]] = None) -> None:
         """Set digits to display."""
         del flash_mask
+        del colors
         if not text:
             # blank display
             cmd = b'3:' + bytes([ord(str(self.number))]) + b'\n'
@@ -41,7 +44,7 @@ class MyPinballsSegmentDisplay(SegmentDisplayPlatformInterface):
             cmd += bytes([ord(str(self.number))]) + b':' + text.encode() + b'\n'
         self.platform.send_cmd(cmd)
 
-    def set_color(self, colors: Any) -> None:
+    def set_color(self, colors: List[RGBColor]) -> None:
         """Set the color(s) of the display."""
         # currently not supported
 

--- a/mpf/platforms/mypinballs/mypinballs.py
+++ b/mpf/platforms/mypinballs/mypinballs.py
@@ -19,8 +19,9 @@ class MyPinballsSegmentDisplay(SegmentDisplayPlatformInterface):
         # clear the display
         self.set_text("", FlashingType.NO_FLASH)
 
-    def set_text(self, text: str, flashing: FlashingType):
+    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = ""):
         """Set digits to display."""
+        del flash_mask
         if not text:
             # blank display
             cmd = b'3:' + bytes([ord(str(self.number))]) + b'\n'

--- a/mpf/platforms/mypinballs/mypinballs.py
+++ b/mpf/platforms/mypinballs/mypinballs.py
@@ -1,6 +1,6 @@
 """Mypinballs hardware platform."""
 import re
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from mpf.core.rgb_color import RGBColor
 from mpf.platforms.interfaces.segment_display_platform_interface import SegmentDisplayPlatformInterface, FlashingType

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -315,7 +315,7 @@ class VirtualSegmentDisplay(SegmentDisplayPlatformInterface):
 
     """Virtual segment display."""
 
-    __slots__ = ["text", "flashing", "platform_options", "colors", "machine", "post_update_events"]
+    __slots__ = ["text", "flashing", "flash_mask", "colors", "machine", "post_update_events"]
 
     def __init__(self, number, machine) -> None:
         """Initialise virtual segment display."""
@@ -323,12 +323,14 @@ class VirtualSegmentDisplay(SegmentDisplayPlatformInterface):
         self.machine = machine
         self.text = ''
         self.flashing = FlashingType.NO_FLASH
+        self.flash_mask = ""
         self.colors = [RGBColor('FFFFFF')]
 
-    def set_text(self, text: str, flashing: FlashingType) -> None:
+    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
         """Set text."""
         self.text = text
         self.flashing = flashing
+        self.flash_mask = flash_mask
 
     def set_color(self, colors: List[RGBColor]) -> None:
         """Set color(s)."""

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -22,6 +22,7 @@ from mpf.core.utility_functions import Util
 from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface, PulseSettings, HoldSettings
 
 
+# pylint: disable=too-many-ancestors,too-many-public-methods
 class VirtualHardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform, LightsPlatform, SwitchPlatform,
                               DriverPlatform, DmdPlatform, RgbDmdPlatform, SegmentDisplayPlatform, StepperPlatform,
                               HardwareSoundPlatform):
@@ -150,6 +151,7 @@ class VirtualHardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform,
 
     def validate_segment_display_section(self, segment_display, config):
         """Validate segment display sections."""
+        del segment_display
         return config
 
     def configure_accelerometer(self, number, config, callback):
@@ -268,6 +270,7 @@ class VirtualHardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform,
 
     async def configure_segment_display(self, number: str, platform_settings) -> SegmentDisplayPlatformInterface:
         """Configure segment display."""
+        del platform_settings
         return VirtualSegmentDisplay(number, self.machine)
 
     async def configure_i2c(self, number: str) -> "I2cPlatformInterface":

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -326,11 +326,14 @@ class VirtualSegmentDisplay(SegmentDisplayPlatformInterface):
         self.flash_mask = ""
         self.colors = [RGBColor('FFFFFF')]
 
-    def set_text(self, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
+    def set_text(self, text: str, flashing: FlashingType = FlashingType.NO_FLASH, flash_mask: str = "",
+                 colors: Optional[List[RGBColor]] = None) -> None:
         """Set text."""
         self.text = text
         self.flashing = flashing
         self.flash_mask = flash_mask
+        if colors:
+            self.colors = colors
 
     def set_color(self, colors: List[RGBColor]) -> None:
         """Set color(s)."""

--- a/mpf/plugins/virtual_segment_display_connector.py
+++ b/mpf/plugins/virtual_segment_display_connector.py
@@ -55,7 +55,7 @@ class VirtualSegmentDisplayConnector:
             text=text,
             flashing=str(flashing.value),
             flash_mask=flash_mask,
-            colors=[color.hex for color in colors] if colors else None)
+            colors=[RGBColor(color).hex for color in colors] if colors else None)
 
     def set_color(self, name: str, colors: List[RGBColor]) -> None:
         """Set the display colors to send to MPF-MC via BCP."""
@@ -63,4 +63,4 @@ class VirtualSegmentDisplayConnector:
             client=self.bcp_client,
             name='update_segment_display',
             segment_display_name=name,
-            colors=[color.hex for color in colors])
+            colors=[RGBColor(color).hex for color in colors])

--- a/mpf/plugins/virtual_segment_display_connector.py
+++ b/mpf/plugins/virtual_segment_display_connector.py
@@ -1,7 +1,7 @@
 """MPF plugin which connects segment displays to MPF-MC to update segment display emulator widgets."""
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from mpf.core.rgb_color import RGBColor
 from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
@@ -42,14 +42,15 @@ class VirtualSegmentDisplayConnector:
             for display in self.config['segment_displays']:
                 display.add_virtual_connector(self)
 
-    def set_text(self, name: str, text: str, flashing: FlashingType) -> None:
+    def set_text(self, name: str, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
         """Set the display text to send to MPF-MC via BCP."""
         self.machine.bcp.interface.bcp_trigger_client(
             client=self.bcp_client,
             name='update_segment_display',
             segment_display_name=name,
             text=text,
-            flashing=flashing)
+            flashing=str(flashing.value),
+            flash_mask=flash_mask)
 
     def set_color(self, name: str, colors: Any) -> None:
         """Set the display colors to send to MPF-MC via BCP."""

--- a/mpf/plugins/virtual_segment_display_connector.py
+++ b/mpf/plugins/virtual_segment_display_connector.py
@@ -48,6 +48,7 @@ class VirtualSegmentDisplayConnector:
     def set_text(self, name: str, text: str, flashing: FlashingType, flash_mask: str = "",
                  colors: Optional[List[RGBColor]] = None) -> None:
         """Set the display text to send to MPF-MC via BCP."""
+
         self.machine.bcp.interface.bcp_trigger_client(
             client=self.bcp_client,
             name='update_segment_display',
@@ -55,7 +56,7 @@ class VirtualSegmentDisplayConnector:
             text=text,
             flashing=str(flashing.value),
             flash_mask=flash_mask,
-            colors=colors)
+            colors=[color.hex for color in colors] if colors else None)
 
     def set_color(self, name: str, colors: List[RGBColor]) -> None:
         """Set the display colors to send to MPF-MC via BCP."""

--- a/mpf/plugins/virtual_segment_display_connector.py
+++ b/mpf/plugins/virtual_segment_display_connector.py
@@ -1,7 +1,7 @@
 """MPF plugin which connects segment displays to MPF-MC to update segment display emulator widgets."""
 
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 from mpf.core.rgb_color import RGBColor
 from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
@@ -42,7 +42,8 @@ class VirtualSegmentDisplayConnector:
             for display in self.config['segment_displays']:
                 display.add_virtual_connector(self)
 
-    def set_text(self, name: str, text: str, flashing: FlashingType, flash_mask: str = "") -> None:
+    def set_text(self, name: str, text: str, flashing: FlashingType, flash_mask: str = "",
+                 colors: Optional[List[RGBColor]] = None) -> None:
         """Set the display text to send to MPF-MC via BCP."""
         self.machine.bcp.interface.bcp_trigger_client(
             client=self.bcp_client,
@@ -50,14 +51,13 @@ class VirtualSegmentDisplayConnector:
             segment_display_name=name,
             text=text,
             flashing=str(flashing.value),
-            flash_mask=flash_mask)
+            flash_mask=flash_mask,
+            colors=colors)
 
-    def set_color(self, name: str, colors: Any) -> None:
+    def set_color(self, name: str, colors: List[RGBColor]) -> None:
         """Set the display colors to send to MPF-MC via BCP."""
-        if not isinstance(colors, list):
-            colors = [colors]
         self.machine.bcp.interface.bcp_trigger_client(
             client=self.bcp_client,
             name='update_segment_display',
             segment_display_name=name,
-            color=[RGBColor(color).hex for color in colors])
+            colors=[color.hex for color in colors])

--- a/mpf/plugins/virtual_segment_display_connector.py
+++ b/mpf/plugins/virtual_segment_display_connector.py
@@ -1,7 +1,7 @@
 """MPF plugin which connects segment displays to MPF-MC to update segment display emulator widgets."""
 
 import logging
-from typing import Any, Optional, List
+from typing import Optional, List
 
 from mpf.core.rgb_color import RGBColor
 from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
@@ -14,6 +14,8 @@ if MYPY:   # pragma: no cover
 class VirtualSegmentDisplayConnector:
 
     """MPF plugin which connects segment displays to MPF-MC to update segment display emulator widgets."""
+
+    __slots__ = ["log", "machine", "bcp_client", "config"]
 
     def __init__(self, machine):
         """Initialize virtual segment display connector plugin."""
@@ -42,6 +44,7 @@ class VirtualSegmentDisplayConnector:
             for display in self.config['segment_displays']:
                 display.add_virtual_connector(self)
 
+    # pylint: disable=too-many-arguments
     def set_text(self, name: str, text: str, flashing: FlashingType, flash_mask: str = "",
                  colors: Optional[List[RGBColor]] = None) -> None:
         """Set the display text to send to MPF-MC via BCP."""

--- a/mpf/plugins/virtual_segment_display_connector.py
+++ b/mpf/plugins/virtual_segment_display_connector.py
@@ -48,7 +48,6 @@ class VirtualSegmentDisplayConnector:
     def set_text(self, name: str, text: str, flashing: FlashingType, flash_mask: str = "",
                  colors: Optional[List[RGBColor]] = None) -> None:
         """Set the display text to send to MPF-MC via BCP."""
-
         self.machine.bcp.interface.bcp_trigger_client(
             client=self.bcp_client,
             name='update_segment_display',

--- a/mpf/tests/machine_files/segment_display/config/config.yaml
+++ b/mpf/tests/machine_files/segment_display/config/config.yaml
@@ -6,6 +6,7 @@ modes:
 segment_displays:
   display1:
     number: 1
+    size: 10
   display2:
     number: 2
   display3:
@@ -53,3 +54,34 @@ segment_display_player:
     display3:
       text: "UPDATE"
       color: "FF0000"
+
+  test_transition:
+    display1:
+      priority: 15
+      key: transition
+      text: "  SCROLL  "
+      transition:
+        type: push
+        direction: right
+      transition_out:
+        type: push
+        direction: left
+      expire: 2s
+
+  test_transition_2:
+    display1:
+      priority: 15
+      key: transition
+      text: "0123456789"
+      transition:
+        type: wipe
+        direction: split
+
+  test_transition_3:
+    display1:
+      priority: 15
+      key: transition
+      text: "ABCDEFGHIJ"
+      transition:
+        type: uncover
+        direction: right

--- a/mpf/tests/machine_files/segment_display/config/config.yaml
+++ b/mpf/tests/machine_files/segment_display/config/config.yaml
@@ -75,8 +75,9 @@ segment_display_player:
       key: transition
       text: "0123456789"
       transition:
-        type: wipe
-        direction: split
+        type: split
+        mode: wipe
+        direction: out
 
   test_transition_3:
     display1:

--- a/mpf/tests/machine_files/segment_display/config/config.yaml
+++ b/mpf/tests/machine_files/segment_display/config/config.yaml
@@ -53,13 +53,14 @@ segment_display_player:
   test_update_events:
     display3:
       text: "UPDATE"
-      color: "FF0000"
+      color: FF0000
 
   test_transition:
     display1:
       priority: 15
       key: transition
       text: "  SCROLL  "
+      color: red
       transition:
         type: push
         direction: right
@@ -85,3 +86,8 @@ segment_display_player:
       transition:
         type: uncover
         direction: right
+
+  test_set_color_to_white:
+    display3:
+      action: set_color
+      color: white

--- a/mpf/tests/test_SegmentDisplay.py
+++ b/mpf/tests/test_SegmentDisplay.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch, call, ANY, Mock
+
 from mpf.devices.segment_display.transitions import NoTransition, PushTransition, CoverTransition, UncoverTransition, \
-    WipeTransition
+    WipeTransition, TransitionRunner
 from mpf.devices.segment_display.segment_display_text import SegmentDisplayText
-from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
+from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType, \
+    SegmentDisplaySoftwareFlashPlatformInterface
 from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
 from mpf.tests.MpfTestCase import test_config
 
@@ -242,202 +245,380 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertEqual("42", display1.hw_display.text)
         self.assertEqual("0", display2.hw_display.text)
 
+    @patch("mpf.platforms.interfaces.segment_display_platform_interface.SegmentDisplaySoftwareFlashPlatformInterface.__abstractmethods__", set())
+    @patch("mpf.platforms.interfaces.segment_display_platform_interface.SegmentDisplaySoftwareFlashPlatformInterface._set_text")
+    def test_software_flash_platform_interface(self, mock_set_text):
+        display = SegmentDisplaySoftwareFlashPlatformInterface("1")
+        display.set_text("12345 ABCDE", FlashingType.NO_FLASH)
+        display.set_software_flash(False)
+        self.assertTrue(mock_set_text.called)
+        mock_set_text.assert_has_calls([call("12345 ABCDE")])
+        display.set_software_flash(True)
+        mock_set_text.reset_mock()
+
+        display.set_text("12345 ABCDE", FlashingType.FLASH_ALL)
+        display.set_software_flash(False)
+        self.assertTrue(mock_set_text.called)
+        mock_set_text.assert_has_calls([call("12345 ABCDE"), call("")])
+        display.set_software_flash(True)
+        mock_set_text.reset_mock()
+
+        display.set_text("12345 ABCDE", FlashingType.FLASH_MATCH)
+        display.set_software_flash(False)
+        self.assertTrue(mock_set_text.called)
+        mock_set_text.assert_has_calls([call("12345 ABCDE"), call("12345 ABC  ")])
+        display.set_software_flash(True)
+        mock_set_text.reset_mock()
+
+        display.set_text("12345 ABCDE", FlashingType.FLASH_MASK, "FFFFF______")
+        display.set_software_flash(False)
+        self.assertTrue(mock_set_text.called)
+        mock_set_text.assert_has_calls([call("12345 ABCDE"), call("      ABCDE")])
+        display.set_software_flash(True)
+        mock_set_text.reset_mock()
+
+    def test_segment_display_text(self):
+        """Test the SegmentDisplayText class."""
+
+        # text equal to display length
+        test_text = SegmentDisplayText("test", 4, False, False)
+        self.assertTrue(isinstance(test_text, list))
+        self.assertEqual(4, len(test_text))
+        self.assertEqual("test", SegmentDisplayText.convert_to_str(test_text))
+
+        # text longer than display
+        test_text = SegmentDisplayText("testing", 4, False, False)
+        self.assertTrue(isinstance(test_text, list))
+        self.assertEqual(4, len(test_text))
+        self.assertEqual("ting", SegmentDisplayText.convert_to_str(test_text))
+
+        # text shorter than display
+        test_text = SegmentDisplayText("test", 7, False, False)
+        self.assertTrue(isinstance(test_text, list))
+        self.assertEqual(7, len(test_text))
+        self.assertEqual("   test", SegmentDisplayText.convert_to_str(test_text))
+
+        # collapse commas
+        test_text = SegmentDisplayText("25,000", 7, False, True)
+        self.assertTrue(isinstance(test_text, list))
+        self.assertEqual(7, len(test_text))
+        self.assertTrue(test_text[3].comma)
+        self.assertEqual(ord("5"), test_text[3].char_code)
+        self.assertFalse(test_text[4].comma)
+        self.assertEqual(ord("0"), test_text[4].char_code)
+        self.assertEqual("  25,000", SegmentDisplayText.convert_to_str(test_text))
+
+        # do not collapse commas
+        test_text = SegmentDisplayText("25,000", 7, False, False)
+        self.assertTrue(isinstance(test_text, list))
+        self.assertEqual(7, len(test_text))
+        self.assertFalse(test_text[2].comma)
+        self.assertEqual(ord("5"), test_text[2].char_code)
+        self.assertFalse(test_text[3].comma)
+        self.assertEqual(ord(","), test_text[3].char_code)
+        self.assertEqual(" 25,000", SegmentDisplayText.convert_to_str(test_text))
+
+        # collapse dots
+        test_text = SegmentDisplayText("25.000", 7, True, False)
+        self.assertTrue(isinstance(test_text, list))
+        self.assertEqual(7, len(test_text))
+        self.assertTrue(test_text[3].dot)
+        self.assertEqual(ord("5"), test_text[3].char_code)
+        self.assertFalse(test_text[4].dot)
+        self.assertEqual(ord("0"), test_text[4].char_code)
+        self.assertEqual("  25.000", SegmentDisplayText.convert_to_str(test_text))
+
+        # do not collapse dots
+        test_text = SegmentDisplayText("25.000", 7, False, False)
+        self.assertTrue(isinstance(test_text, list))
+        self.assertEqual(7, len(test_text))
+        self.assertFalse(test_text[2].dot)
+        self.assertEqual(ord("5"), test_text[2].char_code)
+        self.assertFalse(test_text[3].dot)
+        self.assertEqual(ord("."), test_text[3].char_code)
+        self.assertEqual(" 25.000", SegmentDisplayText.convert_to_str(test_text))
+
     def test_transitions(self):
+        """Test segment display text transitions."""
+        self._test_no_transition()
+        self._test_push_transition()
+        self._test_cover_transition()
+        self._test_uncover_transition()
+        self._test_wipe_transition()
+
+    def _test_no_transition(self):
+        """Test no transition."""
         # no transition
-        transition = NoTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+        transition = NoTransition(5, False, False, {'direction': 'right'})
+        self.assertEqual(1, transition.get_step_count())
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        with self.assertRaises(AssertionError):
+            transition.get_transition_step(1, "12345", "ABCDE")
 
-        self.assertEqual(1, len(transition_steps))
-        self.assertEqual("ABCDE", transition_steps[0])
-
+    def _test_push_transition(self):
+        """Test push transition."""
         # push right
-        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("E1234", transition_steps[0])
-        self.assertEqual("DE123", transition_steps[1])
-        self.assertEqual("CDE12", transition_steps[2])
-        self.assertEqual("BCDE1", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
+        transition = PushTransition(5, False, False, {'direction': 'right'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("E1234",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("DE123",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("CDE12",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("BCDE1",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
         # push left
-        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("2345A", transition_steps[0])
-        self.assertEqual("345AB", transition_steps[1])
-        self.assertEqual("45ABC", transition_steps[2])
-        self.assertEqual("5ABCD", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
+        transition = PushTransition(5, False, False, {'direction': 'left'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("2345A",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("345AB",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("45ABC",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("5ABCD",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
         # push split out (odd display length)
-        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'split_out'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(3, len(transition_steps))
-        self.assertEqual("23C45", transition_steps[0])
-        self.assertEqual("3BCD4", transition_steps[1])
-        self.assertEqual("ABCDE", transition_steps[2])
+        transition = PushTransition(5, False, False, {'direction': 'split_out'})
+        self.assertEqual(3, transition.get_step_count())
+        self.assertEqual("23C45",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("3BCD4",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
 
         # push split out (even display length)
-        transition = PushTransition("123456", "ABCDEF", 6, False, False, {'direction': 'split_out'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(3, len(transition_steps))
-        self.assertEqual("23CD45", transition_steps[0])
-        self.assertEqual("3BCDE4", transition_steps[1])
-        self.assertEqual("ABCDEF", transition_steps[2])
+        transition = PushTransition(6, False, False, {'direction': 'split_out'})
+        self.assertEqual(3, transition.get_step_count())
+        self.assertEqual("23CD45",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "123456", "ABCDEF")))
+        self.assertEqual("3BCDE4",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "123456", "ABCDEF")))
+        self.assertEqual("ABCDEF",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "123456", "ABCDEF")))
 
         # push split in (odd display length)
-        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'split_in'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(3, len(transition_steps))
-        self.assertEqual("C234D", transition_steps[0])
-        self.assertEqual("BC3DE", transition_steps[1])
-        self.assertEqual("ABCDE", transition_steps[2])
+        transition = PushTransition(5, False, False, {'direction': 'split_in'})
+        self.assertEqual(3, transition.get_step_count())
+        self.assertEqual("C234D",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("BC3DE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
 
         # push split in (even display length)
-        transition = PushTransition("123456", "ABCDEF", 6, False, False, {'direction': 'split_in'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(3, len(transition_steps))
-        self.assertEqual("C2345D", transition_steps[0])
-        self.assertEqual("BC34DE", transition_steps[1])
-        self.assertEqual("ABCDEF", transition_steps[2])
+        transition = PushTransition(6, False, False, {'direction': 'split_in'})
+        self.assertEqual(3, transition.get_step_count())
+        self.assertEqual("C2345D",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "123456", "ABCDEF")))
+        self.assertEqual("BC34DE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "123456", "ABCDEF")))
+        self.assertEqual("ABCDEF",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "123456", "ABCDEF")))
 
         # push right (display larger than text)
-        transition = PushTransition("12345", "ABCDE", 8, False, False, {'direction': 'right'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(8, len(transition_steps))
-        self.assertEqual("E   1234", transition_steps[0])
-        self.assertEqual("DE   123", transition_steps[1])
-        self.assertEqual("CDE   12", transition_steps[2])
-        self.assertEqual("BCDE   1", transition_steps[3])
-        self.assertEqual("ABCDE   ", transition_steps[4])
-        self.assertEqual(" ABCDE  ", transition_steps[5])
-        self.assertEqual("  ABCDE ", transition_steps[6])
-        self.assertEqual("   ABCDE", transition_steps[7])
+        transition = PushTransition(8, False, False, {'direction': 'right'})
+        self.assertEqual(8, transition.get_step_count())
+        self.assertEqual("E   1234",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("DE   123",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("CDE   12",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("BCDE   1",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE   ",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
+        self.assertEqual(" ABCDE  ",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(5, "12345", "ABCDE")))
+        self.assertEqual("  ABCDE ",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(6, "12345", "ABCDE")))
+        self.assertEqual("   ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(7, "12345", "ABCDE")))
 
         # push left (display larger than text)
-        transition = PushTransition("12345", "ABCDE", 8, False, False, {'direction': 'left'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(8, len(transition_steps))
-        self.assertEqual("  12345 ", transition_steps[0])
-        self.assertEqual(" 12345  ", transition_steps[1])
-        self.assertEqual("12345   ", transition_steps[2])
-        self.assertEqual("2345   A", transition_steps[3])
-        self.assertEqual("345   AB", transition_steps[4])
-        self.assertEqual("45   ABC", transition_steps[5])
-        self.assertEqual("5   ABCD", transition_steps[6])
-        self.assertEqual("   ABCDE", transition_steps[7])
+        transition = PushTransition(8, False, False, {'direction': 'left'})
+        self.assertEqual(8, transition.get_step_count())
+        self.assertEqual("  12345 ",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual(" 12345  ",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("12345   ",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("2345   A",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("345   AB",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
+        self.assertEqual("45   ABC",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(5, "12345", "ABCDE")))
+        self.assertEqual("5   ABCD",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(6, "12345", "ABCDE")))
+        self.assertEqual("   ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(7, "12345", "ABCDE")))
 
         # push right (collapse commas)
-        transition = PushTransition("1,000", "25,000", 5, False, True, {'direction': 'right'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("0 1,00", transition_steps[0])
-        self.assertEqual("00 1,0", transition_steps[1])
-        self.assertEqual("000 1,", transition_steps[2])
-        self.assertEqual("5,000 ", transition_steps[3])
-        self.assertEqual("25,000", transition_steps[4])
+        transition = PushTransition(5, False, True, {'direction': 'right'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("0 1,00",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "1,000", "25,000")))
+        self.assertEqual("00 1,0",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "1,000", "25,000")))
+        self.assertEqual("000 1,",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "1,000", "25,000")))
+        self.assertEqual("5,000 ",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "1,000", "25,000")))
+        self.assertEqual("25,000",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "1,000", "25,000")))
 
         # push left (collapse commas)
-        transition = PushTransition("1,000", "25,000", 5, False, True, {'direction': 'left'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+        transition = PushTransition(5, False, True, {'direction': 'left'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("1,0002",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "1,000", "25,000")))
+        self.assertEqual("00025,",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "1,000", "25,000")))
+        self.assertEqual("0025,0",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "1,000", "25,000")))
+        self.assertEqual("025,00",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "1,000", "25,000")))
+        self.assertEqual("25,000",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "1,000", "25,000")))
 
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("1,0002", transition_steps[0])
-        self.assertEqual("00025,", transition_steps[1])
-        self.assertEqual("0025,0", transition_steps[2])
-        self.assertEqual("025,00", transition_steps[3])
-        self.assertEqual("25,000", transition_steps[4])
-
+    def _test_cover_transition(self):
+        """Test cover transition."""
         # cover right
-        transition = CoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("E2345", transition_steps[0])
-        self.assertEqual("DE345", transition_steps[1])
-        self.assertEqual("CDE45", transition_steps[2])
-        self.assertEqual("BCDE5", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
+        transition = CoverTransition(5, False, False, {'direction': 'right'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("E2345",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("DE345",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("CDE45",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("BCDE5",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
         # cover left
-        transition = CoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+        transition = CoverTransition(5, False, False, {'direction': 'left'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("1234A",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("123AB",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("12ABC",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("1ABCD",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("1234A", transition_steps[0])
-        self.assertEqual("123AB", transition_steps[1])
-        self.assertEqual("12ABC", transition_steps[2])
-        self.assertEqual("1ABCD", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
-
+    def _test_uncover_transition(self):
+        """Test uncover transition."""
         # uncover right
-        transition = UncoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("A1234", transition_steps[0])
-        self.assertEqual("AB123", transition_steps[1])
-        self.assertEqual("ABC12", transition_steps[2])
-        self.assertEqual("ABCD1", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
+        transition = UncoverTransition(5, False, False, {'direction': 'right'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("A1234",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("AB123",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("ABC12",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("ABCD1",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
         # uncover left
-        transition = UncoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+        transition = UncoverTransition(5, False, False, {'direction': 'left'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("2345E",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("345DE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("45CDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("5BCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("2345E", transition_steps[0])
-        self.assertEqual("345DE", transition_steps[1])
-        self.assertEqual("45CDE", transition_steps[2])
-        self.assertEqual("5BCDE", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
-
+    def _test_wipe_transition(self):
+        """Test wipe transition."""
         # wipe right
-        transition = WipeTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("A2345", transition_steps[0])
-        self.assertEqual("AB345", transition_steps[1])
-        self.assertEqual("ABC45", transition_steps[2])
-        self.assertEqual("ABCD5", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
+        transition = WipeTransition(5, False, False, {'direction': 'right'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("A2345",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("AB345",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("ABC45",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("ABCD5",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
         # wipe left
-        transition = WipeTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(5, len(transition_steps))
-        self.assertEqual("1234E", transition_steps[0])
-        self.assertEqual("123DE", transition_steps[1])
-        self.assertEqual("12CDE", transition_steps[2])
-        self.assertEqual("1BCDE", transition_steps[3])
-        self.assertEqual("ABCDE", transition_steps[4])
+        transition = WipeTransition(5, False, False, {'direction': 'left'})
+        self.assertEqual(5, transition.get_step_count())
+        self.assertEqual("1234E",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("123DE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("12CDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
+        self.assertEqual("1BCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(3, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(4, "12345", "ABCDE")))
 
         # wipe split (odd output length)
-        transition = WipeTransition("12345", "ABCDE", 5, False, False, {'direction': 'split'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
-
-        self.assertEqual(3, len(transition_steps))
-        self.assertEqual("12C45", transition_steps[0])
-        self.assertEqual("1BCD5", transition_steps[1])
-        self.assertEqual("ABCDE", transition_steps[2])
+        transition = WipeTransition(5, False, False, {'direction': 'split'})
+        self.assertEqual(3, transition.get_step_count())
+        self.assertEqual("12C45",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "12345", "ABCDE")))
+        self.assertEqual("1BCD5",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "12345", "ABCDE")))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "12345", "ABCDE")))
 
         # wipe split (even output length)
-        transition = WipeTransition("123456", "ABCDEF", 6, False, False, {'direction': 'split'})
-        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+        transition = WipeTransition(6, False, False, {'direction': 'split'})
+        self.assertEqual(3, transition.get_step_count())
+        self.assertEqual("12CD56",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(0, "123456", "ABCDEF")))
+        self.assertEqual("1BCDE6",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(1, "123456", "ABCDEF")))
+        self.assertEqual("ABCDEF",
+                         SegmentDisplayText.convert_to_str(transition.get_transition_step(2, "123456", "ABCDEF")))
 
-        self.assertEqual(3, len(transition_steps))
-        self.assertEqual("12CD56", transition_steps[0])
-        self.assertEqual("1BCDE6", transition_steps[1])
-        self.assertEqual("ABCDEF", transition_steps[2])
+    def test_transition_runner(self):
+        """Test the transition runner using an iterator."""
+        transition_iterator = iter(TransitionRunner(self.machine,
+                                                    PushTransition(5, False, False, {'direction': 'right'}),
+                                                    "12345", "ABCDE"))
+        self.assertEqual("E1234",
+                         SegmentDisplayText.convert_to_str(next(transition_iterator)))
+        self.assertEqual("DE123",
+                         SegmentDisplayText.convert_to_str(next(transition_iterator)))
+        self.assertEqual("CDE12",
+                         SegmentDisplayText.convert_to_str(next(transition_iterator)))
+        self.assertEqual("BCDE1",
+                         SegmentDisplayText.convert_to_str(next(transition_iterator)))
+        self.assertEqual("ABCDE",
+                         SegmentDisplayText.convert_to_str(next(transition_iterator)))
+
+        with self.assertRaises(StopIteration):
+            next(transition_iterator)

--- a/mpf/tests/test_SegmentDisplay.py
+++ b/mpf/tests/test_SegmentDisplay.py
@@ -622,3 +622,61 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
 
         with self.assertRaises(StopIteration):
             next(transition_iterator)
+
+    @patch("mpf.devices.segment_display.segment_display.SegmentDisplay._update_display")
+    def test_transitions_with_player(self, mock_update_display):
+        self.post_event("test_transition")
+        self.advance_time_and_run(3)
+        self.assertTrue(mock_update_display.called)
+        self.assertEqual(21, mock_update_display.call_count)
+        mock_update_display.assert_has_calls([call('          '),
+                                              call('          '),
+                                              call('L         '),
+                                              call('LL        '),
+                                              call('OLL       '),
+                                              call('ROLL      '),
+                                              call('CROLL     '),
+                                              call('SCROLL    '),
+                                              call(' SCROLL   '),
+                                              call('  SCROLL  '),
+                                              call('  SCROLL  '),
+                                              call(' SCROLL   '),
+                                              call('SCROLL    '),
+                                              call('CROLL     '),
+                                              call('ROLL      '),
+                                              call('OLL       '),
+                                              call('LL        '),
+                                              call('L         '),
+                                              call('          '),
+                                              call('          '),
+                                              call('          ')])
+        mock_update_display.reset_mock()
+
+        self.post_event("test_transition_2")
+        self.advance_time_and_run(1)
+        self.assertTrue(mock_update_display.called)
+        self.assertEqual(6, mock_update_display.call_count)
+        mock_update_display.assert_has_calls([call('    45    '),
+                                              call('   3456   '),
+                                              call('  234567  '),
+                                              call(' 12345678 '),
+                                              call('0123456789'),
+                                              call('0123456789')])
+        mock_update_display.reset_mock()
+
+        self.post_event("test_transition_3")
+        self.advance_time_and_run(1)
+        self.assertTrue(mock_update_display.called)
+        self.assertEqual(11, mock_update_display.call_count)
+        mock_update_display.assert_has_calls([call('A012345678'),
+                                              call('AB01234567'),
+                                              call('ABC0123456'),
+                                              call('ABCD012345'),
+                                              call('ABCDE01234'),
+                                              call('ABCDEF0123'),
+                                              call('ABCDEFG012'),
+                                              call('ABCDEFGH01'),
+                                              call('ABCDEFGHI0'),
+                                              call('ABCDEFGHIJ'),
+                                              call('ABCDEFGHIJ')])
+        mock_update_display.reset_mock()

--- a/mpf/tests/test_SegmentDisplay.py
+++ b/mpf/tests/test_SegmentDisplay.py
@@ -1,6 +1,6 @@
-from unittest.mock import MagicMock, call
-
-from mpf.core.rgb_color import RGBColor
+from mpf.devices.segment_display.transitions import NoTransition, PushTransition, CoverTransition, UncoverTransition, \
+    WipeTransition
+from mpf.devices.segment_display.segment_display_text import SegmentDisplayText
 from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
 from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
 from mpf.tests.MpfTestCase import test_config
@@ -241,3 +241,203 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.advance_time_and_run(.01)
         self.assertEqual("42", display1.hw_display.text)
         self.assertEqual("0", display2.hw_display.text)
+
+    def test_transitions(self):
+        # no transition
+        transition = NoTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(1, len(transition_steps))
+        self.assertEqual("ABCDE", transition_steps[0])
+
+        # push right
+        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("E1234", transition_steps[0])
+        self.assertEqual("DE123", transition_steps[1])
+        self.assertEqual("CDE12", transition_steps[2])
+        self.assertEqual("BCDE1", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # push left
+        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("2345A", transition_steps[0])
+        self.assertEqual("345AB", transition_steps[1])
+        self.assertEqual("45ABC", transition_steps[2])
+        self.assertEqual("5ABCD", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # push split out (odd display length)
+        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'split_out'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(3, len(transition_steps))
+        self.assertEqual("23C45", transition_steps[0])
+        self.assertEqual("3BCD4", transition_steps[1])
+        self.assertEqual("ABCDE", transition_steps[2])
+
+        # push split out (even display length)
+        transition = PushTransition("123456", "ABCDEF", 6, False, False, {'direction': 'split_out'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(3, len(transition_steps))
+        self.assertEqual("23CD45", transition_steps[0])
+        self.assertEqual("3BCDE4", transition_steps[1])
+        self.assertEqual("ABCDEF", transition_steps[2])
+
+        # push split in (odd display length)
+        transition = PushTransition("12345", "ABCDE", 5, False, False, {'direction': 'split_in'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(3, len(transition_steps))
+        self.assertEqual("C234D", transition_steps[0])
+        self.assertEqual("BC3DE", transition_steps[1])
+        self.assertEqual("ABCDE", transition_steps[2])
+
+        # push split in (even display length)
+        transition = PushTransition("123456", "ABCDEF", 6, False, False, {'direction': 'split_in'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(3, len(transition_steps))
+        self.assertEqual("C2345D", transition_steps[0])
+        self.assertEqual("BC34DE", transition_steps[1])
+        self.assertEqual("ABCDEF", transition_steps[2])
+
+        # push right (display larger than text)
+        transition = PushTransition("12345", "ABCDE", 8, False, False, {'direction': 'right'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(8, len(transition_steps))
+        self.assertEqual("E   1234", transition_steps[0])
+        self.assertEqual("DE   123", transition_steps[1])
+        self.assertEqual("CDE   12", transition_steps[2])
+        self.assertEqual("BCDE   1", transition_steps[3])
+        self.assertEqual("ABCDE   ", transition_steps[4])
+        self.assertEqual(" ABCDE  ", transition_steps[5])
+        self.assertEqual("  ABCDE ", transition_steps[6])
+        self.assertEqual("   ABCDE", transition_steps[7])
+
+        # push left (display larger than text)
+        transition = PushTransition("12345", "ABCDE", 8, False, False, {'direction': 'left'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(8, len(transition_steps))
+        self.assertEqual("  12345 ", transition_steps[0])
+        self.assertEqual(" 12345  ", transition_steps[1])
+        self.assertEqual("12345   ", transition_steps[2])
+        self.assertEqual("2345   A", transition_steps[3])
+        self.assertEqual("345   AB", transition_steps[4])
+        self.assertEqual("45   ABC", transition_steps[5])
+        self.assertEqual("5   ABCD", transition_steps[6])
+        self.assertEqual("   ABCDE", transition_steps[7])
+
+        # push right (collapse commas)
+        transition = PushTransition("1,000", "25,000", 5, False, True, {'direction': 'right'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("0 1,00", transition_steps[0])
+        self.assertEqual("00 1,0", transition_steps[1])
+        self.assertEqual("000 1,", transition_steps[2])
+        self.assertEqual("5,000 ", transition_steps[3])
+        self.assertEqual("25,000", transition_steps[4])
+
+        # push left (collapse commas)
+        transition = PushTransition("1,000", "25,000", 5, False, True, {'direction': 'left'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("1,0002", transition_steps[0])
+        self.assertEqual("00025,", transition_steps[1])
+        self.assertEqual("0025,0", transition_steps[2])
+        self.assertEqual("025,00", transition_steps[3])
+        self.assertEqual("25,000", transition_steps[4])
+
+        # cover right
+        transition = CoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("E2345", transition_steps[0])
+        self.assertEqual("DE345", transition_steps[1])
+        self.assertEqual("CDE45", transition_steps[2])
+        self.assertEqual("BCDE5", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # cover left
+        transition = CoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("1234A", transition_steps[0])
+        self.assertEqual("123AB", transition_steps[1])
+        self.assertEqual("12ABC", transition_steps[2])
+        self.assertEqual("1ABCD", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # uncover right
+        transition = UncoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("A1234", transition_steps[0])
+        self.assertEqual("AB123", transition_steps[1])
+        self.assertEqual("ABC12", transition_steps[2])
+        self.assertEqual("ABCD1", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # uncover left
+        transition = UncoverTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("2345E", transition_steps[0])
+        self.assertEqual("345DE", transition_steps[1])
+        self.assertEqual("45CDE", transition_steps[2])
+        self.assertEqual("5BCDE", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # wipe right
+        transition = WipeTransition("12345", "ABCDE", 5, False, False, {'direction': 'right'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("A2345", transition_steps[0])
+        self.assertEqual("AB345", transition_steps[1])
+        self.assertEqual("ABC45", transition_steps[2])
+        self.assertEqual("ABCD5", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # wipe left
+        transition = WipeTransition("12345", "ABCDE", 5, False, False, {'direction': 'left'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(5, len(transition_steps))
+        self.assertEqual("1234E", transition_steps[0])
+        self.assertEqual("123DE", transition_steps[1])
+        self.assertEqual("12CDE", transition_steps[2])
+        self.assertEqual("1BCDE", transition_steps[3])
+        self.assertEqual("ABCDE", transition_steps[4])
+
+        # wipe split (odd output length)
+        transition = WipeTransition("12345", "ABCDE", 5, False, False, {'direction': 'split'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(3, len(transition_steps))
+        self.assertEqual("12C45", transition_steps[0])
+        self.assertEqual("1BCD5", transition_steps[1])
+        self.assertEqual("ABCDE", transition_steps[2])
+
+        # wipe split (even output length)
+        transition = WipeTransition("123456", "ABCDEF", 6, False, False, {'direction': 'split'})
+        transition_steps = list(map(SegmentDisplayText.to_str, transition.transition_steps))
+
+        self.assertEqual(3, len(transition_steps))
+        self.assertEqual("12CD56", transition_steps[0])
+        self.assertEqual("1BCDE6", transition_steps[1])
+        self.assertEqual("ABCDEF", transition_steps[2])

--- a/mpf/tests/test_Utility_Functions.py
+++ b/mpf/tests/test_Utility_Functions.py
@@ -64,6 +64,16 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(result[0][0], '1')
         self.assertEqual(result[1][4], 'e')
 
+    def test_flatten_list(self):
+        my_list = [0, 1, [2, 3, 4], [5, [6, 7], 8], "nine"]
+        result = list(Util.flatten_list(my_list))
+        self.assertEqual(type(result), list)
+        self.assertEqual(len(my_list), 5)
+        self.assertEqual(len(result), 10)
+        self.assertEqual(result[0], 0)
+        self.assertEqual(result[6], 6)
+        self.assertEqual(result[9], "nine")
+
     def test_dict_merge(self):
         dict_a = dict(key1='val1', key2='val2', list1=[1, 2, 3])
         dict_b = dict(key3='val3', key4='val4', list1=[4, 5, 6])

--- a/mpf/tests/test_VirtualSegmentDisplayConnector.py
+++ b/mpf/tests/test_VirtualSegmentDisplayConnector.py
@@ -47,7 +47,7 @@ class TestVirtualSegmentDisplayConnector(MpfBcpTestCase):
         display1.add_text("NEW TEXT")
         display1.set_color(RGBColor("FF0000"))
         self.assertTrue(mock_bcp_trigger_client.called)
-        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing=FlashingType.NO_FLASH,
+        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='False', flash_mask='',
                                                        name='update_segment_display', segment_display_name='display1',
                                                        text='NEW TEXT'),
                                                   call(client=ANY, name='update_segment_display',
@@ -57,10 +57,26 @@ class TestVirtualSegmentDisplayConnector(MpfBcpTestCase):
         display2.add_text("OTHER TEXT")
         display2.set_flashing(FlashingType.FLASH_ALL)
         self.assertTrue(mock_bcp_trigger_client.called)
-        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing=FlashingType.NO_FLASH,
+        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='False', flash_mask='',
                                                        name='update_segment_display', segment_display_name='display2',
                                                        text='OTHER TEXT'),
-                                                  call(client=ANY, flashing=FlashingType.FLASH_ALL,
+                                                  call(client=ANY, flashing='True', flash_mask='',
+                                                       name='update_segment_display', segment_display_name='display2',
+                                                       text='OTHER TEXT')
+                                                  ])
+        mock_bcp_trigger_client.reset_mock()
+
+        display2.set_flashing(FlashingType.FLASH_MATCH)
+        self.assertTrue(mock_bcp_trigger_client.called)
+        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='match', flash_mask='',
+                                                       name='update_segment_display', segment_display_name='display2',
+                                                       text='OTHER TEXT')
+                                                  ])
+        mock_bcp_trigger_client.reset_mock()
+
+        display2.set_flashing(FlashingType.FLASH_MASK, "______FFFF")
+        self.assertTrue(mock_bcp_trigger_client.called)
+        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='mask', flash_mask='______FFFF',
                                                        name='update_segment_display', segment_display_name='display2',
                                                        text='OTHER TEXT')
                                                   ])

--- a/mpf/tests/test_VirtualSegmentDisplayConnector.py
+++ b/mpf/tests/test_VirtualSegmentDisplayConnector.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch, call, ANY
 
 from mpf.core.rgb_color import RGBColor
+from mpf.devices.segment_display.text_stack_entry import TextStackEntry
 from mpf.platforms.interfaces.segment_display_platform_interface import FlashingType
 from mpf.tests.MpfBcpTestCase import MpfBcpTestCase
 
@@ -54,16 +55,11 @@ class TestVirtualSegmentDisplayConnector(MpfBcpTestCase):
                                                        segment_display_name='display1', colors=["ff0000", "00ff00"])])
         mock_bcp_trigger_client.reset_mock()
 
-        display2.add_text("OTHER TEXT")
-        display2.set_flashing(FlashingType.FLASH_ALL)
+        display2.add_text_entry(TextStackEntry("OTHER TEXT", [RGBColor("green")], FlashingType.FLASH_ALL, ""))
         self.assertTrue(mock_bcp_trigger_client.called)
-        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='False', flash_mask='',
+        mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='True', flash_mask='',
                                                        name='update_segment_display', segment_display_name='display2',
-                                                       text='OTHER TEXT', colors=None),
-                                                  call(client=ANY, flashing='True', flash_mask='',
-                                                       name='update_segment_display', segment_display_name='display2',
-                                                       text='OTHER TEXT', colors=None)
-                                                  ])
+                                                       text='OTHER TEXT', colors=[RGBColor("green").hex])])
         mock_bcp_trigger_client.reset_mock()
 
         display2.set_flashing(FlashingType.FLASH_MATCH)

--- a/mpf/tests/test_VirtualSegmentDisplayConnector.py
+++ b/mpf/tests/test_VirtualSegmentDisplayConnector.py
@@ -45,13 +45,13 @@ class TestVirtualSegmentDisplayConnector(MpfBcpTestCase):
         self.assertIsNone(display3.virtual_connector)
 
         display1.add_text("NEW TEXT")
-        display1.set_color(RGBColor("FF0000"))
+        display1.set_color([RGBColor("FF0000"), RGBColor("00FF00")])
         self.assertTrue(mock_bcp_trigger_client.called)
         mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='False', flash_mask='',
                                                        name='update_segment_display', segment_display_name='display1',
-                                                       text='NEW TEXT'),
+                                                       text='NEW TEXT', colors=None),
                                                   call(client=ANY, name='update_segment_display',
-                                                       segment_display_name='display1', color=["ff0000"])])
+                                                       segment_display_name='display1', colors=["ff0000", "00ff00"])])
         mock_bcp_trigger_client.reset_mock()
 
         display2.add_text("OTHER TEXT")
@@ -59,10 +59,10 @@ class TestVirtualSegmentDisplayConnector(MpfBcpTestCase):
         self.assertTrue(mock_bcp_trigger_client.called)
         mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='False', flash_mask='',
                                                        name='update_segment_display', segment_display_name='display2',
-                                                       text='OTHER TEXT'),
+                                                       text='OTHER TEXT', colors=None),
                                                   call(client=ANY, flashing='True', flash_mask='',
                                                        name='update_segment_display', segment_display_name='display2',
-                                                       text='OTHER TEXT')
+                                                       text='OTHER TEXT', colors=None)
                                                   ])
         mock_bcp_trigger_client.reset_mock()
 
@@ -70,7 +70,7 @@ class TestVirtualSegmentDisplayConnector(MpfBcpTestCase):
         self.assertTrue(mock_bcp_trigger_client.called)
         mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='match', flash_mask='',
                                                        name='update_segment_display', segment_display_name='display2',
-                                                       text='OTHER TEXT')
+                                                       text='OTHER TEXT', colors=None)
                                                   ])
         mock_bcp_trigger_client.reset_mock()
 
@@ -78,7 +78,7 @@ class TestVirtualSegmentDisplayConnector(MpfBcpTestCase):
         self.assertTrue(mock_bcp_trigger_client.called)
         mock_bcp_trigger_client.assert_has_calls([call(client=ANY, flashing='mask', flash_mask='______FFFF',
                                                        name='update_segment_display', segment_display_name='display2',
-                                                       text='OTHER TEXT')
+                                                       text='OTHER TEXT', colors=None)
                                                   ])
         mock_bcp_trigger_client.reset_mock()
 


### PR DESCRIPTION
This PR builds on the recent segment display improvements in MPF and MPF-MC. This PR adds new text transition effects to all segment display devices (similar to slide transitions in the MC). These transitions will work with all platforms. The transitions include full color support as well as integrated dot/period and comma support. Transitions include push, cover, uncover, wipe, and split and most allow additional transition text (with independent color settings) paired with the effect when switching between the current and new text.

The segment display text stack has been extended to optionally store color, flashing, and transition information. This allows the entire segment display state to be stored in the stack and restored when the stack entry becomes active again. Parameters with a None value leave the current state unchanged when becoming active. This allows a great deal of control when creating segment display shows. The add action in the segment_display_player can now configure text, and optionally flashing, colors, and transitions.

In addition, a new mask flashing mode was added that allows flashing control over each individual character in the display.

Configs should be backwardly compatible with existing segment display usage with many additional settings now available.