### PR TITLE
Add 'set_tick_interval' control event for Timers, with event kwargs

### DIFF
--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -157,9 +157,13 @@ class Timer(ModeDevice):
                 handler = self.change_tick_interval
                 kwargs = {'change': entry['value']}
 
+            elif entry['action'] == 'set_tick_interval':
+                handler = self.set_tick_interval
+                kwargs = {'timer_value': entry['value']}
+
             elif entry['action'] == 'reset_tick_interval':
                 handler = self.set_tick_interval
-                kwargs = {'timer_value': self.config['tick_interval'].evaluate([])}
+                kwargs = {'timer_value': self.config['tick_interval']}
 
             else:
                 raise AssertionError("Invalid control_event action {} in mode".
@@ -557,9 +561,8 @@ class Timer(ModeDevice):
                 often registered as an event handler which may contain
                 additional keyword arguments.
         """
-        del kwargs
 
-        self.tick_secs = abs(self._get_timer_value(timer_value))
+        self.tick_secs = abs(self._get_timer_value(timer_value.evaluate(kwargs)))
         self._create_system_timer()
 
     def jump(self, timer_value, **kwargs):

--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -561,7 +561,6 @@ class Timer(ModeDevice):
                 often registered as an event handler which may contain
                 additional keyword arguments.
         """
-
         self.tick_secs = abs(self._get_timer_value(timer_value.evaluate(kwargs)))
         self._create_system_timer()
 

--- a/mpf/tests/machine_files/timer/modes/mode_with_timers/config/mode_with_timers.yaml
+++ b/mpf/tests/machine_files/timer/modes/mode_with_timers/config/mode_with_timers.yaml
@@ -95,3 +95,9 @@ timers:
           - event: timer_change_tick_event
             action: change_tick_interval
             value: 0.1
+          - event: timer_set_tick_event_fixed
+            action: set_tick_interval
+            value: 0.2
+          - event: timer_set_tick_event_kwarg
+            action: set_tick_interval
+            value: event_value

--- a/mpf/tests/test_Timer.py
+++ b/mpf/tests/test_Timer.py
@@ -153,6 +153,38 @@ class TestTimer(MpfFakeGameTestCase):
         self.advance_time_and_run(1)
         self.assertEventCalled("timer_timer_change_tick_tick", 12)
 
+    def test_set_tick_fixed(self):
+        self.start_mode("mode_with_timers")
+        self.mock_event("timer_timer_change_tick_tick")
+        self.advance_time_and_run()
+        self.post_event("timer_change_tick_start")
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 1)
+        self.advance_time_and_run(1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 2)
+        self.post_event("timer_set_tick_event_fixed")
+        self.assertEventCalled("timer_timer_change_tick_tick", 2)
+        self.advance_time_and_run(1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 7)
+
+    def test_set_tick_kwarg(self):
+        self.start_mode("mode_with_timers")
+        self.mock_event("timer_timer_change_tick_tick")
+        self.advance_time_and_run()
+        self.post_event("timer_change_tick_start")
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 1)
+        self.advance_time_and_run(1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 2)
+        self.post_event_with_params("timer_set_tick_event_kwarg", event_value=0.1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 2)
+        self.advance_time_and_run(1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 12)
+        self.post_event_with_params("timer_set_tick_event_kwarg", event_value=0.2)
+        self.assertEventCalled("timer_timer_change_tick_tick", 12)
+        self.advance_time_and_run(1)
+        self.assertEventCalled("timer_timer_change_tick_tick", 17)
+
     def test_start_running(self):
         # add a fake player
         self.start_game()


### PR DESCRIPTION
This PR adds a new control event to the Timer device, `set_tick_interval`. It differs from the existing `change_tick_interval` because it uses absolute values instead of relative, and it leverages the existing `def set_tick_interval(self):` method that the Timer has (currently used only by the `reset_tick_interval` event).

The new control event also supports kwarg placeholders, so the triggering event can specify a new absolute tick interval and the timer will switch to that interval. Yay!