### PR TITLE
Option to override switch in starting game from s_start

### DIFF
--- a/mpf/tests/MpfFakeGameTestCase.py
+++ b/mpf/tests/MpfFakeGameTestCase.py
@@ -24,7 +24,7 @@ class MpfFakeGameTestCase(MpfGameTestCase):
         self.machine_config_patches['machine'] = dict()
         self.machine_config_patches['machine']['min_balls'] = 0
 
-    def start_game(self, num_balls_known=3):
+    def start_game(self, num_balls_known=3, start_switch=None):
         """Start a game.
         
         Does not require ball devices or a start button to be present in the
@@ -36,10 +36,13 @@ class MpfFakeGameTestCase(MpfGameTestCase):
             self.machine.playfield.balls += 1
             self.machine.playfield.available_balls += 1
 
+        if start_switch is None:
+            start_switch = "s_start"
+
         # game start should work
         self.machine.playfield.add_ball = _add_ball
         self.machine.ball_controller.num_balls_known = num_balls_known
-        super().start_game()
+        super().start_game(start_switch=start_switch)
 
     def drain_all_balls(self):
         """Drain all the balls in play.

--- a/mpf/tests/MpfGameTestCase.py
+++ b/mpf/tests/MpfGameTestCase.py
@@ -24,9 +24,9 @@ class MpfGameTestCase(MpfTestCase):
         self.machine_config_patches['switches'] = dict()
         self.machine_config_patches['switches']['s_start'] = {"number": "", "tags": "start"}
 
-    def start_two_player_game(self):
+    def start_two_player_game(self, start_switch=None):
         """Start two player game."""
-        self.start_game()
+        self.start_game(start_switch=start_switch)
         self.add_player()
 
     def fill_troughs(self):

--- a/mpf/tests/MpfGameTestCase.py
+++ b/mpf/tests/MpfGameTestCase.py
@@ -37,7 +37,7 @@ class MpfGameTestCase(MpfTestCase):
 
         self.advance_time_and_run()
 
-    def start_game(self, num_balls_known=None):
+    def start_game(self, num_balls_known=None, start_switch=None):
         """Start a game.
 
         This method checks to make sure a game is not running,
@@ -55,9 +55,12 @@ class MpfGameTestCase(MpfTestCase):
         if num_balls_known is not None:
             self.assertNumBallsKnown(num_balls_known)
 
+        if start_switch is None:
+            start_switch = "s_start"
+
         # game start should work
         self.assertGameIsNotRunning()
-        self.hit_and_release_switch("s_start")
+        self.hit_and_release_switch(start_switch)
         self.advance_time_and_run()
         self.assertGameIsRunning()
         self.assertEqual(1, self.machine.game.num_players)


### PR DESCRIPTION
Added ability to pass in the start switch name if you want to start a test game that does not have a switch s_start.  If it is not specified, it will default to s_start.