### PR TITLE
Miscellaneous updates: CoilPlayer, Bonus, BCP Service

### DIFF
--- a/mpf/config_players/coil_player.py
+++ b/mpf/config_players/coil_player.py
@@ -13,6 +13,7 @@ class CoilPlayer(DeviceConfigPlayer):
     config_file_section = 'coil_player'
     show_section = 'coils'
     machine_collection_name = 'coils'
+    allow_placeholders_in_keys = True
 
     __slots__ = []  # type: List[str]
 

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -274,6 +274,7 @@ bonus_entries:
     reset_player_score_entry: single|bool|false
     player_score_entry: single|str|None
     skip_if_zero: single|bool|true
+    skip_if_negative: single|bool|false
 coils:
     __valid_in__: machine
     __type__: device

--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -264,6 +264,8 @@ class BcpInterface(MpfController):
             self._monitor_modes(client)
         elif category == "core_events":
             self._monitor_core_events(client)
+        elif category == "service_events":
+            self._monitor_service_events(client)
         elif category == "status_request":
             self._monitor_status_request(client)
         else:
@@ -292,6 +294,8 @@ class BcpInterface(MpfController):
             self._monitor_modes_stop(client)
         elif category == "core_events":
             self._monitor_core_events_stop(client)
+        elif category == "service_events":
+            self._monitor_service_events_stop(client)
         elif category == "status_request":
             self._monitor_status_request_stop(client)
         else:
@@ -519,6 +523,21 @@ class BcpInterface(MpfController):
             self.machine.events.remove_handler_by_event('ball_ended', self._ball_ended)
             self.machine.events.remove_handler_by_event('player_turn_started', self._player_turn_start)
             self.machine.events.remove_handler_by_event('player_added', self._player_added)
+
+    def _monitor_service_events(self, client):
+        """Begin monitoring all service events via the specified client."""
+        if not self.machine.bcp.transport.get_transports_for_handler("_service_events"):
+            for event in ["service_mode_entered", "service_main_menu", "service_menu_selected"]:
+                self.add_registered_trigger_event_for_client(client, event)
+        self.machine.bcp.transport.add_handler_to_transport("_service_events", client)
+
+    def _monitor_service_events_stop(self, client):
+        """Stop monitoring all service events via the specified client."""
+        self.machine.bcp.transport.add_handler_to_transport("_service_events", client)
+
+        if not self.machine.bcp.transport.get_transports_for_handler("_service_events"):
+            for event in ["service_mode_entered", "service_main_menu", "service_menu_selected"]:
+                self.remove_registered_trigger_event_for_client(client, event)
 
     def _monitor_status_request(self, client):
         """Begin monitoring status_request messages via the specified client."""

--- a/mpf/modes/bonus/code/bonus.py
+++ b/mpf/modes/bonus/code/bonus.py
@@ -94,7 +94,7 @@ class Bonus(Mode):
         hits = self.player.vars.get(entry['player_score_entry'], 1)
         score = entry['score'].evaluate([]) * hits
 
-        if not score and entry['skip_if_zero']:
+        if (not score and entry['skip_if_zero']) or (score < 0 and entry['skip_if_negative']):
             self.debug_log("Skipping bonus entry '{}' because its value is 0".
                            format(entry['event']))
             self._bonus_next_item()

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -304,10 +304,12 @@ software_update_script: single|str|None
         else:
             state_string = "inactive"
 
+        label_string = "" if change.label == "%" else change.label
+
         self.machine.events.post("service_switch_test_start",
                                  switch_name=change.name,
                                  switch_num=change.num,
-                                 switch_label=change.label,
+                                 switch_label=label_string,
                                  switch_state=state_string)
 
     async def _switch_test_menu(self):

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -360,10 +360,11 @@ software_update_script: single|str|None
 
     def _update_light_slide(self, items, position, color):
         board, light = items[position]
+        label_string = "" if light.config['label'] == "%" else light.config['label']
         self.machine.events.post("service_light_test_start",
                                  board_name=board,
                                  light_name=light.name,
-                                 light_label=light.config['label'],
+                                 light_label=label_string,
                                  light_num=light.config['number'],
                                  test_color=color)
 

--- a/mpf/platforms/fast/fast_driver.py
+++ b/mpf/platforms/fast/fast_driver.py
@@ -59,7 +59,7 @@ class FASTDriver(DriverPlatformInterface):
 
     def get_hold_pwm_for_cmd(self, power):
         """Return a hex string for a float power setting for hold."""
-        if self.platform_settings['hold_pwm_patter']:
+        if self.platform_settings.get('hold_pwm_patter'):
             return self.platform_settings['hold_pwm_patter']
 
         return self.get_pwm_for_cmd(power)
@@ -77,7 +77,7 @@ class FASTDriver(DriverPlatformInterface):
         """Return recycle ms."""
         if not recycle:
             return "00"
-        if self.platform_settings['recycle_ms'] is not None:
+        if self.platform_settings.get('recycle_ms') is not None:
             return Util.int_to_hex_string(self.platform_settings['recycle_ms'])
 
         # default recycle_ms to pulse_ms * 2

--- a/mpf/tests/machine_files/service_mode/config/config.yaml
+++ b/mpf/tests/machine_files/service_mode/config/config.yaml
@@ -57,6 +57,7 @@ lights:
       number: 1
     l_light5:
       number: 5
+      label: Light Five
 
 sound_system:
   tracks:

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -314,7 +314,7 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.mock_event("service_switch_test_stop")
         self.hit_switch_and_run("s_start", 1)
 
-        self.assertEventCalledWith("service_switch_test_start", switch_label='%', switch_name='s_start',
+        self.assertEventCalledWith("service_switch_test_start", switch_label='', switch_name='s_start',
                                    switch_num='', switch_state='active')
 
         # leave switch test
@@ -364,7 +364,7 @@ class TestServiceMode(MpfFakeGameTestCase):
         for color in ["white", "red", "green", "blue", "yellow", "white"]:
             self.assertEventCalledWith("service_light_test_start",
                                        board_name='Virtual',
-                                       light_label='%',
+                                       light_label='',
                                        light_name='l_light1',
                                        light_num='1',
                                        test_color=color)
@@ -379,7 +379,7 @@ class TestServiceMode(MpfFakeGameTestCase):
 
         self.assertEventCalledWith("service_light_test_start",
                                    board_name='Virtual',
-                                   light_label='%',
+                                   light_label='Light Five',
                                    light_name='l_light5',
                                    light_num='5',
                                    test_color="red")
@@ -392,7 +392,7 @@ class TestServiceMode(MpfFakeGameTestCase):
 
         self.assertEventCalledWith("service_light_test_start",
                                    board_name='Virtual',
-                                   light_label='%',
+                                   light_label='',
                                    light_name='l_light1',
                                    light_num='1',
                                    test_color="red")


### PR DESCRIPTION
This PR presents a handful of changes I've been carrying around in my local branch and never got around to merging. It's my last PR for the week, I promise! 😝 

* **CoilPlayer** now supports placeholders in the keys, so shows can use tokens to target coils. Very useful for adding flashers to shows.
* **Bonus Mode** gets a new option `skip_if_negative` so that bonus calculations less than zero will be ignored, rather than subtracting from the player's score
* **BCP Clients** can subscribe to service mode events as a group, instead of needing to get them all individually
* **Switch Diagnostics** in the service menu will gracefully handle switches without labels (currently displays `%`)
* **Fast Drivers** have fallbacks for `hold_pwm_patter` and `recycle_ms` not being present in the config