### PR TITLE
Service list custom values for list_coils etc

### DIFF
--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -131,17 +131,19 @@ class BcpInterface(MpfController):
         elif subcommand == "stop":
             await self._service_stop(client)
         elif subcommand == "list_switches":
+            values = kwargs.get("values") and kwargs["values"].split(",")
             self.machine.bcp.transport.send_to_client(client, "list_switches",
-                                                      switches=[(s[0], str(s[1].hw_switch.number), s[1].name,
-                                                                 s[1].state)
+                                                      switches=[self._switch_body(s[0], s[1], values)
                                                                 for s in self.machine.service.get_switch_map()])
         elif subcommand == "list_coils":
+            values = kwargs.get("values") and kwargs["values"].split(",")
             self.machine.bcp.transport.send_to_client(client, "list_coils",
-                                                      coils=[(s[0], str(s[1].hw_driver.number), s[1].name) for s in
+                                                      coils=[self._coil_body(s[0], s[1], values) for s in
                                                              self.machine.service.get_coil_map()])
         elif subcommand == "list_lights":
+            values = kwargs.get("values") and kwargs["values"].split(",")
             self.machine.bcp.transport.send_to_client(client, "list_lights",
-                                                      lights=[(s[0], s[1].get_hw_numbers(), s[1].name, s[1].get_color())
+                                                      lights=[self._light_body(s[0], s[1], values)
                                                               for s in self.machine.service.get_light_map()])
         elif subcommand == "list_shows":
             self.machine.bcp.transport.send_to_client(client, "list_shows",
@@ -229,6 +231,47 @@ class BcpInterface(MpfController):
             return
 
         self.machine.bcp.transport.send_to_client(client, "coil_enable", error=False)
+
+    @staticmethod
+    def _coil_body(board, coil, values):
+        if not values:
+            return (board, str(coil.hw_driver.number), coil.name)
+
+        c = {
+            "board": board,
+            "name": coil.name,
+            "label": coil.label,
+            "number": coil.hw_driver.number
+        }
+        return tuple(c[value] for value in values)
+
+    @staticmethod
+    def _light_body(board, light, values):
+        if not values:
+            return (board, light.get_hw_numbers(), light.name, light.get_color(), light.label)
+
+        l = {
+            "board": board,
+            "color": light.get_color(),
+            "label": light.label,
+            "name": light.name,
+            "number": light.get_hw_numbers(),
+        }
+        return tuple(l[value] for value in values)
+
+    @staticmethod
+    def _switch_body(board, switch, values):
+        if not values:
+            return (board, str(switch.hw_switch.number), switch.name, switch.state)
+
+        s = {
+            "board": board,
+            "label": switch.label,
+            "name": switch.name,
+            "number": switch.hw_switch.number,
+            "state": switch.state
+        }
+        return tuple(s[value] for value in values)
 
     def _light_color(self, client, light_name, color_name):
         try:

--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -248,7 +248,7 @@ class BcpInterface(MpfController):
     @staticmethod
     def _light_body(board, light, values):
         if not values:
-            return (board, light.get_hw_numbers(), light.name, light.get_color(), light.label)
+            return (board, light.get_hw_numbers(), light.name, light.get_color())
 
         light_values = {
             "board": board,

--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -133,8 +133,8 @@ class BcpInterface(MpfController):
         elif subcommand == "list_switches":
             values = kwargs.get("values") and kwargs["values"].split(",")
             self.machine.bcp.transport.send_to_client(client, "list_switches",
-                                                      switches=[self._switch_body(s[0], s[1], values)
-                                                                for s in self.machine.service.get_switch_map()])
+                                                      switches=[self._switch_body(s[0], s[1], values) for s in
+                                                                self.machine.service.get_switch_map()])
         elif subcommand == "list_coils":
             values = kwargs.get("values") and kwargs["values"].split(",")
             self.machine.bcp.transport.send_to_client(client, "list_coils",
@@ -237,41 +237,41 @@ class BcpInterface(MpfController):
         if not values:
             return (board, str(coil.hw_driver.number), coil.name)
 
-        c = {
+        coil_values = {
             "board": board,
             "name": coil.name,
             "label": coil.label,
             "number": coil.hw_driver.number
         }
-        return tuple(c[value] for value in values)
+        return tuple(coil_values[value] for value in values)
 
     @staticmethod
     def _light_body(board, light, values):
         if not values:
             return (board, light.get_hw_numbers(), light.name, light.get_color(), light.label)
 
-        l = {
+        light_values = {
             "board": board,
             "color": light.get_color(),
             "label": light.label,
             "name": light.name,
             "number": light.get_hw_numbers(),
         }
-        return tuple(l[value] for value in values)
+        return tuple(light_values[value] for value in values)
 
     @staticmethod
     def _switch_body(board, switch, values):
         if not values:
             return (board, str(switch.hw_switch.number), switch.name, switch.state)
 
-        s = {
+        switch_values = {
             "board": board,
             "label": switch.label,
             "name": switch.name,
-            "number": switch.hw_switch.number,
+            "number": str(switch.hw_switch.number),
             "state": switch.state
         }
-        return tuple(s[value] for value in values)
+        return tuple([switch_values[value] for value in values])
 
     def _light_color(self, client, light_name, color_name):
         try:

--- a/mpf/tests/machine_files/bcp/config/config.yaml
+++ b/mpf/tests/machine_files/bcp/config/config.yaml
@@ -6,27 +6,38 @@ modes:
 
 switches:
     s_test:
-        number:
+        number: 1000
     s_test2:
-        number:
+        number: 1001
     s_start:
-        number:
+        number: 1002
         tags: start
     s_ball_switch1:
-        number:
+        number: 1003
+        label: Ball One
     s_ball_switch2:
-        number:
+        number: 1004
+        label: Ball Two
     s_ball_switch_launcher:
-        number:
+        number: 1005
+        label: Launcher
 
 game:
     balls_per_game: 3
 
 coils:
     eject_coil1:
-        number:
+        number: 1000
     eject_coil2:
-        number:
+        number: 1001
+
+lights:
+    l_test:
+        number: 1000
+        label: Light One
+    l_test2:
+        number: 1001
+        label: Other Light
 
 playfields:
     playfield:

--- a/mpf/tests/test_BcpInterface.py
+++ b/mpf/tests/test_BcpInterface.py
@@ -481,10 +481,8 @@ class TestBcpInterface(MpfBcpTestCase):
         self.assertListEqual(
             [
                 ('list_lights', {'lights': [
-                    ('Virtual', ['led-1000-b', 'led-1000-g', 'led-1000-r'], 'l_test',
-                        "000000", 'Light One'),
-                    ('Virtual', ['led-1001-b', 'led-1001-g', 'led-1001-r'], 'l_test2',
-                        "000000", 'Other Light'),
+                    ('Virtual', ['led-1000-b', 'led-1000-g', 'led-1000-r'], 'l_test', '000000'),
+                    ('Virtual', ['led-1001-b', 'led-1001-g', 'led-1001-r'], 'l_test2', '000000'),
                 ]}),
             ],
             queue)

--- a/mpf/tests/test_BcpInterface.py
+++ b/mpf/tests/test_BcpInterface.py
@@ -451,7 +451,7 @@ class TestBcpInterface(MpfBcpTestCase):
         self.assertEqual(1, len(queue))
         self.assertListEqual(
             [
-                ('list_coils', {'coils': [('Virtual', '1000', 'eject_coil2'), ('Virtual', '1001', 'eject_coil1')]})
+                ('list_coils', {'coils': [('Virtual', '1000', 'eject_coil1'), ('Virtual', '1001', 'eject_coil2')]})
             ],
             queue)
 
@@ -462,6 +462,81 @@ class TestBcpInterface(MpfBcpTestCase):
         self.assertEqual(1, len(queue))
         self.assertListEqual(
             [
-                ('list_coils', {'coils': [('eject_coil2', '1000'),('eject_coil1', '1001')]})
+                ('list_coils', {'coils': [('eject_coil1', '1000'),('eject_coil2', '1001')]})
+            ],
+            queue)
+
+    def test_list_lights(self):
+        self.assertIn('mode1', self.machine.modes)
+        self.assertIn('mode2', self.machine.modes)
+
+        self._bcp_external_client.reset_and_return_queue()
+
+        # register monitor
+        self._bcp_external_client.send('service', { 'subcommand': 'list_lights'}) #, {'category': 'modes'})
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_lights', {'lights': [
+                    ('Virtual', ['led-1000-b', 'led-1000-g', 'led-1000-r'], 'l_test',
+                        "000000", 'Light One'),
+                    ('Virtual', ['led-1001-b', 'led-1001-g', 'led-1001-r'], 'l_test2',
+                        "000000", 'Other Light'),
+                ]}),
+            ],
+            queue)
+
+        self._bcp_external_client.send('service', { 'subcommand': 'list_lights', 'values': 'name,label'})
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_lights', {'lights': [('l_test', 'Light One'), ('l_test2', 'Other Light')]})
+            ],
+            queue)
+
+
+    def test_list_switches(self):
+        self.assertIn('mode1', self.machine.modes)
+        self.assertIn('mode2', self.machine.modes)
+
+        self._bcp_external_client.reset_and_return_queue()
+
+        # register monitor
+        self._bcp_external_client.send('service', { 'subcommand': 'list_switches'}) #, {'category': 'modes'})
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_switches', {'switches': [
+                    ('Virtual', '1000', 's_test', 0),
+                    ('Virtual', '1001', 's_test2', 0),
+                    ('Virtual', '1002', 's_start', 0),
+                    ('Virtual', '1003', 's_ball_switch1', 0),
+                    ('Virtual', '1004', 's_ball_switch2', 0),
+                    ('Virtual', '1005', 's_ball_switch_launcher', 0),
+                ]}),
+            ],
+            queue)
+
+        self._bcp_external_client.send('service', { 'subcommand': 'list_switches', 'values': 'number,label'})
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_switches', {'switches': [
+                    ('1000','%'),('1001','%'),('1002','%'),
+                    ('1003','Ball One'), ('1004', 'Ball Two'),
+                    ('1005', 'Launcher')
+                ]})
             ],
             queue)

--- a/mpf/tests/test_BcpInterface.py
+++ b/mpf/tests/test_BcpInterface.py
@@ -436,3 +436,32 @@ class TestBcpInterface(MpfBcpTestCase):
         self.advance_time_and_run()
         queue = self._bcp_external_client.reset_and_return_queue()
         self.assertFalse(queue)
+
+    def test_list_coils(self):
+        self.assertIn('mode1', self.machine.modes)
+        self.assertIn('mode2', self.machine.modes)
+
+        self._bcp_external_client.reset_and_return_queue()
+
+        # register monitor
+        self._bcp_external_client.send('service', { 'subcommand': 'list_coils'}) #, {'category': 'modes'})
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_coils', {'coils': [('Virtual', '1000', 'eject_coil2'), ('Virtual', '1001', 'eject_coil1')]})
+            ],
+            queue)
+
+        self._bcp_external_client.send('service', { 'subcommand': 'list_coils', 'values': 'name,number'})
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_coils', {'coils': [('eject_coil2', '1000'),('eject_coil1', '1001')]})
+            ],
+            queue)


### PR DESCRIPTION
### Parameter Values for Service Lists
This PR adds an optional `values` parameter when requesting `list_coils`, `list_lights`, and `list_switches`. The parameter allows a BCP client to specify which device properties it needs included in the list (and in a predictable order), so that Service modes can display a full list of devices without unnecessary detail.

If no `values` kwarg is supplied, the response payload uses the existing values as default, so this change is fully backward compatible.
