### PR TITLE
MultiballLock blocking_facility 

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1006,6 +1006,7 @@ multiball_locks:
     __type__: device
     balls_to_lock: single|int|
     balls_to_replace: single|int|-1
+    blocking_facility: single|str|None
     lock_devices: list|machine(ball_devices)|
     source_devices: list|machine(ball_devices)|None
     source_playfield: single|machine(ball_devices)|playfield

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -151,14 +151,17 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
     def _register_handlers(self):
         priority = (self.mode.priority if self.mode else 0) + \
             self.config['priority']
+        blocking_facility = self.config['blocking_facility']
         # register on ball_enter of lock_devices
         for device in self.lock_devices:
             self.machine.events.add_handler(
                 'balldevice_' + device.name + '_ball_enter',
-                self._lock_ball, device=device, priority=priority)
+                self._lock_ball, device=device, priority=priority,
+                blocking_facility=blocking_facility)
             self.machine.events.add_handler(
                 'balldevice_' + device.name + '_ball_entered',
-                self._post_events, device=device, priority=priority)
+                self._post_events, device=device, priority=priority,
+                blocking_facility=blocking_facility)
 
     def _unregister_handlers(self):
         # unregister ball_enter handlers

--- a/mpf/tests/machine_files/multiball_locks/config/config.yaml
+++ b/mpf/tests/machine_files/multiball_locks/config/config.yaml
@@ -10,6 +10,8 @@ coils:
         number:
     eject_coil3:
         number:
+    eject_coil4:
+        number:
 
 switches:
     s_ball_switch1:
@@ -34,6 +36,10 @@ switches:
         number:
     s_lockt3:
         number:
+    s_lockb1:
+        number:
+    s_lockb2:
+        number:
 
 playfields:
     playfield:
@@ -53,6 +59,10 @@ ball_devices:
     bd_lock_triple:
         eject_coil: eject_coil3
         ball_switches: s_lockt1, s_lockt2, s_lockt3
+        eject_timeouts: 2s
+    bd_lock_block:
+        eject_coil: eject_coil4
+        ball_switches: s_lockb1, s_lockb2
         eject_timeouts: 2s
 
 multiballs:

--- a/mpf/tests/machine_files/multiball_locks/config/testDefault.yaml
+++ b/mpf/tests/machine_files/multiball_locks/config/testDefault.yaml
@@ -3,3 +3,4 @@ config: config.yaml
 
 modes:
     - default
+    - blocking

--- a/mpf/tests/machine_files/multiball_locks/modes/blocking/config/blocking.yaml
+++ b/mpf/tests/machine_files/multiball_locks/modes/blocking/config/blocking.yaml
@@ -1,0 +1,8 @@
+#config_version=5
+mode:
+  start_events: start_blocking
+  priority: 1000
+
+blocking:
+  balldevice_bd_lock_block_ball_enter:
+    foo: 102

--- a/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
+++ b/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
@@ -19,3 +19,8 @@ multiball_locks:
     lock_devices: bd_lock_triple
     balls_to_lock: 3
     locked_ball_counting_strategy: virtual_only
+  lock_with_block:
+    lock_devices: bd_lock_block
+    balls_to_lock: 2
+    locked_ball_counting_strategy: virtual_only
+    blocking_facility: foo

--- a/mpf/tests/test_MultiballLock.py
+++ b/mpf/tests/test_MultiballLock.py
@@ -137,6 +137,36 @@ class TestMultiballLock(MpfGameTestCase):
         self.assertEventCalled("should_post_when_disabled")
         self.assertEventNotCalled("should_not_post_when_disabled")
 
+    def test_blocking_facility(self):
+        self.fill_troughs()
+        self.start_game()
+
+        self.post_event("start_default")
+
+        # takes roughly 4s to get ball confirmed
+        self.advance_time_and_run(4)
+        self.assertNotEqual(None, self.machine.game)
+        self.assertEqual(1, self.machine.playfield.balls)
+
+        self.advance_time_and_run(4)
+        self.assertEqual(1, self.machine.playfield.available_balls)
+
+        lock_device = self.machine.ball_devices["bd_lock_block"]
+        mb_lock = self.machine.multiball_locks["lock_with_block"]
+        self.assertEqual(lock_device.balls, 0)
+        self.machine.default_platform.add_ball_to_device(lock_device)
+        self.advance_time_and_run(10)
+        self.assertEqual(1, lock_device.balls)
+        self.assertEqual(1, mb_lock.locked_balls)
+
+        self.post_event("start_blocking")
+        self.advance_time_and_run(2)
+
+        self.machine.default_platform.add_ball_to_device(lock_device)
+        self.advance_time_and_run(10)
+        self.assertEqual(1, lock_device.balls)
+        self.assertEqual(1, mb_lock.locked_balls)
+
 
 class TestMultiballLockCountingStrategies(MpfGameTestCase):
 


### PR DESCRIPTION
This PR has a couple of updates for miscellaneous MPF behaviors.

### Multiball Blocking Facility
After many hours struggling to conditionally prevent a multiball from capturing a ball in a lock (with no other devices available to take the `unclaimed_ball`), I stumbled across the `blocking_facility` code. It's totally undocumented but I was able to step through and figure out how to get it working, and it does *exactly* what I need!

This PR adds `blocking_facility` as a valid config option on `multiball_locks:` devices, so that they can catch blocking events and avoid locking balls when desired.

_TO DO: I'll get a better understanding of it and write some documentation for blocking facility_
