### PR TITLE
Clamp ratio in RGBColor.blend

### DIFF
--- a/mpf/core/rgb_color.py
+++ b/mpf/core/rgb_color.py
@@ -342,6 +342,8 @@ class RGBColor:
             colors
 
         """
+        fraction_clamped = max(0, min(fraction, 1))
+
         if isinstance(start_color, RGBColor):
             start_color = start_color.rgb
         else:
@@ -353,7 +355,7 @@ class RGBColor:
             end_color = RGBColor(start_color).rgb
 
         output_color = tuple(start_color[i] + int(
-            (end_color[i] - start_color[i]) * fraction) for i in range(3))
+            (end_color[i] - start_color[i]) * fraction_clamped) for i in range(3))
         return RGBColor(output_color)
 
     @staticmethod

--- a/mpf/tests/test_RGBColor.py
+++ b/mpf/tests/test_RGBColor.py
@@ -95,6 +95,12 @@ class TestRGBColor(unittest.TestCase):
         color_blend = RGBColor.blend(color1, color2, 0.75)
         self.assertEqual((32, 40, 48), color_blend.rgb)
 
+        color_blend = RGBColor.blend(color1, color2, -0.5)
+        self.assertEqual(color1.rgb, color_blend.rgb)
+
+        color_blend = RGBColor.blend(color1, color2, 1.5)
+        self.assertEqual(color2.rgb, color_blend.rgb)
+
     def test_color_correction(self):
         color = RGBColor(RGBColor.name_to_rgb('DarkGray'))
         self.assertEqual((169, 169, 169), color.rgb)


### PR DESCRIPTION
Background:
This update addresses a bug I ran into where lights with invalid rgb colors like (-38, -38, -38) were being created.  Looks like Greg also ran into a similar issue back in November: https://groups.google.com/g/mpf-users/c/_LvMPy9IoOM/m/2DDsMLvKBwAJ

Jan added some asserts to debug Greg's issue and that's how I stumbled across this.

I'm not sure if you'll be able to repro, since it happens intermittently for me, but I've provided my light settings and settings for my ball save mode since this bug happens when my ball save show ends.

light_settings from lights.yaml:
```
#config_version=5

light_settings:
  default_fade_ms: 100
  default_color_correction_profile: correction_profile
  color_correction_profiles:
    correction_profile:
      whitepoint: [1.0, 1.0, 1.0]
      gamma: 2.5
      linear_slope: 1.0
      linear_cutoff: 0.0
```

ball_saves.yaml:
```
#config_version=5

ball_saves:
  default:
    active_time: 10s
    hurry_up_time: 2s
    grace_period: 2s
    enable_events: ball_starting, s_force_ball_save_active
    timer_start_events: balldevice_bd_plunger_ball_eject_success, s_orbit_active
    auto_launch: yes
    balls_to_save: 1
```

ball_save.yaml:
```
#config_version=5

mode:
  start_events: ball_starting

show_player:
  ball_save_default_timer_start:
    flash_color:
      speed: 3
      show_tokens:
        light: l_ball_save
        color: white
  ball_save_default_hurry_up:
    flash_color:
      speed: 6
      show_tokens:
        light: l_ball_save
        color: white
  ball_save_default_disabled:
    flash_color:
      action: stop
```

Whenever I repro the bug, it's always the following two method calls that append the bad color onto the light stack.:
1. remove_from_stack_by_key: https://github.com/missionpinball/mpf/blob/dev/mpf/devices/light.py#L515
2. _get_color_and_fade: https://github.com/missionpinball/mpf/blob/dev/mpf/devices/light.py#L736-L748

The target_time that gets generated in _get_color_and_fade() is smaller than color_settings.start_time so the ratio we pass to blend becomes negative and a bad color is generated.  To fix this I updated RGBColor.blend method so that it always clamps the ratio in case it is out of bounds.  I'm not 100% sure if this is the right fix but I figured I'd make a PR to start a discussion on the issue.   
