### PR TITLE
make playfield activation optional in shots

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1407,6 +1407,7 @@ shots:
     delay_switch: dict|machine(switches):ms|None
     persist_enable: single|bool|true
     playfield: single|machine(playfields)|playfield
+    mark_playfield_active: single|bool|true
     enable_events: event_handler|event_handler:ms|None
     disable_events: event_handler|event_handler:ms|None
     reset_events: event_handler|event_handler:ms|None

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -51,7 +51,8 @@ class Shot(EnableDisableMixin, ModeDevice):
     def _mark_active(self, **kwargs):
         """Mark playfield active."""
         del kwargs
-        self.config['playfield'].mark_playfield_active_from_device_action()
+        if self.config['mark_playfield_active']:
+            self.config['playfield'].mark_playfield_active_from_device_action()
 
     def device_loaded_in_mode(self, mode: Mode, player: Player):
         """Add device to a mode that was already started.


### PR DESCRIPTION
Add a new parameter `mark_playfield_active` to shots.