### PR TITLE
Added Machine Vars for Date and Time

### DIFF
--- a/mpf/core/clock.py
+++ b/mpf/core/clock.py
@@ -1,5 +1,6 @@
 """MPF clock and main loop."""
 import asyncio
+import datetime
 from typing import Tuple
 from serial_asyncio import create_serial_connection
 from mpf.core.logging import LogMixin
@@ -87,6 +88,11 @@ class ClockBase(LogMixin):
     def get_time(self):
         """Get the last tick made by the clock."""
         return self.loop.time()
+
+    @staticmethod
+    def get_datetime():
+        """Get current datetime."""
+        return datetime.datetime.now()
 
     def start_server(self, client_connected_cb, host=None, port=None, **kwd):
         """Start a server."""

--- a/mpf/core/machine_vars.py
+++ b/mpf/core/machine_vars.py
@@ -1,5 +1,8 @@
 """Contains the MachineVariables class."""
 
+import asyncio
+from time import time, sleep
+import datetime
 import copy
 from platform import platform, python_version, system, release, version, system_alias, machine as platform_machine
 from typing import Any, Dict, Optional
@@ -93,6 +96,30 @@ class MachineVariables(LogMixin):
 
         desc: Architecture of your machine (32bit/64bit).
         '''
+
+        '''Call function to to set the following machine_var(s):
+            machine_var: year
+            machine_var: month
+            machine_var: day
+            machine_var: hour
+            machine_var: minute
+            machine_var: second
+        
+        desc: The current date and time of your machine.
+        '''
+        #This function updates every second to constantly update the date and time
+        asyncio.create_task(self.update_date_time())
+
+    async def update_date_time(self):
+        while True:
+            self.set_machine_var(name="year", value=datetime.datetime.now().year)
+            self.set_machine_var(name="month", value=datetime.datetime.now().month)
+            self.set_machine_var(name="day", value=datetime.datetime.now().day)
+            self.set_machine_var(name="hour", value=datetime.datetime.now().hour)
+            self.set_machine_var(name="minute", value=datetime.datetime.now().minute)
+            self.set_machine_var(name="second", value=datetime.datetime.now().second)
+            #Run function every second
+            await asyncio.sleep(1)
 
     def __getitem__(self, key):
         """Allow the user to access a machine variable with []. This would be used is machine.variables["var_name"]."""

--- a/mpf/core/machine_vars.py
+++ b/mpf/core/machine_vars.py
@@ -1,8 +1,4 @@
 """Contains the MachineVariables class."""
-
-import asyncio
-from time import time, sleep
-import datetime
 import copy
 from platform import platform, python_version, system, release, version, system_alias, machine as platform_machine
 from typing import Any, Dict, Optional
@@ -96,30 +92,6 @@ class MachineVariables(LogMixin):
 
         desc: Architecture of your machine (32bit/64bit).
         '''
-
-        '''Call function to to set the following machine_var(s):
-            machine_var: year
-            machine_var: month
-            machine_var: day
-            machine_var: hour
-            machine_var: minute
-            machine_var: second
-        
-        desc: The current date and time of your machine.
-        '''
-        #This function updates every second to constantly update the date and time
-        asyncio.create_task(self.update_date_time())
-
-    async def update_date_time(self):
-        while True:
-            self.set_machine_var(name="year", value=datetime.datetime.now().year)
-            self.set_machine_var(name="month", value=datetime.datetime.now().month)
-            self.set_machine_var(name="day", value=datetime.datetime.now().day)
-            self.set_machine_var(name="hour", value=datetime.datetime.now().hour)
-            self.set_machine_var(name="minute", value=datetime.datetime.now().minute)
-            self.set_machine_var(name="second", value=datetime.datetime.now().second)
-            #Run function every second
-            await asyncio.sleep(1)
 
     def __getitem__(self, key):
         """Allow the user to access a machine variable with []. This would be used is machine.variables["var_name"]."""

--- a/mpf/core/placeholder_manager.py
+++ b/mpf/core/placeholder_manager.py
@@ -508,6 +508,54 @@ class PlayersPlaceholder(BasePlaceholder):
         return PlayerPlaceholder(self._machine, item)
 
 
+class TimePlaceholder(BasePlaceholder):
+
+    """Return current time."""
+
+    __slots__ = ["_machine"]
+
+    def __init__(self, machine):
+        """Initialise placeholder."""
+        self._machine = machine     # type: MachineController
+
+    def subscribe(self):
+        """Subscribe to machine changes.
+
+        Will never return.
+        """
+        return asyncio.Future()
+
+    def subscribe_attribute(self, item):
+        """Invalidate placeholders every second."""
+        current_time = self._machine.clock.get_datetime()
+        if item == "second":
+            return asyncio.sleep(1)
+        if item == "minute":
+            return asyncio.sleep(60 - current_time.second)
+        if item in ("hour", "day", "month", "year"):
+            return asyncio.sleep(3600 - current_time.second - 60 * current_time.minute)
+
+        raise AssertionError("Invalid time element {}".format(item))
+
+    def __getattr__(self, item):
+        """Attribute access."""
+        current_time = self._machine.clock.get_datetime()
+        if item == "second":
+            return current_time.second
+        if item == "minute":
+            return current_time.minute
+        if item == "hour":
+            return current_time.hour
+        if item == "day":
+            return current_time.day
+        if item == "month":
+            return current_time.month
+        if item == "year":
+            return current_time.year
+
+        raise AssertionError("Invalid time element {}".format(item))
+
+
 class MachinePlaceholder(BasePlaceholder):
 
     """Wraps the machine."""
@@ -527,6 +575,8 @@ class MachinePlaceholder(BasePlaceholder):
 
     def subscribe_attribute(self, item):
         """Subscribe to machine variable."""
+        if item == "time":
+            return asyncio.Future()
         return self._machine.events.wait_for_event('machine_var_{}'.format(item))
 
     def __getitem__(self, item):
@@ -535,6 +585,8 @@ class MachinePlaceholder(BasePlaceholder):
 
     def __getattr__(self, item):
         """Attribute access."""
+        if item == "time":
+            return TimePlaceholder(self._machine)
         return self._machine.variables.get_machine_var(item)
 
 
@@ -667,6 +719,11 @@ class BasePlaceholderManager(MpfController):
         if isinstance(slice_value, dict) and node.attr in slice_value:
             ret_value = slice_value[node.attr]
         else:
+            if slice_value is None:
+                if subscribe:   # pylint: disable-msg=no-else-raise
+                    raise TemplateEvalError(subscription)
+                else:
+                    raise AssertionError("Element {} in path is None".format(node))
             try:
                 ret_value = getattr(slice_value, node.attr)
             except (ValueError, AttributeError):

--- a/mpf/tests/loop.py
+++ b/mpf/tests/loop.py
@@ -1,3 +1,4 @@
+import datetime
 import selectors
 import socket
 from asyncio import base_events, coroutine, events      # type: ignore
@@ -447,6 +448,10 @@ class TestClock(ClockBase):
         self._mock_sockets = {}
         self._mock_servers = {}
         self._mock_serials = {}
+
+    def get_datetime(self):
+        """Create datetime based on time travel loop."""
+        return datetime.datetime.fromtimestamp(self.get_time())
 
     def _create_event_loop(self):
         return self._test_loop

--- a/mpf/tests/machine_files/machine_vars/config/config.yaml
+++ b/mpf/tests/machine_files/machine_vars/config/config.yaml
@@ -13,3 +13,7 @@ machine_vars:
     initial_value: 6
     value_type: int
     persist: False
+
+event_player:
+  "{machine.time.second >= 30}": test_event3
+  "{machine.time.second >= 40}": test_event4

--- a/mpf/tests/test_MachineVariables.py
+++ b/mpf/tests/test_MachineVariables.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from mpf.tests.MpfTestCase import MpfTestCase
 from mpf._version import version, extended_version
 
+import datetime
 
 class TestMachineVariables(MpfTestCase):
 
@@ -34,6 +35,12 @@ class TestMachineVariables(MpfTestCase):
         self.assertTrue(self.machine.variables.is_machine_var("platform_machine"))
         self.assertEqual(version, self.machine.variables.get_machine_var("mpf_version"))
         self.assertEqual(extended_version, self.machine.variables.get_machine_var("mpf_extended_version"))
+        self.assertEqual(datetime.datetime.now().year, self.machine.variables.get_machine_var("year"))
+        self.assertEqual(datetime.datetime.now().month, self.machine.variables.get_machine_var("month"))
+        self.assertEqual(datetime.datetime.now().day, self.machine.variables.get_machine_var("day"))
+        self.assertEqual(datetime.datetime.now().hour, self.machine.variables.get_machine_var("hour"))
+        self.assertEqual(datetime.datetime.now().minute, self.machine.variables.get_machine_var("minute"))
+        self.assertEqual(datetime.datetime.now().second, self.machine.variables.get_machine_var("second"))
 
     def testVarLoadAndRemove(self):
         self.assertFalse(self.machine.variables.is_machine_var("expired_value"))


### PR DESCRIPTION
Added machine vars for year, month, day, hour, minute, and second.
New async function was created to update this time every second, so when
you call it in MPF, it will always know the current time when the action
is taken.  Tests were updated to ensure that the machine var time
matches the actual time of the machine.

In the future, we will need to give a setting to write to the system
clock.  But for now, the user would need to set the system clock though
the OS/System, and MPF will read that value into a machine var.

This is related to issue #1402.