### PR TITLE
Adds a default show bl_color for blinkenlights

### DIFF
--- a/mpf/config_players/blinkenlight_player.py
+++ b/mpf/config_players/blinkenlight_player.py
@@ -1,5 +1,4 @@
 """Blinkenlight config player."""
-from typing import Union
 from mpf.config_players.device_config_player import DeviceConfigPlayer
 from mpf.devices.blinkenlight import Blinkenlight
 
@@ -38,7 +37,7 @@ class BlinkenlightPlayer(DeviceConfigPlayer):
                     raise AssertionError("Unknown action {}".format(action))
 
     @staticmethod
-    def _add_color(blinkenlight: Union[Blinkenlight, str], color, key, priority):
+    def _add_color(blinkenlight: Blinkenlight, color, key, priority):
         """Instructs a blinkenlight to add a color to its list of colors."""
         blinkenlight.add_color(color, key, priority)
 

--- a/mpf/config_players/blinkenlight_player.py
+++ b/mpf/config_players/blinkenlight_player.py
@@ -38,7 +38,7 @@ class BlinkenlightPlayer(DeviceConfigPlayer):
     @staticmethod
     def _add_color(blinkenlight: Blinkenlight, color, key, priority):
         """Instructs a blinkenlight to add a color to its list of colors."""
-        if blinkenlight is None:
+        if blinkenlight is None or isinstance(blinkenlight, str):
             return
         blinkenlight.add_color(color, key, priority)
 
@@ -59,7 +59,8 @@ class BlinkenlightPlayer(DeviceConfigPlayer):
     def clear_context(self, context):
         """Clear the context. In our case, this means remove the mode colors from all blinkenlights."""
         for (key, _), blinkenlight in self._get_instance_dict(context).items():
-            blinkenlight.remove_color_with_key(key)
+            if not isinstance(blinkenlight, str):
+                blinkenlight.remove_color_with_key(key)
         self._reset_instance_dict(context)
 
     def get_express_config(self, value):

--- a/mpf/config_players/blinkenlight_player.py
+++ b/mpf/config_players/blinkenlight_player.py
@@ -1,7 +1,7 @@
 """Blinkenlight config player."""
+from typing import Union
 from mpf.config_players.device_config_player import DeviceConfigPlayer
 from mpf.devices.blinkenlight import Blinkenlight
-from typing import Union
 
 
 class BlinkenlightPlayer(DeviceConfigPlayer):
@@ -38,24 +38,18 @@ class BlinkenlightPlayer(DeviceConfigPlayer):
                     raise AssertionError("Unknown action {}".format(action))
 
     @staticmethod
-    def _add_color(blinkenlight: Union[Blinkenlight,str], color, key, priority):
+    def _add_color(blinkenlight: Union[Blinkenlight, str], color, key, priority):
         """Instructs a blinkenlight to add a color to its list of colors."""
-        if blinkenlight is None:
-            return
         blinkenlight.add_color(color, key, priority)
 
     @staticmethod
     def _remove_all_colors(blinkenlight):
         """Instructs a blinkenlight to remove all of its colors."""
-        if blinkenlight is None:
-            return
         blinkenlight.remove_all_colors()
 
     @staticmethod
     def _remove_color(blinkenlight, key):
         """Instructs a blinkenlight to remove a color with a given key from its list of colors."""
-        if blinkenlight is None:
-            return
         blinkenlight.remove_color_with_key(key)
 
     def clear_context(self, context):

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -388,6 +388,16 @@ shows:
             (leds): (color)
             (light): (color)
             (lights): (color)
+    bl_color:
+        - time: 0
+          duration: -1
+          blinkenlights:
+            (led): (color)
+            (leds): (color)
+            (light): (color)
+            (lights): (color)
+            (blinkenlight): (color)
+            (blinkenlights): (color)
     flash_color:
         - duration: 1
           lights:

--- a/mpf/tests/test_ConfigLoader.py
+++ b/mpf/tests/test_ConfigLoader.py
@@ -28,5 +28,5 @@ class TestConfigLoader(TestCase):
         self.assertTrue(config.get_show_config("mode1_show"))
         self.assertTrue(config.get_show_config("show1"))
         self.assertCountEqual(
-            ['flash', 'on', 'off', 'led_color', 'flash_color', 'test_show', 'show1', 'game_show', 'mode1_show'],
+            ['flash', 'on', 'off', 'led_color', 'bl_color', 'flash_color', 'test_show', 'show1', 'game_show', 'mode1_show'],
             config.get_shows())

--- a/mpf/tests/test_ServiceCli.py
+++ b/mpf/tests/test_ServiceCli.py
@@ -108,6 +108,7 @@ Virtual;1000;c_test3;
 
         cli.onecmd("list_shows")
         expected = """Name;Token;
+bl_color;['blinkenlight', 'blinkenlights', 'color', 'led', 'leds', 'light', 'lights'];
 flash;['led', 'leds', 'light', 'lights'];
 flash_color;['color', 'led', 'leds', 'light', 'lights'];
 led_color;['color', 'led', 'leds', 'light', 'lights'];


### PR DESCRIPTION
The bl_color show takes a token for the light (led, light, blinkenlight,
etc.) as well as the color that is being passed.  It calls to the
blinkenlights player only, but can take any of the standard light
tokens.  It also includes some error handling for blinkenlight_player to
verify its a type, and not one of the blank strings when adding or
removing.