### PR TITLE
Create a default machine_var entry for master_volume

### DIFF
--- a/mpf/core/config_processor.py
+++ b/mpf/core/config_processor.py
@@ -76,7 +76,7 @@ class ConfigProcessor:
             self.log.debug('Cache file not found: %s', filename)
             return -1
 
-    # pylint: disable-msg=too-many-arguments
+    # pylint: disable-msg=too-many-arguments,too-many-locals
     def load_config_files_with_cache(self, filenames: List[str], config_type: str,
                                      ignore_unknown_sections=False, config_spec=None) -> dict:   # pragma: no cover
         """Load multiple configs with a combined cache."""

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -419,6 +419,12 @@ settings:
     key_type: float
     default: 1.0
 
+machine_vars:
+  master_volume:
+    initial_value: 0.5
+    value_type: float
+    persist: true
+
 psus:
   default:
     voltage: 48

--- a/mpf/tests/test_MachineVariables.py
+++ b/mpf/tests/test_MachineVariables.py
@@ -34,6 +34,7 @@ class TestMachineVariables(MpfTestCase):
         self.assertTrue(self.machine.variables.is_machine_var("platform_machine"))
         self.assertEqual(version, self.machine.variables.get_machine_var("mpf_version"))
         self.assertEqual(extended_version, self.machine.variables.get_machine_var("mpf_extended_version"))
+        self.assertEqual(0.5, self.machine.variables.get_machine_var("master_volume"))
 
     def testTime(self):
         current_date = self.machine.clock.get_datetime()
@@ -91,7 +92,10 @@ class TestMachineVariables(MpfTestCase):
         self.advance_time_and_run(10)
 
         self.machine.variables.machine_var_data_manager._trigger_save.assert_called_with()
-        self.assertEqual({'test1': {'value': 42, 'expire': None}, 'test2': {'value': '5', 'expire': None}},
+        self.assertEqual({
+                          'master_volume': {'value': 0.5, 'expire': None},
+                          'test1': {'value': 42, 'expire': None},
+                          'test2': {'value': '5', 'expire': None}},
                          self.machine.variables.machine_var_data_manager.data)
 
     def testVarSetAndGet(self):


### PR DESCRIPTION
This PR adds a default `machine_vars:` entry for `master_volume`.

MPF and MC already coordinate on volume changes by setting the `master_volume` machine variable, but that value is never persisted. As a result, volume changes are reset each time the game starts.

By defining an entry for `master_volume` with `persist: true`, the user's selected volume will be saved so it can be restored on the next game start.