### PR TITLE
BCP: Service test start events

### DIFF
--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -527,7 +527,8 @@ class BcpInterface(MpfController):
     def _monitor_service_events(self, client):
         """Begin monitoring all service events via the specified client."""
         if not self.machine.bcp.transport.get_transports_for_handler("_service_events"):
-            for event in ["service_mode_entered", "service_main_menu", "service_menu_selected"]:
+            for event in ["service_mode_entered", "service_main_menu", "service_menu_selected",
+                          "service_switch_test_start"]:
                 self.add_registered_trigger_event_for_client(client, event)
         self.machine.bcp.transport.add_handler_to_transport("_service_events", client)
 
@@ -536,7 +537,8 @@ class BcpInterface(MpfController):
         self.machine.bcp.transport.add_handler_to_transport("_service_events", client)
 
         if not self.machine.bcp.transport.get_transports_for_handler("_service_events"):
-            for event in ["service_mode_entered", "service_main_menu", "service_menu_selected"]:
+            for event in ["service_mode_entered", "service_main_menu", "service_menu_selected",
+                          "service_switch_test_start"]:
                 self.remove_registered_trigger_event_for_client(client, event)
 
     def _monitor_status_request(self, client):


### PR DESCRIPTION
This PR extends the work in https://github.com/missionpinball/mpf/pull/1582 for exposing service events to BCP clients who subscribe to the `service_events` triggers.

The previous commit handles the necessary events for opening and navigating the service menus, but are missing the events for starting diagnostic tests (switch edge test, coil pulsing, lights, et cetera). This PR adds the test start event so subscribed clients can act accordingly.