### PR TITLE
handle autofire hw rules in a switch matrix

### DIFF
--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -1054,7 +1054,8 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         _, _, coil_num = driver.number.split('-')
 
         # mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
-        switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
+        if switch_num >= 32:
+            switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
 
         msg = bytearray()
         msg.append(driver.sol_card.addr)
@@ -1076,7 +1077,8 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         _, _, coil_num = driver.number.split('-')
 
         # mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
-        switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
+        if switch_num >= 32:
+            switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
 
         msg = bytearray()
         msg.append(driver.sol_card.addr)

--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -1053,7 +1053,7 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
 
         _, _, coil_num = driver.number.split('-')
         
-        #mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
+        # mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
         switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
         
         msg = bytearray()
@@ -1075,7 +1075,7 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
             return
         _, _, coil_num = driver.number.split('-')
         
-        #mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
+        # mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
         switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
         
         msg = bytearray()

--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -1052,10 +1052,10 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
             return
 
         _, _, coil_num = driver.number.split('-')
-        
+
         # mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
         switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
-        
+
         msg = bytearray()
         msg.append(driver.sol_card.addr)
         msg.extend(OppRs232Intf.SET_SOL_INP_CMD)
@@ -1074,10 +1074,10 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         if self.min_version[driver.sol_card.chain_serial] < 0x20000:
             return
         _, _, coil_num = driver.number.split('-')
-        
+
         # mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
         switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
-        
+
         msg = bytearray()
         msg.append(driver.sol_card.addr)
         msg.extend(OppRs232Intf.SET_SOL_INP_CMD)

--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -1052,6 +1052,10 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
             return
 
         _, _, coil_num = driver.number.split('-')
+        
+        #mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
+        switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
+        
         msg = bytearray()
         msg.append(driver.sol_card.addr)
         msg.extend(OppRs232Intf.SET_SOL_INP_CMD)
@@ -1070,6 +1074,10 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         if self.min_version[driver.sol_card.chain_serial] < 0x20000:
             return
         _, _, coil_num = driver.number.split('-')
+        
+        #mirror switch matrix columns to handle the fact that OPP matrix is in reverse column order
+        switch_num = 8 * (15 - (switch_num // 8)) + switch_num % 8
+        
         msg = bytearray()
         msg.append(driver.sol_card.addr)
         msg.extend(OppRs232Intf.SET_SOL_INP_CMD)


### PR DESCRIPTION
matrix switch based hw rules need to have the matrix columns mirrored since opp has reverse column order