### PR TITLE
Adds Multiball Ball Save for Add A Ball

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -982,6 +982,9 @@ multiballs:
     start_events: event_handler|event_handler:ms|None
     stop_events: event_handler|event_handler:ms|None
     add_a_ball_events: event_handler|event_handler:ms|None
+    add_a_ball_shoot_again: single|template_ms|5s
+    add_a_ball_hurry_up_time: single|template_ms|0
+    add_a_ball_grace_period: single|template_ms|0
     start_or_add_a_ball_events: event_handler|event_handler:ms|None
 multiball_locks:
     __valid_in__: mode

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -163,8 +163,7 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
         self._start_shoot_again(shoot_again_ms, grace_period_ms, hurry_up_time_ms)
 
     def _start_shoot_again(self, shoot_again_ms, grace_period_ms, hurry_up_time_ms):
-        """Sets the event callbacks for shoot again, grace period, and hurry up,
-           if values above 0 are provided
+        """Set callbacks for shoot again, grace period, and hurry up, if values above 0 are provided.
 
         This is started for both beginning multiball ball save and add a ball ball save
         """

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -302,8 +302,7 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
         if self.shoot_again:
             # if main ball save timer is running, don't run this timer
             return
-        else:
-            self.shoot_again = True
+        self.shoot_again = True
 
         shoot_again_ms = self.config['add_a_ball_shoot_again'].evaluate([])
         if not shoot_again_ms:

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -159,10 +159,18 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
         shoot_again_ms = self.config['shoot_again'].evaluate([])
         grace_period_ms = self.config['grace_period'].evaluate([])
         hurry_up_time_ms = self.config['hurry_up_time'].evaluate([])
+
+        self._start_shoot_again(shoot_again_ms, grace_period_ms, hurry_up_time_ms)
+
+    def _start_shoot_again(self, shoot_again_ms, grace_period_ms, hurry_up_time_ms):
+        """Sets the event callbacks for shoot again, grace period, and hurry up,
+           if values above 0 are provided
+
+        This is started for both beginning multiball ball save and add a ball ball save
+        """
         if shoot_again_ms > 0:
             self.debug_log('Starting ball save timer: %ss',
                            shoot_again_ms)
-            # Register stop handler
             self.delay.add(name='disable_shoot_again',
                            ms=(shoot_again_ms +
                                grace_period_ms),
@@ -321,24 +329,7 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
 
         grace_period_ms = self.config['add_a_ball_grace_period'].evaluate([])
         hurry_up_time_ms = self.config['add_a_ball_hurry_up_time'].evaluate([])
-        if shoot_again_ms > 0:
-            self.debug_log('Starting add a ball ball save timer: %ss',
-                           shoot_again_ms)
-            self.delay.add(name='disable_shoot_again',
-                           ms=(shoot_again_ms +
-                               grace_period_ms),
-                           callback=self.stop)
-        if grace_period_ms > 0:
-            self.grace_period = True
-            self.delay.add(name='grace_period',
-                           ms=shoot_again_ms,
-                           callback=self._grace_period)
-        if hurry_up_time_ms > 0:
-            self.hurry_up = True
-            self.delay.add(name='hurry_up',
-                           ms=(shoot_again_ms -
-                               hurry_up_time_ms),
-                           callback=self._hurry_up)
+        self._start_shoot_again(shoot_again_ms, grace_period_ms, hurry_up_time_ms)
 
     @event_handler(9)
     def event_start_or_add_a_ball(self, **kwargs):

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -136,7 +136,7 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
             self.machine.events.add_handler('ball_drain',
                                             self._ball_drain_shoot_again,
                                             priority=1000)
-            self.timer_start()
+            self._timer_start()
 
         self.machine.events.post("multiball_" + self.name + "_started",
                                  balls=self.balls_live_target)
@@ -146,7 +146,7 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
             balls: The number of balls in this multiball
         '''
 
-    def timer_start(self) -> None:
+    def _timer_start(self) -> None:
         """Start the timer.
 
         This is started when multiball starts if configured.
@@ -291,9 +291,9 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
             self.balls_added_live += 1
             self.machine.game.balls_in_play += 1
             self.source_playfield.add_ball(balls=1)
-            self.add_a_ball_timer_start()
+            self._add_a_ball_timer_start()
 
-    def add_a_ball_timer_start(self) -> None:
+    def _add_a_ball_timer_start(self) -> None:
         """Start the timer for add a ball ball save.
 
         This is started when multiball add a ball is triggered if configured,
@@ -308,11 +308,11 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
         if not shoot_again_ms:
             # No shoot again. Just stop multiball right away
             self.stop()
-        else:
-            # Enable shoot again
-            self.machine.events.add_handler('ball_drain',
-                                            self._ball_drain_shoot_again,
-                                            priority=1000)
+            return
+        # Enable shoot again
+        self.machine.events.add_handler('ball_drain',
+                                        self._ball_drain_shoot_again,
+                                        priority=1000)
 
         self.machine.events.post('ball_save_{}_add_a_ball_timer_start'.format(self.name))
         '''event: ball_save_(name)_add_a_ball_timer_start

--- a/mpf/tests/machine_files/multiball/config/config.yaml
+++ b/mpf/tests/machine_files/multiball/config/config.yaml
@@ -117,3 +117,15 @@ multiballs:
         grace_period: 5s
         start_events: mb_alltimers_start
         stop_events: mb_alltimers_stop
+    mb_add_a_ball_timers:
+        ball_count: 2
+        shoot_again: 30s
+        hurry_up_time: 10s
+        grace_period: 5s
+        add_a_ball_events: add_ball
+        add_a_ball_shoot_again: 20s
+        add_a_ball_hurry_up_time: 5s
+        add_a_ball_grace_period: 10s
+        start_events: mb_add_a_ball_timers_start
+        stop_events: mb_add_a_ball_timers_stop
+

--- a/mpf/tests/test_MultiBall.py
+++ b/mpf/tests/test_MultiBall.py
@@ -1158,3 +1158,73 @@ class TestMultiBall(MpfGameTestCase):
         self.assertEventCalled("multiball_mb_mode5_lean_ended")
         self.assertEventNotCalled("multiball_mb_mode5_lean_grace_period")
         self.assertEventNotCalled("multiball_mb_mode5_lean_hurry_up")
+
+    def testAddABallSaver(self):
+        self.fill_troughs()
+        self.start_game()
+        self.assertAvailableBallsOnPlayfield(1)
+        self.mock_event("multiball_mb_add_a_ball_timers_ended")
+        self.mock_event("multiball_mb_add_a_ball_timers_shoot_again_ended")
+        self.mock_event("multiball_mb_add_a_ball_timers_grace_period")
+        self.mock_event("multiball_mb_add_a_ball_timers_hurry_up")
+        self.mock_event("ball_save_mb_add_a_ball_timers_timer_start")
+        self.mock_event("ball_save_mb_add_a_ball_timers_add_a_ball_timer_start")
+
+        # start mb 30s shoot again, 10s hurry up, 5s grace
+        self.post_event("mb_add_a_ball_timers_start")
+        self.advance_time_and_run(5)
+        self.assertAvailableBallsOnPlayfield(2)
+        self.assertEventCalled("ball_save_mb_add_a_ball_timers_timer_start")
+
+        # end ball save
+        self.advance_time_and_run(35)
+        self.assertEventCalled("multiball_mb_add_a_ball_timers_shoot_again_ended")
+
+        #add a ball - ball save 20, hurry up 5, grace 10
+        self.post_event("add_ball")
+        self.advance_time_and_run(5)
+        self.assertAvailableBallsOnPlayfield(3)
+        self.assertEventCalled("ball_save_mb_add_a_ball_timers_timer_start",1)
+        self.assertEventCalled("ball_save_mb_add_a_ball_timers_add_a_ball_timer_start")
+        self.assertEventNotCalled("multiball_mb_add_a_ball_timers_ended")
+        self.drain_one_ball()
+        self.advance_time_and_run(5)
+        self.assertAvailableBallsOnPlayfield(3)
+
+        #hurry up
+        self.advance_time_and_run(7)
+        self.assertEventCalled("multiball_mb_add_a_ball_timers_hurry_up")
+        self.drain_one_ball()
+        self.advance_time_and_run(5)
+        self.assertAvailableBallsOnPlayfield(3)
+        #grace period
+        self.assertEventCalled("multiball_mb_add_a_ball_timers_grace_period")
+        self.drain_one_ball()
+        self.advance_time_and_run(10)
+        self.assertAvailableBallsOnPlayfield(3)
+        self.assertEventCalled("multiball_mb_add_a_ball_timers_shoot_again_ended")
+
+        #drain out and mb should end
+        self.drain_one_ball()
+        self.drain_one_ball()
+        self.advance_time_and_run(5)
+        self.assertEventCalled("multiball_mb_add_a_ball_timers_ended")
+
+    def testAddABallSaverDuringShootAgain(self):
+        self.fill_troughs()
+        self.start_game()
+        self.assertAvailableBallsOnPlayfield(1)
+        self.mock_event("ball_save_mb_add_a_ball_timers_timer_start")
+        self.mock_event("ball_save_mb_add_a_ball_timers_add_a_ball_timer_start")
+
+        # start mb 30s shoot again, 10s hurry up, 5s grace
+        self.post_event("mb_add_a_ball_timers_start")
+        self.advance_time_and_run(5)
+        self.assertAvailableBallsOnPlayfield(2)
+        self.assertEventCalled("ball_save_mb_add_a_ball_timers_timer_start")
+        # add a ball
+        self.post_event("add_ball")
+        self.advance_time_and_run(5)
+        self.assertAvailableBallsOnPlayfield(3)
+        self.assertEventCalled("ball_save_mb_add_a_ball_timers_timer_start", 1)
+        self.assertEventNotCalled("ball_save_mb_add_a_ball_timers_add_a_ball_timer_start")


### PR DESCRIPTION
This adds a unique ball save feature for add a ball.  This uses the same
event calls, so you can trigger your shows off the same events for
normal ball save and add a ball ball save.  The add a ball ball save
will not run (or add time) if the ball save is already running.  But if
the normal ball save has expired, it will start this ball save at the
add a ball configured times for shoot again, hurry up, and grace period.