### PR TITLE
Production bundles: new options for MC and target machine path

### DIFF
--- a/mpf/commands/build.py
+++ b/mpf/commands/build.py
@@ -36,6 +36,10 @@ class Command(MpfCommandLineParser):
                                  "via a comma-"
                                  "separated list (no spaces between)")
 
+        parser.add_argument("-b",
+                            action="store_false", dest="mc", default=True,
+                            help="Builds a production config for MPF only, without MC.")
+
         self.args = parser.parse_args(remaining_args)
         self.args.configfile = Util.string_to_event_list(self.args.configfile)
 
@@ -46,8 +50,10 @@ class Command(MpfCommandLineParser):
         """Create a production bundle."""
         config_loader = YamlMultifileConfigLoader(self.machine_path, self.args.configfile, False, False)
         mpf_config = config_loader.load_mpf_config()
-        mc_config = config_loader.load_mc_config()
+        if self.args.mc:
+            mc_config = config_loader.load_mc_config()
 
         pickle.dump(mpf_config, open(ProductionConfigLoader.get_mpf_bundle_path(self.machine_path), "wb"))
-        pickle.dump(mc_config, open(ProductionConfigLoader.get_mpf_mc_bundle_path(self.machine_path), "wb"))
+        if self.args.mc:
+            pickle.dump(mc_config, open(ProductionConfigLoader.get_mpf_mc_bundle_path(self.machine_path), "wb"))
         print("Success.")

--- a/mpf/commands/build.py
+++ b/mpf/commands/build.py
@@ -40,6 +40,11 @@ class Command(MpfCommandLineParser):
                             action="store_false", dest="mc", default=True,
                             help="Builds a production config for MPF only, without MC.")
 
+        parser.add_argument("--dest-path",
+                            action="store", dest="dest_path", default=False,
+                            help="Path to set as machine_path on the production bundle. May "
+                                "be different than the machine_path on the current machine.")
+
         self.args = parser.parse_args(remaining_args)
         self.args.configfile = Util.string_to_event_list(self.args.configfile)
 
@@ -52,6 +57,9 @@ class Command(MpfCommandLineParser):
         mpf_config = config_loader.load_mpf_config()
         if self.args.mc:
             mc_config = config_loader.load_mc_config()
+
+        if self.args.dest_path:
+            mpf_config.set_machine_path(self.args.dest_path)
 
         pickle.dump(mpf_config, open(ProductionConfigLoader.get_mpf_bundle_path(self.machine_path), "wb"))
         if self.args.mc:

--- a/mpf/commands/build.py
+++ b/mpf/commands/build.py
@@ -43,7 +43,7 @@ class Command(MpfCommandLineParser):
         parser.add_argument("--dest-path",
                             action="store", dest="dest_path", default=False,
                             help="Path to set as machine_path on the production bundle. May "
-                                "be different than the machine_path on the current machine.")
+                                 "be different than the machine_path on the current machine.")
 
         self.args = parser.parse_args(remaining_args)
         self.args.configfile = Util.string_to_event_list(self.args.configfile)

--- a/mpf/core/config_loader.py
+++ b/mpf/core/config_loader.py
@@ -36,6 +36,10 @@ class MpfConfig:
         """Return machine path."""
         return self._machine_path
 
+    def set_machine_path(self, value):
+        """Set a new machine path."""
+        self._machine_path = value
+
     def get_config_spec(self):
         """Return config spec."""
         return self._config_spec


### PR DESCRIPTION
This PR makes three additions to the fabulous production bundle behavior.

### Production bundle building without MC
This PR adds support for the argument `-b` when running `mpf build production_bundle`, which builds an MPF bundle only. The `-b` arg was chosen because that's the argument used to run MPF without connecting to a BCP host—effectively, how you run MPF without an MC.

### Explicit machine paths for production bundles
A side-effect of how the production bundles are built—loading all the config files and pickling them—is that the bundle is saved with the `machine_path` of the machine that generated the bundle. This causes trouble when trying to distribute a bundle to other machines with different file structures. This PR adds a new command argument `--dest-path=<machine_path>` which will generate the config data and then overwrite the `machine_path` with the explicitly-provided path.

The machine path is a private variable, so this PR also adds a method `set_machine_path(pathname)` to the config loader.

### Running production bundles without _/config_
This PR adds support for running an MPF machine from a production bundle without any other file structure requirements. Currently, MPF will always check for a machine folder by looking for the _/config_ folder. When running production bundles this folder is not used, so this PR makes it not required.