### PR TITLE
Reset timer on show advance/step_back

### DIFF
--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -614,6 +614,7 @@ class RunningShow:
     def advance(self, steps=1, show_step=None):
         """Manually advance this show to the next step."""
         self._remove_delay_handler()
+        self.next_step_time = self.machine.clock.get_time()
 
         if steps != 1:
             self.next_step_index += steps - 1
@@ -628,6 +629,7 @@ class RunningShow:
     def step_back(self, steps=1):
         """Manually step back this show to a previous step."""
         self._remove_delay_handler()
+        self.next_step_time = self.machine.clock.get_time()
 
         self.next_step_index -= steps + 1
 

--- a/mpf/tests/test_Shows.py
+++ b/mpf/tests/test_Shows.py
@@ -940,3 +940,41 @@ class TestShows(MpfTestCase):
         self.assertLightFlashing("led_01", "red")
         self.assertLightFlashing("led_02", "red")
         self.assertLightFlashing("led_03", "red")
+
+    def test_advance_resets_time(self):
+        # test flash
+        # initially on
+        show_flash = self.machine.shows['flash'].play(show_tokens=dict(leds='led_01', lights='light_01'))
+        self.advance_time_and_run(.1)
+        self.assertLightColor("led_01", [255, 255, 255])
+        self.assertLightChannel("light_01", 255)
+
+        # after advance, is off
+        show_flash.advance()
+        self.advance_time_and_run(.1)
+        self.assertLightColor("led_01", [0, 0, 0])
+        self.assertLightChannel("light_01", 0)
+
+        # after 1sec, back on
+        self.advance_time_and_run(1)
+        self.assertLightColor("led_01", [255, 255, 255])
+        self.assertLightChannel("light_01", 255)
+
+    def test_step_back_resets_time(self):
+        # test flash
+        # initially on
+        show_flash = self.machine.shows['flash'].play(show_tokens=dict(leds='led_01', lights='light_01'))
+        self.advance_time_and_run(.1)
+        self.assertLightColor("led_01", [255, 255, 255])
+        self.assertLightChannel("light_01", 255)
+
+        # after step_back, is off
+        show_flash.step_back()
+        self.advance_time_and_run(.1)
+        self.assertLightColor("led_01", [0, 0, 0])
+        self.assertLightChannel("light_01", 0)
+
+        # after 1sec, back on
+        self.advance_time_and_run(1)
+        self.assertLightColor("led_01", [255, 255, 255])
+        self.assertLightChannel("light_01", 255)


### PR DESCRIPTION
Resets the show timer when advancing or stepping back.

I am setting up an attract mode that advances or steps back when the flipper buttons are pressed. Each slide changes after 4 seconds. When rapidly pressing the flipper button, say 5 times, the slide that it stops on doesn't change for 20 seconds or so as if the times are being accumulated. The expected behavior is to change after 4 seconds. 

This change resets the next step time to the current time when advancing or stepping back.

Let me know if you have any questions. 