### PR TITLE
fix expire issues with multiple segment_display_player entries

### DIFF
--- a/mpf/config_players/segment_display_player.py
+++ b/mpf/config_players/segment_display_player.py
@@ -45,6 +45,10 @@ class SegmentDisplayPlayer(DeviceConfigPlayer):
                 key += s['key']
 
             if action == "add":
+                if key in instance_dict[display]:
+                    if instance_dict[display][key] is not True:
+                        self.delay.remove(instance_dict[display][key])
+
                 # add text
                 s = TransitionManager.validate_config(s, self.machine.config_validator)
                 display.add_text_entry(text=s['text'],

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -154,7 +154,7 @@ class SegmentDisplay(SystemWideDevice):
     # pylint: disable=too-many-arguments
     def _start_transition(self, transition: TransitionBase, current_text: str, new_text: str,
                           current_colors: List[RGBColor], new_colors: List[RGBColor],
-                          update_hz: float):
+                          update_hz: float, flashing, flash_mask):
         """Start the specified transition."""
         current_colors = self._expand_colors(current_colors, len(current_text))
         new_colors = self._expand_colors(new_colors, len(new_text))
@@ -163,8 +163,7 @@ class SegmentDisplay(SystemWideDevice):
         self._current_transition = TransitionRunner(self.machine, transition, current_text, new_text,
                                                     current_colors, new_colors)
         transition_text = next(self._current_transition)
-        self._update_display(SegmentDisplayState(transition_text, self._current_state.flashing,
-                                                 self._current_state.flash_mask))
+        self._update_display(SegmentDisplayState(transition_text, flashing, flash_mask))
         self._transition_update_task = self.machine.clock.schedule_interval(self._update_transition, 1 / update_hz)
 
     def _update_transition(self):
@@ -249,9 +248,16 @@ class SegmentDisplay(SystemWideDevice):
             else:
                 previous_text = " " * self.size
 
+            if top_text_stack_entry.flashing is not None:
+                flashing = top_text_stack_entry.flashing
+                flash_mask = top_text_stack_entry.flash_mask
+            else:
+                flashing = self._current_state.flashing
+                flash_mask = self._current_state.flash_mask
+
             self._start_transition(transition, previous_text, top_text_stack_entry.text,
                                    self._current_state.text.get_colors(), top_text_stack_entry.colors,
-                                   self.config['default_transition_update_hz'])
+                                   self.config['default_transition_update_hz'], flashing, flash_mask)
         else:
             # no transition - subscribe to text template changes and update display
             self._current_placeholder = TextTemplate(self.machine, top_text_stack_entry.text)

--- a/mpf/tests/machine_files/segment_display/config/config_flashing.yaml
+++ b/mpf/tests/machine_files/segment_display/config/config_flashing.yaml
@@ -1,0 +1,15 @@
+#config_version=5
+segment_displays:
+  display1:
+    debug: true
+    number: 1
+    size: 10
+
+segment_display_player:
+  test_event1:
+    display1:
+      flashing: all
+      text: EVENT1
+      transition:
+        type: push
+        direction: left

--- a/mpf/tests/machine_files/segment_display/config/config_transition.yaml
+++ b/mpf/tests/machine_files/segment_display/config/config_transition.yaml
@@ -1,0 +1,53 @@
+#config_version=5
+segment_displays:
+  display1:
+    debug: true
+    number: 1
+    size: 10
+
+segment_display_player:
+  test_event1:
+    display1:
+      priority: 1
+      text: EVENT1
+      color: red
+      expire: 2s
+      transition:
+        type: push
+        direction: left
+      transition_out:
+        type: cover
+        direction: left
+  test_event2:
+    display1:
+      priority: 10
+      text: EVENT2
+      color: blue
+      expire: 5s
+      transition:
+        type: push
+        direction: right
+
+  test_event3:
+    display1:
+      key: test3
+      priority: 1
+      text: EVENT3
+      color: red
+      expire: 2s
+      transition:
+        type: push
+        direction: left
+      transition_out:
+        type: cover
+        direction: left
+  test_event4:
+    display1:
+      key: test4
+      priority: 10
+      text: EVENT4
+      color: blue
+      expire: 5s
+      transition:
+        type: push
+        direction: right

--- a/mpf/tests/test_SegmentDisplay.py
+++ b/mpf/tests/test_SegmentDisplay.py
@@ -1198,6 +1198,53 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         ])
         mock_set_text.reset_mock()
 
+    @test_config("config_transition.yaml")
+    def test_transition_stack(self):
+        """Test that lower priority entries do not run transitions on higher priority entries."""
+        self.post_event("test_event2")
+        self.advance_time_and_run(.5)
+        self.assertEqual("    EVENT2", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(4)
+        self.assertEqual("    EVENT2", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(1)
+        self.assertEqual("          ", self.machine.segment_displays["display1"].text)
+
+        self.post_event("test_event1")
+        self.post_event("test_event2")
+        self.advance_time_and_run(.5)
+        self.assertEqual("    EVENT2", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(4)
+        self.assertEqual("    EVENT2", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(1)
+        self.assertEqual("          ", self.machine.segment_displays["display1"].text)
+
+        self.post_event("test_event2")
+        self.post_event("test_event1")
+        self.advance_time_and_run(.5)
+        self.assertEqual("    EVENT1", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(1)
+        self.assertEqual("    EVENT1", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(1)
+        self.assertEqual("          ", self.machine.segment_displays["display1"].text)
+
+        self.post_event("test_event3")
+        self.post_event("test_event4")
+        self.advance_time_and_run(.5)
+        self.assertEqual("    EVENT4", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(4)
+        self.assertEqual("    EVENT4", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(1)
+        self.assertEqual("          ", self.machine.segment_displays["display1"].text)
+
+        self.post_event("test_event3")
+        self.post_event("test_event4")
+        self.advance_time_and_run(.5)
+        self.assertEqual("    EVENT4", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(4)
+        self.assertEqual("    EVENT4", self.machine.segment_displays["display1"].text)
+        self.advance_time_and_run(1)
+        self.assertEqual("          ", self.machine.segment_displays["display1"].text)
+
     def test_text_stack(self):
         """Test the segment display text stack functionality."""
         display1 = self.machine.segment_displays["display1"]

--- a/mpf/tests/test_SegmentDisplay.py
+++ b/mpf/tests/test_SegmentDisplay.py
@@ -1198,6 +1198,14 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         ])
         mock_set_text.reset_mock()
 
+    @test_config("config_flashing.yaml")
+    def test_flashing_and_transition(self):
+        """Test that flashing workings with transitions."""
+        self.post_event("test_event1")
+        self.advance_time_and_run(.5)
+        self.assertEqual("    EVENT1", self.machine.segment_displays["display1"].text)
+        self.assertEqual(FlashingType.FLASH_ALL, self.machine.segment_displays["display1"].flashing)
+
     @test_config("config_transition.yaml")
     def test_transition_stack(self):
         """Test that lower priority entries do not run transitions on higher priority entries."""


### PR DESCRIPTION
Multiple segment_display_players in the same context (i.e. mode) with the same (or default) key would not properly remove each others. Expire from the previous player would remove the latest one. Added a test as well.