### PR TITLE
New MPF Device: Spinner!

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1751,6 +1751,8 @@ spinners:
     active_ms: single|ms|1000ms
     idle_ms: single|ms|
     playfield: single|machine(playfields)|playfield
+    enable_events: event_handler|event_handler:ms|None
+    disable_events: event_handler|event_handler:ms|None
 steppers:
     __valid_in__: machine
     __type__: device

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1747,10 +1747,11 @@ spinners:
     __type__: device
     switch: list|machine(switches)|None
     switches: list|machine(switches)|None
-    switch_tags: list|str|None
+    labels: list|str|None
     active_ms: single|ms|1000ms
     idle_ms: single|ms|None
     playfield: single|machine(playfields)|playfield
+    reset_when_inactive: single|bool|true
     enable_events: event_handler|event_handler:ms|None
     disable_events: event_handler|event_handler:ms|None
 steppers:

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1749,7 +1749,7 @@ spinners:
     switches: list|machine(switches)|None
     switch_tags: list|str|None
     active_ms: single|ms|1000ms
-    idle_ms: single|ms|
+    idle_ms: single|ms|None
     playfield: single|machine(playfields)|playfield
     enable_events: event_handler|event_handler:ms|None
     disable_events: event_handler|event_handler:ms|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1742,6 +1742,15 @@ spike_node:
     coil_priorities: list|int|None
     num_leds: single|int|None
     num_inputs: single|int|None
+spinners:
+    __valid_in__: machine
+    __type__: device
+    switch: list|machine(switches)|None
+    switches: list|machine(switches)|None
+    switch_tags: list|str|None
+    active_ms: single|ms|1000ms
+    idle_ms: single|ms|
+    playfield: single|machine(playfields)|playfield
 steppers:
     __valid_in__: machine
     __type__: device

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -76,7 +76,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.achievement import Achievement     # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.combo_switch import ComboSwitch    # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.score_queue import ScoreQueue      # pylint: disable-msg=cyclic-import,unused-import
-
+    from mpf.devices.spinner import Spinner      # pylint: disable-msg=cyclic-import,unused-import
 
 # pylint: disable-msg=too-many-instance-attributes
 class MachineController(LogMixin):
@@ -196,6 +196,7 @@ class MachineController(LogMixin):
             self.achievement_groups = {}                # type: Dict[str, AchievementGroup]
             self.combo_switches = {}                    # type: Dict[str, ComboSwitch]
             self.score_queues = {}                      # type: Dict[str, ScoreQueue]
+            self.spinners = {}                          # type: Dict[str, Spinner]
 
         self._set_machine_path()
 

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -78,6 +78,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.score_queue import ScoreQueue      # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.spinner import Spinner      # pylint: disable-msg=cyclic-import,unused-import
 
+
 # pylint: disable-msg=too-many-instance-attributes
 class MachineController(LogMixin):
 

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -57,12 +57,12 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
             return
         tag = kwargs.get('tag')
         if not self._active:
-            self.machine.events.post("spinner_{}_active".format(self.name))
+            self.machine.events.post("spinner_{}_active".format(self.name), tag=tag)
             if tag:
                 self.machine.events.post("spinner_{}_{}_active".format(self.name, tag))
             self._active = True
             self._idle = False
-        self.machine.events.post("spinner_{}_hit".format(self.name))
+        self.machine.events.post("spinner_{}_hit".format(self.name), tag=tag)
         if tag:
             self.machine.events.post("spinner_{}_{}_hit".format(self.name, tag))
         self.delay.clear()

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -1,0 +1,104 @@
+"""Contains the base classes for spinners."""
+
+from mpf.core.enable_disable_mixin import EnableDisableMixinSystemWideDevice
+
+from mpf.core.delays import DelayManager
+from mpf.core.device_monitor import DeviceMonitor
+from mpf.core.system_wide_device import SystemWideDevice
+from mpf.exceptions.config_file_error import ConfigFileError
+
+
+MYPY = False
+if MYPY:   # pragma: no cover
+    from mpf.devices.driver import Driver           # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.core.machine import MachineController  # pylint: disable-msg=cyclic-import,unused-import
+
+
+@DeviceMonitor(_active="active", _idle="idle")
+class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
+
+    """Represents a spinner or spinner group in a pinball machine.
+
+    Args: Same as the `Target` parent class
+    """
+
+    config_section = 'spinners'
+    collection = 'spinners'
+    class_label = 'spinner'
+
+    __slots__ = [ "_active_ms", "_active", "_idle", "delay", "_tags"]
+
+    def __init__(self, machine: "MachineController", name: str) -> None:
+        """Initialise drop target."""
+        self._tags = None
+        self._active = False
+        self._idle = True
+        self._active_ms = None
+        super().__init__(machine, name)
+        self.delay = DelayManager(machine)
+
+
+    async def _initialize(self):
+        await super()._initialize()
+        # Cache this value because it's used a lot in rapid succession
+        self._active_ms = self.config['active_ms']
+        # can't read the switch until the switch controller is set up
+        self.machine.events.add_handler('init_phase_4',
+                                        self._register_switch_handlers, priority=1)
+
+    def _register_switch_handlers(self, **kwargs):
+        del kwargs
+        # register for notification of switch state
+        # this is in addition to the parent since drop targets track
+        # self.complete in separately
+
+        self.info_log("Generating switch handlers: {}".format(self.config['switch']))
+        for switch in self.config['switches']:
+            callback_kwargs = { "tag": self._tags[switch] } if self._tags else None
+            self.machine.switch_controller.add_switch_handler_obj(
+                switch,
+                self._update_state_from_switch, 1, callback_kwargs=callback_kwargs)
+
+    def _update_state_from_switch(self, reconcile=False, **kwargs):
+        self.info_log("Updating switch with kwargs {}".format(kwargs))
+        tag = kwargs.get('tag')
+        if not self._active:
+            self.machine.events.post("spinner_{}_active".format(self.name))
+            if tag:
+                self.machine.events.post("spinner_{}_{}_hit".format(self.name, tag))
+            self._active = True
+            self._idle = False
+        self.machine.events.post("spinner_{}_hit".format(self.name))
+        if tag:
+            self.machine.events.post("spinner_{}_{}_hit".format(self.name, tag))
+        self.delay.clear()
+        self.delay.add(self._active_ms, self._deactivate)
+
+    def _deactivate(self, **kwargs):
+        del kwargs
+        self.machine.events.post("spinner_{}_inactive".format(self.name))
+        self._active = False
+        if self.config['idle_ms']:
+            self.delay.add(self.config['idle_ms'], self._on_idle)
+        else:
+            self._idle = True
+
+    def _on_idle(self, **kwargs):
+        del kwargs
+        self.machine.events.post("spinner_{}_idle".format(self.name))
+        self._idle = True
+
+    def validate_and_parse_config(self, config: dict, is_mode_config: bool, debug_prefix: str = None):
+        """Validate and parse shot config."""
+        config = super().validate_and_parse_config(config, is_mode_config, debug_prefix)
+        for switch in config['switch']:
+            if switch not in config['switches']:
+                config['switches'].append(switch)
+
+        if config['switch_tags']:
+            if len(config['switch_tags']) != len(config['switches']):
+                raise ConfigFileError("Spinner switch_tags must be the same number as switches")
+            self._tags = dict(zip(config['switches'], config['switch_tags']))
+            self.info_log("built a list of tags! {}".format(self._tags))
+
+        return config

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -10,7 +10,6 @@ from mpf.exceptions.config_file_error import ConfigFileError
 
 MYPY = False
 if MYPY:   # pragma: no cover
-    from mpf.devices.driver import Driver           # pylint: disable-msg=cyclic-import,unused-import
     from mpf.core.machine import MachineController  # pylint: disable-msg=cyclic-import,unused-import
 
 
@@ -26,13 +25,14 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
     __slots__ = ["_active_ms", "_active", "_idle", "delay", "_tags"]
 
     def __init__(self, machine: "MachineController", name: str) -> None:
-        """Initialise drop target."""
+        """Initialise spinner device."""
+        super().__init__(machine, name)
         self._tags = None
         self._active = False
         self._idle = True
         self._active_ms = None
-        super().__init__(machine, name)
         self.delay = DelayManager(machine)
+        self.enabled = True  # Default to enabled
 
     async def _initialize(self):
         await super()._initialize()

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -59,7 +59,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         if not self._active:
             self.machine.events.post("spinner_{}_active".format(self.name))
             if tag:
-                self.machine.events.post("spinner_{}_{}_hit".format(self.name, tag))
+                self.machine.events.post("spinner_{}_{}_active".format(self.name, tag))
             self._active = True
             self._idle = False
         self.machine.events.post("spinner_{}_hit".format(self.name))

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -17,16 +17,13 @@ if MYPY:   # pragma: no cover
 @DeviceMonitor(_active="active", _idle="idle")
 class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
-    """Represents a spinner or spinner group in a pinball machine.
-
-    Args: Same as the `Target` parent class
-    """
+    """Represents a spinner or spinner group in a pinball machine."""
 
     config_section = 'spinners'
     collection = 'spinners'
     class_label = 'spinner'
 
-    __slots__ = [ "_active_ms", "_active", "_idle", "delay", "_tags"]
+    __slots__ = ["_active_ms", "_active", "_idle", "delay", "_tags"]
 
     def __init__(self, machine: "MachineController", name: str) -> None:
         """Initialise drop target."""
@@ -37,30 +34,27 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         super().__init__(machine, name)
         self.delay = DelayManager(machine)
 
-
     async def _initialize(self):
         await super()._initialize()
         # Cache this value because it's used a lot in rapid succession
         self._active_ms = self.config['active_ms']
-        # can't read the switch until the switch controller is set up
+        # Can't read the switch until the switch controller is set up
         self.machine.events.add_handler('init_phase_4',
                                         self._register_switch_handlers, priority=1)
 
     def _register_switch_handlers(self, **kwargs):
         del kwargs
-        # register for notification of switch state
-        # this is in addition to the parent since drop targets track
-        # self.complete in separately
 
-        self.info_log("Generating switch handlers: {}".format(self.config['switch']))
         for switch in self.config['switches']:
-            callback_kwargs = { "tag": self._tags[switch] } if self._tags else None
+            callback_kwargs = {"tag": self._tags[switch]} if self._tags else None
+            # register for notification of switch active state
             self.machine.switch_controller.add_switch_handler_obj(
                 switch,
                 self._update_state_from_switch, 1, callback_kwargs=callback_kwargs)
 
-    def _update_state_from_switch(self, reconcile=False, **kwargs):
-        self.info_log("Updating switch with kwargs {}".format(kwargs))
+    def _update_state_from_switch(self, **kwargs):
+        if not self.enabled:
+            return
         tag = kwargs.get('tag')
         if not self._active:
             self.machine.events.post("spinner_{}_active".format(self.name))
@@ -75,6 +69,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         self.delay.add(self._active_ms, self._deactivate)
 
     def _deactivate(self, **kwargs):
+        """Post an 'inactive' event after no switch hits for the active_ms duration."""
         del kwargs
         self.machine.events.post("spinner_{}_inactive".format(self.name))
         self._active = False
@@ -84,12 +79,13 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
             self._idle = True
 
     def _on_idle(self, **kwargs):
+        """Post an 'idle' event if the spinner has been inactive for the idle_ms duration."""
         del kwargs
         self.machine.events.post("spinner_{}_idle".format(self.name))
         self._idle = True
 
     def validate_and_parse_config(self, config: dict, is_mode_config: bool, debug_prefix: str = None):
-        """Validate and parse shot config."""
+        """Validate and parse spinner config."""
         config = super().validate_and_parse_config(config, is_mode_config, debug_prefix)
         for switch in config['switch']:
             if switch not in config['switches']:
@@ -97,8 +93,17 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
         if config['switch_tags']:
             if len(config['switch_tags']) != len(config['switches']):
-                raise ConfigFileError("Spinner switch_tags must be the same number as switches")
+                raise ConfigFileError("Spinner switch_tags must be the same number as switches", 1, self.name)
             self._tags = dict(zip(config['switches'], config['switch_tags']))
-            self.info_log("built a list of tags! {}".format(self._tags))
 
         return config
+
+    @property
+    def active(self):
+        """Return whether the spinner is actively spinning."""
+        return self._active
+
+    @property
+    def idle(self):
+        """Return whether the spinner is idle."""
+        return self._idle

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -56,6 +56,7 @@ mpf:
         diverters: mpf.devices.diverter.Diverter
         score_reels: mpf.devices.score_reel.ScoreReel
         score_reel_groups: mpf.devices.score_reel_group.ScoreReelGroup
+        spinners: mpf.devices.spinner.Spinner
         playfield_transfers: mpf.devices.playfield_transfer.PlayfieldTransfer
         multiballs: mpf.devices.multiball.Multiball
         motors: mpf.devices.motor.Motor

--- a/mpf/tests/machine_files/spinners/config/test_spinners.yaml
+++ b/mpf/tests/machine_files/spinners/config/test_spinners.yaml
@@ -1,0 +1,27 @@
+#config_version=5
+
+switches:
+  switch1:
+    number:
+  switch2:
+    number:
+  switch3:
+    number:
+  switch4:
+    number:
+
+spinners:
+  spin1:
+    switch: switch1
+    active_ms: 800
+    idle_ms: 0
+  spin2:
+    switches: switch2, switch3
+    labels: foo, bar
+    active_ms: 400
+    idle_ms: 800
+  spin3:
+    switches: switch4
+    active_ms: 400
+    idle_ms: 800
+    reset_when_inactive: false

--- a/mpf/tests/test_Spinners.py
+++ b/mpf/tests/test_Spinners.py
@@ -1,0 +1,197 @@
+from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
+from unittest.mock import MagicMock
+
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestSpinners(MpfTestCase):
+
+    def get_config_file(self):
+        return 'test_spinners.yaml'
+
+    def get_machine_path(self):
+        return 'tests/machine_files/spinners/'
+
+    def get_platform(self):
+        return 'smart_virtual'
+
+    def test_spinner_active_inactive(self):
+        self.mock_event("spinner_spin1_active")
+        self.mock_event("spinner_spin1_hit")
+        self.mock_event("spinner_spin1_inactive")
+        self.mock_event("spinner_spin1_idle")
+
+        self.hit_and_release_switch("switch1")
+        self.assertEventCalled("spinner_spin1_active")
+        self.assertEventCalled("spinner_spin1_hit")
+
+        self.advance_time_and_run(0.5)
+        self.assertEventNotCalled("spinner_spin1_inactive")
+        self.assertEventNotCalled("spinner_spin1_idle")
+
+        self.advance_time_and_run(0.5)
+        self.assertEventCalled("spinner_spin1_inactive")
+        self.assertEventNotCalled("spinner_spin1_idle")
+
+    def test_spinner_active_inactive_idle(self):
+        self.mock_event("spinner_spin2_active")
+        self.mock_event("spinner_spin2_hit")
+        self.mock_event("spinner_spin2_inactive")
+        self.mock_event("spinner_spin2_idle")
+
+        self.hit_and_release_switch("switch2")
+        self.assertEventCalled("spinner_spin2_active")
+        self.assertEventCalled("spinner_spin2_hit")
+
+        self.advance_time_and_run(0.1)
+        self.assertEventNotCalled("spinner_spin2_inactive")
+        self.assertEventNotCalled("spinner_spin2_idle")
+
+        self.advance_time_and_run(0.4)
+        self.assertEventCalled("spinner_spin2_inactive")
+        self.assertEventNotCalled("spinner_spin2_idle")
+
+        self.advance_time_and_run(0.5)
+        self.assertEventNotCalled("spinner_spin2_idle")
+
+        self.advance_time_and_run(0.4)
+        self.assertEventCalled("spinner_spin2_idle")
+
+    def test_single_spinner_hits(self):
+        self.mock_event("spinner_spin1_active")
+        self.mock_event("spinner_spin1_hit")
+        self.mock_event("spinner_spin1_inactive")
+        self.mock_event("spinner_spin1_idle")
+
+        self.hit_and_release_switch("switch1")
+        self.assertEventCalled("spinner_spin1_active")
+        self.assertEventCalled("spinner_spin1_hit")
+        self.assertEqual({"hits": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+
+        self.hit_and_release_switch("switch1")
+        self.advance_time_and_run(0.5)
+        self.assertEqual({"hits": 2, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEventNotCalled("spinner_spin1_inactive")
+
+        self.hit_and_release_switch("switch1")
+        self.advance_time_and_run(0.5)
+        self.assertEqual({"hits": 3, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEventNotCalled("spinner_spin1_inactive")
+
+        self.hit_and_release_switch("switch1")
+        self.advance_time_and_run(0.5)
+        self.assertEqual({"hits": 4, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEventNotCalled("spinner_spin1_inactive")
+
+        self.advance_time_and_run(0.5)
+        self.assertEqual(1, self._events["spinner_spin1_active"])
+        self.assertEqual(4, self._events["spinner_spin1_hit"])
+        self.assertEventCalled("spinner_spin1_inactive")
+        self.assertEventNotCalled("spinner_spin1_idle")
+
+    def test_double_spinner_hits(self):
+        self.mock_event("spinner_spin2_active")
+        self.mock_event("spinner_spin2_hit")
+        self.mock_event("spinner_spin2_foo_hit")
+        self.mock_event("spinner_spin2_bar_hit")
+        self.mock_event("spinner_spin2_inactive")
+        self.mock_event("spinner_spin2_idle")
+
+        self.hit_and_release_switch("switch2")
+        self.assertEventCalled("spinner_spin2_active")
+        self.assertEventCalled("spinner_spin2_hit")
+        self.assertEventCalled("spinner_spin2_foo_hit")
+        self.assertEqual({"hits": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
+        self.assertEqual(0, self._events["spinner_spin2_bar_hit"])
+
+        self.hit_and_release_switch("switch3")
+        self.advance_time_and_run(0.3)
+        self.assertEqual({"hits": 2, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
+        self.assertEqual(1, self._events["spinner_spin2_bar_hit"])
+
+        self.hit_and_release_switch("switch3")
+        self.advance_time_and_run(0.3)
+        self.assertEqual({"hits": 3, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
+        self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
+
+        self.hit_and_release_switch("switch2")
+        self.advance_time_and_run(0.3)
+        self.assertEqual({"hits": 4, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual(2, self._events["spinner_spin2_foo_hit"])
+        self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
+        self.assertEventNotCalled("spinner_spin2_inactive")
+
+        self.advance_time_and_run(0.3)
+        self.assertEventCalled("spinner_spin2_inactive")
+        self.assertEventNotCalled("spinner_spin2_idle")
+
+        # Re-activate the spinner before it goes idle
+        self.hit_and_release_switch("switch2")
+        self.advance_time_and_run(0.3)
+        self.assertEqual({"hits": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual(3, self._events["spinner_spin2_foo_hit"])
+        self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
+        # Active should be called again
+        self.assertEqual(2, self._events["spinner_spin2_active"])
+        self.assertEqual(1, self._events["spinner_spin2_inactive"])
+        self.assertEventNotCalled("spinner_spin2_idle")
+
+        self.advance_time_and_run(0.3)
+        self.assertEqual(2, self._events["spinner_spin2_active"])
+        self.assertEqual(2, self._events["spinner_spin2_inactive"])
+        self.assertEventNotCalled("spinner_spin2_idle")
+
+        self.advance_time_and_run(0.5)
+        self.assertEventNotCalled("spinner_spin2_idle")
+
+        self.advance_time_and_run(0.3)
+        self.assertEventCalled("spinner_spin2_idle")
+
+    def test_reset_when_inactive_false(self):
+        self.mock_event("spinner_spin3_active")
+        self.mock_event("spinner_spin3_hit")
+        self.mock_event("spinner_spin3_inactive")
+        self.mock_event("spinner_spin3_idle")
+
+        self.hit_and_release_switch("switch4")
+        self.assertEventCalled("spinner_spin3_active")
+        self.assertEventCalled("spinner_spin3_hit")
+        self.assertEqual({"hits": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEventNotCalled("spinner_spin3_inactive")
+
+        self.hit_and_release_switch("switch4")
+        self.advance_time_and_run(0.3)
+        self.assertEqual({"hits": 2, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEventNotCalled("spinner_spin3_inactive")
+
+        self.hit_and_release_switch("switch4")
+        self.advance_time_and_run(0.3)
+        self.assertEqual({"hits": 3, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEventNotCalled("spinner_spin3_inactive")
+
+        self.advance_time_and_run(0.3)
+        self.assertEventCalled("spinner_spin3_inactive")
+        self.assertEventNotCalled("spinner_spin3_idle")
+
+        # Re-activate the spinner before it goes idle
+        self.hit_and_release_switch("switch4")
+        self.advance_time_and_run(0.3)
+        self.assertEqual({"hits": 4, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        # Active should be called again
+        self.assertEqual(2, self._events["spinner_spin3_active"])
+        self.assertEqual(1, self._events["spinner_spin3_inactive"])
+        self.assertEventNotCalled("spinner_spin3_idle")
+
+        self.advance_time_and_run(0.3)
+        self.assertEqual(2, self._events["spinner_spin3_active"])
+        self.assertEqual(2, self._events["spinner_spin3_inactive"])
+        self.assertEventNotCalled("spinner_spin3_idle")
+
+        self.advance_time_and_run(0.5)
+        self.assertEventNotCalled("spinner_spin3_idle")
+
+        self.advance_time_and_run(0.3)
+        self.assertEventCalled("spinner_spin3_idle")


### PR DESCRIPTION
### Spinner

This PR introduces a new Device type to MPF: the **Spinner**

The Spinner device provides a convenient mechanism for aggregating rapid switch hits and tracking when a "batch" of hits begins and ends. The Spinner is `active` while switch hits are occurring, `inactive` when switch hits stop for a given time, and `idle` after being inactive for a certain time.

```

spinners:
  basic_spinner:
    switch: s_orbit_spinner
    active_ms: 500
  dual_spinner:
    switches: s_top_loop_left, s_top_loop_right
    switch_tags: left, right
    active_ms: 1200
    idle_ms: 2400
```

The consolidated events allow the game to start light and sound shows that play during the spin without having to time/overlap the shows against the inconsistent switch hits. The extra `idle_ms` time can be used for slides or widgets that should persist longer than the spin but still be removed after a timeout.

### Basic Usage

The lifecycle:
1. Spinner sits, `idle: true` and `active: false`
2. The spinner switch is hit
    i. The device switches to `active: true` and sets a timeout for `active_ms` duration
    ii. The device posts _spinner_<name>_active_ event
    iii. The device posts _spinner_<name>_hit_ event
3. Additional switch hits occur
    i. The device resets the timeout for another `active_ms` duration
    ii. The device posts _spinner_<name>_hit_ event
4. Switch hits stop and the active delay timer expires
    i. The device switches to `active: false`
    ii. The device posts _spinner_<name>_inactive_ event
    iii. (Optional) If `idle_ms` is defined, the device sets a timeout for `idle_ms` duration
5. (Optional) No switch hits occur and the idle delay timer expires 
    i. The device posts _spinner_<name>_idle_ event
    ii. The device switches to `idle: true`

If no `idle_ms` is defined, the spinner will immediately go to (and post) its idle state when it turns inactive. If it is idle and new switch hits occur, the spinner will re-activate and the cycle starts over.

### Advanced Usage: Spinner Tags

In some situations it is useful to combine multiple spinner switches into a single spinner device—for example a series of inline spinners, or a horseshoe with a spinner at each entrance. If the designer wants to count *all* of the switch hits (either in aggregate or separately), but use a single `active_ms` and `idle_ms` for the group, the Spinner device supports that.

The Spinner config accepts multiple `switches:` (using the same pattern as Shots, either `switch:` or `switches:` can be defined as a single entry or list) and a hit to any switch will trigger the hit and active states. Optionally, the `switch_tags:` config can be defined that maps a tag to each switch. When defined, the Spinner will post both _spinner_<name>_hit_ and _spinner_<name>_<tag>_hit_ events with the tag of whichever switch triggered the hit.

> Question: I chose `switch_tags` because it's used in other configs, but would `switch_labels` or just `labels` be a better name?

### Sample Event Log

In the below log you can see a Spinner named _top_loop_ that is activated by an entrance on the left side and an exit on the right side. The switch hits are aggregated (_spinner_top_loop_hit_) and separated (_spinner_top_loop_left_hit_, _spinner_top_loop_right_hit_), and the Spinner deactivates and idles after it's `active_ms: 1000` and `idle_ms: 2000`.
```
2021-06-15 13:53:43,950 : ======'spinner_top_loop_active'======
2021-06-15 13:53:43,950 : ======'spinner_top_loop_left_active'======
2021-06-15 13:53:43,950 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:43,950 : ======'spinner_top_loop_left_hit'======
2021-06-15 13:53:44,265 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:44,265 : ======'spinner_top_loop_left_hit'======
2021-06-15 13:53:44,583 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:44,583 : ======'spinner_top_loop_left_hit'======
2021-06-15 13:53:44,883 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:44,883 : ======'spinner_top_loop_left_hit'======
2021-06-15 13:53:45,216 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:45,216 : ======'spinner_top_loop_right_hit'======
2021-06-15 13:53:45,483 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:45,483 : ======'spinner_top_loop_right_hit'======
2021-06-15 13:53:45,700 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:45,700 : ======'spinner_top_loop_left_hit'======
2021-06-15 13:53:45,950 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:45,950 : ======'spinner_top_loop_right_hit'======
2021-06-15 13:53:46,166 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:46,166 : ======'spinner_top_loop_right_hit'======
2021-06-15 13:53:46,482 : ======'spinner_top_loop_hit'======
2021-06-15 13:53:46,482 : ======'spinner_top_loop_right_hit'======
2021-06-15 13:53:47,483 : ======'spinner_top_loop_inactive'======
2021-06-15 13:53:49,484 : ======'spinner_top_loop_idle'======
```

![Spin!](https://media.giphy.com/media/yFARJCFogqrle/giphy.gif)