### PR TITLE
Add event docstrings for spinners, ball_start_target

### DIFF
--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -82,14 +82,14 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         self.hits += 1
         self.machine.events.post("spinner_{}_hit".format(self.name), hits=self.hits, label=label)
         '''event: spinner_(name)_hit
-            desc: The spinner (name) was just hit.
+        desc: The spinner (name) was just hit.
 
-            This event will post whenever a spinner switch is hit.
+        This event will post whenever a spinner switch is hit.
 
-            args:
-            hits: The number of switch hits the spinner has had since it became active
-            label: The label of the switch that was hit
-            '''
+        args:
+        hits: The number of switch hits the spinner has had since it became active
+        label: The label of the switch that was hit
+        '''
         if label:
             self.machine.events.post("spinner_{}_{}_hit".format(self.name, label))
             '''event: spinner_(name)_(label)_hit
@@ -106,14 +106,14 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         del kwargs
         self.machine.events.post("spinner_{}_inactive".format(self.name), hits=self.hits)
         '''event: spinner_(name)_inactive
-            desc: The spinner (name) is no longer receiving hits
+        desc: The spinner (name) is no longer receiving hits
 
-            This event will post whenever a spinner has not received hits and
-            its active_ms has timed out.
+        This event will post whenever a spinner has not received hits and
+        its active_ms has timed out.
 
-            args:
-            hits: The number of switch hits the spinner had while it was active
-            '''
+        args:
+        hits: The number of switch hits the spinner had while it was active
+        '''
         self._active = False
         if self.config['idle_ms']:
             self.delay.add(self.config['idle_ms'], self._on_idle)
@@ -127,15 +127,15 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         del kwargs
         self.machine.events.post("spinner_{}_idle".format(self.name), hits=self.hits)
         '''event: spinner_(name)_idle
-            desc: The spinner (name) is now idle
+        desc: The spinner (name) is now idle
 
-            This event will post whenever a spinner has not received hits and
-            its idle_ms has timed out. If no idle_ms is defined, this event
-            will not post.
+        This event will post whenever a spinner has not received hits and
+        its idle_ms has timed out. If no idle_ms is defined, this event
+        will not post.
 
-            args:
-            hits: The number of switch hits the spinner had while it was active
-            '''
+        args:
+        hits: The number of switch hits the spinner had while it was active
+        '''
         self.hits = 0
         self._idle = True
 

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -60,14 +60,44 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         label = kwargs.get("label")
         if not self._active:
             self.machine.events.post("spinner_{}_active".format(self.name), label=label)
+            '''event: spinner_(name)_active
+            desc: The idle spinner (name) was just hit and became active.
+
+            This event will post whenever a spinner switch is hit and the spinner
+            is not already active.
+
+            args:
+            label: The label of the switch that triggered the activation
+            '''
             if label:
                 self.machine.events.post("spinner_{}_{}_active".format(self.name, label))
+                '''event: spinner_(name)_(label)_active
+                desc: The idle spinner (name) was just hit and became active.
+
+                This event will post whenever a spinner switch is hit and the spinner
+                is not already active, but only if labels are defined for the spinner.
+                '''
             self._active = True
             self._idle = False
         self.hits += 1
         self.machine.events.post("spinner_{}_hit".format(self.name), hits=self.hits, label=label)
+        '''event: spinner_(name)_hit
+            desc: The spinner (name) was just hit.
+
+            This event will post whenever a spinner switch is hit.
+
+            args:
+            hits: The number of switch hits the spinner has had since it became active
+            label: The label of the switch that was hit
+            '''
         if label:
             self.machine.events.post("spinner_{}_{}_hit".format(self.name, label))
+            '''event: spinner_(name)_(label)_hit
+            desc: The spinner (name) was just hit on the switch labelled (label).
+
+            This event will post whenever a spinner switch is hit and labels
+            are defined for the spinner
+            '''
         self.delay.clear()
         self.delay.add(self._active_ms, self._deactivate)
 
@@ -75,6 +105,15 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         """Post an 'inactive' event after no switch hits for the active_ms duration."""
         del kwargs
         self.machine.events.post("spinner_{}_inactive".format(self.name), hits=self.hits)
+        '''event: spinner_(name)_inactive
+            desc: The spinner (name) is no longer receiving hits
+
+            This event will post whenever a spinner has not received hits and
+            its active_ms has timed out.
+
+            args:
+            hits: The number of switch hits the spinner had while it was active
+            '''
         self._active = False
         if self.config['idle_ms']:
             self.delay.add(self.config['idle_ms'], self._on_idle)
@@ -87,6 +126,16 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         """Post an 'idle' event if the spinner has been inactive for the idle_ms duration."""
         del kwargs
         self.machine.events.post("spinner_{}_idle".format(self.name), hits=self.hits)
+        '''event: spinner_(name)_idle
+            desc: The spinner (name) is now idle
+
+            This event will post whenever a spinner has not received hits and
+            its idle_ms has timed out. If no idle_ms is defined, this event
+            will not post.
+
+            args:
+            hits: The number of switch hits the spinner had while it was active
+            '''
         self.hits = 0
         self._idle = True
 

--- a/mpf/modes/game/code/game.py
+++ b/mpf/modes/game/code/game.py
@@ -386,6 +386,19 @@ class Game(AsyncMode):
 
         # This relay event allows handlers to select a new target playfield for the ball
         result = await self.machine.events.post_relay_async("ball_start_target", target=self.machine.playfield.name)
+        '''event: ball_start_target
+
+        desc: Posted when a new ball starts and is ready to be physically ejected
+            to the playfield.
+
+        This is a relay event.
+
+        args:
+        target: The name of the ball_device target where the ball will be ejected
+            to. Can be modified by a relay event handler to change the target
+            before the ball is ejected.
+
+        '''
         self.machine.playfields[result["target"]].add_ball(player_controlled=True)
 
     def ball_drained(self, balls=0, **kwargs):

--- a/mpf/modes/game/code/game.py
+++ b/mpf/modes/game/code/game.py
@@ -397,7 +397,6 @@ class Game(AsyncMode):
         target: The name of the ball_device target where the ball will be ejected
             to. Can be modified by a relay event handler to change the target
             before the ball is ejected.
-
         '''
         self.machine.playfields[result["target"]].add_ball(player_controlled=True)
 


### PR DESCRIPTION
This PR adds event docstrings for all the new Spinner device events, and the _ball_start_target_ event.