### PR TITLE
Partial revert of 986b0c8 to restore drop_target_bank_mixed events

### DIFF
--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -464,11 +464,11 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
         only posted once, when all the drop targets are up.'''
 
     def _bank_mixed(self):
-        if self.state == DropTargetBankState.MIXED:
-            return
+        prev_state = self.state
         self.state = DropTargetBankState.MIXED
         self.complete = False
         self.machine.events.post('drop_target_bank_' + self.name + '_mixed',
+                                 prev_value=prev_state,
                                  down=self.down)
         '''event: drop_target_bank_(name)_mixed
         desc: The drop targets in the drop target bank


### PR DESCRIPTION
This PR partially reverts changes made in https://github.com/missionpinball/mpf/commit/986b0c899ac41218606cb304634fc19cf8d89bc8 related to drop target banks.

Based on [a forum discussion](https://groups.google.com/g/mpf-users/c/YDeEVrESuog/m/FxWfNXwXAwAJ) where a user was seeing multiple _drop_target_bank_<name>_down_ events unnecessarily, the above commit prevented drop targets from posting state events if the state was not changing. This works very well for UP and DOWN events, but causes regressions for MIXED.

_drop_target_bank_<name>_mixed_ events are useful to know when any drop target is hit, much like a shot group is useful for listening instead of every shot individually. The mixed event includes a kwargs `down` with the count of how many targets are down, so there is information available to know more about the state. This PR adds another kwarg `prev_state` in case a user wants to prevent subsequent changes.

The related changes have not yet been released so this should not cause any regressions, and the user from the forum was only having trouble with the DOWN events, which remain unchanged here.