### PR TITLE
Service mode_setting to prevent device list sorting

### DIFF
--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -132,19 +132,22 @@ class BcpInterface(MpfController):
             await self._service_stop(client)
         elif subcommand == "list_switches":
             values = kwargs.get("values") and kwargs["values"].split(",")
+            do_sort = kwargs.get("sort")
             self.machine.bcp.transport.send_to_client(client, "list_switches",
                                                       switches=[self._switch_body(s[0], s[1], values) for s in
-                                                                self.machine.service.get_switch_map()])
+                                                                self.machine.service.get_switch_map(do_sort)])
         elif subcommand == "list_coils":
             values = kwargs.get("values") and kwargs["values"].split(",")
+            do_sort = kwargs.get("sort")
             self.machine.bcp.transport.send_to_client(client, "list_coils",
                                                       coils=[self._coil_body(s[0], s[1], values) for s in
-                                                             self.machine.service.get_coil_map()])
+                                                             self.machine.service.get_coil_map(do_sort)])
         elif subcommand == "list_lights":
             values = kwargs.get("values") and kwargs["values"].split(",")
+            do_sort = kwargs.get("sort")
             self.machine.bcp.transport.send_to_client(client, "list_lights",
                                                       lights=[self._light_body(s[0], s[1], values)
-                                                              for s in self.machine.service.get_light_map()])
+                                                              for s in self.machine.service.get_light_map(do_sort)])
         elif subcommand == "list_shows":
             self.machine.bcp.transport.send_to_client(client, "list_shows",
                                                       shows=[(s.name, sorted(s.tokens))

--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -132,19 +132,19 @@ class BcpInterface(MpfController):
             await self._service_stop(client)
         elif subcommand == "list_switches":
             values = kwargs.get("values") and kwargs["values"].split(",")
-            do_sort = kwargs.get("sort")
+            do_sort = kwargs.get("sort", True)
             self.machine.bcp.transport.send_to_client(client, "list_switches",
                                                       switches=[self._switch_body(s[0], s[1], values) for s in
                                                                 self.machine.service.get_switch_map(do_sort)])
         elif subcommand == "list_coils":
             values = kwargs.get("values") and kwargs["values"].split(",")
-            do_sort = kwargs.get("sort")
+            do_sort = kwargs.get("sort", True)
             self.machine.bcp.transport.send_to_client(client, "list_coils",
                                                       coils=[self._coil_body(s[0], s[1], values) for s in
                                                              self.machine.service.get_coil_map(do_sort)])
         elif subcommand == "list_lights":
             values = kwargs.get("values") and kwargs["values"].split(",")
-            do_sort = kwargs.get("sort")
+            do_sort = kwargs.get("sort", True)
             self.machine.bcp.transport.send_to_client(client, "list_lights",
                                                       lights=[self._light_body(s[0], s[1], values)
                                                               for s in self.machine.service.get_light_map(do_sort)])

--- a/mpf/core/service_controller.py
+++ b/mpf/core/service_controller.py
@@ -77,18 +77,19 @@ class ServiceController(MpfController):
         del issue
         # this is prepared but not yet implemented in service mode
 
-    def get_switch_map(self):
+    def get_switch_map(self, do_sort=True):
         """Return a map of all switches in the machine."""
         switch_map = []
         for switch in self.machine.switches.values():
             switch_map.append(SwitchMap(switch.hw_switch.get_board_name(), switch))
 
         # sort by board + driver number
-        switch_map.sort(key=lambda x: (self._natural_key_sort(x[0]),
-                                       self._natural_key_sort(str(x[1].hw_switch.number))))
+        if do_sort:
+            switch_map.sort(key=lambda x: (self._natural_key_sort(x[0]),
+                                           self._natural_key_sort(str(x[1].hw_switch.number))))
         return switch_map
 
-    def get_coil_map(self) -> List[CoilMap]:
+    def get_coil_map(self, do_sort=True) -> List[CoilMap]:
         """Return a map of all coils in the machine."""
         coil_map = []
         for coil in self.machine.coils.values():
@@ -96,15 +97,19 @@ class ServiceController(MpfController):
             coil_map.append(CoilMap(coil.hw_driver.get_board_name(), coil))
 
         # sort by board + driver number
-        coil_map.sort(key=lambda x: (self._natural_key_sort(x[0]), self._natural_key_sort(str(x[1].hw_driver.number))))
+        if do_sort:
+            coil_map.sort(key=lambda x: (self._natural_key_sort(x[0]),
+                                         self._natural_key_sort(str(x[1].hw_driver.number))))
         return coil_map
 
-    def get_light_map(self) -> List[LightMap]:
+    def get_light_map(self, do_sort=True) -> List[LightMap]:
         """Return a map of all lights in the machine."""
         light_map = []
         for light in self.machine.lights.values():
             light_map.append(LightMap(next(iter(light.hw_drivers.values()))[0].get_board_name(), light))
 
         # sort by board + driver number
-        light_map.sort(key=lambda x: (self._natural_key_sort(x[0]), self._natural_key_sort(str(x[1].config['number']))))
+        if do_sort:
+            light_map.sort(key=lambda x: (self._natural_key_sort(x[0]),
+                                          self._natural_key_sort(str(x[1].config['number']))))
         return light_map

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -17,12 +17,13 @@ class Service(AsyncMode):
 
     """The service mode."""
 
-    __slots__ = ["_update_script"]
+    __slots__ = ["_update_script", "_do_sort"]
 
     def __init__(self, *args, **kwargs):
         """Initialize service mode."""
         super().__init__(*args, **kwargs)
         self._update_script = None
+        self._do_sort = self.config.get('mode_settings', {}).get('sort_devices_by_number', True)
 
     @staticmethod
     def get_config_spec():
@@ -38,6 +39,7 @@ up_events: list|str|sw_service_up_active
 down_events: list|str|sw_service_down_active
 software_update: single|bool|False
 software_update_script: single|str|None
+sort_devices_by_number: single|bool|True
 '''
 
     async def _service_mode_exit(self):
@@ -355,7 +357,7 @@ software_update_script: single|str|None
 
     async def _coil_test_menu(self):
         position = 0
-        items = self.machine.service.get_coil_map()
+        items = self.machine.service.get_coil_map(do_sort=self._do_sort)
 
         # do not crash if no coils are configured
         if not items:   # pragma: no cover
@@ -397,7 +399,7 @@ software_update_script: single|str|None
         position = 0
         color_position = 0
         colors = ["white", "red", "green", "blue", "yellow"]
-        items = self.machine.service.get_light_map()
+        items = self.machine.service.get_light_map(do_sort=self._do_sort)
 
         # do not crash if no lights are configured
         if not items:   # pragma: no cover

--- a/mpf/tests/machine_files/bcp/config/config.yaml
+++ b/mpf/tests/machine_files/bcp/config/config.yaml
@@ -5,39 +5,39 @@ modes:
   - mode2
 
 switches:
+    s_start:
+        number: 1002
+        tags: start
     s_test:
         number: 1000
     s_test2:
         number: 1001
-    s_start:
-        number: 1002
-        tags: start
+    s_ball_switch_launcher:
+        number: 1005
+        label: Launcher
     s_ball_switch1:
         number: 1003
         label: Ball One
     s_ball_switch2:
         number: 1004
         label: Ball Two
-    s_ball_switch_launcher:
-        number: 1005
-        label: Launcher
 
 game:
     balls_per_game: 3
 
 coils:
-    eject_coil1:
-        number: 1000
     eject_coil2:
         number: 1001
+    eject_coil1:
+        number: 1000
 
 lights:
-    l_test:
-        number: 1000
-        label: Light One
     l_test2:
         number: 1001
         label: Other Light
+    l_test:
+        number: 1000
+        label: Light One
 
 playfields:
     playfield:

--- a/mpf/tests/test_BcpInterface.py
+++ b/mpf/tests/test_BcpInterface.py
@@ -466,6 +466,17 @@ class TestBcpInterface(MpfBcpTestCase):
             ],
             queue)
 
+        self._bcp_external_client.send('service', { 'subcommand': 'list_coils', 'sort': False })
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_coils', {'coils': [('Virtual', '1001', 'eject_coil2'), ('Virtual', '1000', 'eject_coil1')]})
+            ],
+            queue)
+
     def test_list_lights(self):
         self.assertIn('mode1', self.machine.modes)
         self.assertIn('mode2', self.machine.modes)
@@ -495,6 +506,20 @@ class TestBcpInterface(MpfBcpTestCase):
         self.assertListEqual(
             [
                 ('list_lights', {'lights': [('l_test', 'Light One'), ('l_test2', 'Other Light')]})
+            ],
+            queue)
+
+        self._bcp_external_client.send('service', { 'subcommand': 'list_lights', 'sort': False })
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_lights', {'lights': [
+                    ('Virtual', ['led-1001-b', 'led-1001-g', 'led-1001-r'], 'l_test2', '000000'),
+                    ('Virtual', ['led-1000-b', 'led-1000-g', 'led-1000-r'], 'l_test', '000000'),
+                ]}),
             ],
             queue)
 
@@ -536,5 +561,23 @@ class TestBcpInterface(MpfBcpTestCase):
                     ('1003','Ball One'), ('1004', 'Ball Two'),
                     ('1005', 'Launcher')
                 ]})
+            ],
+            queue)
+
+        self._bcp_external_client.send('service', { 'subcommand': 'list_switches', 'sort': False})
+        self.advance_time_and_run()
+
+        queue = self._bcp_external_client.reset_and_return_queue()
+        self.assertEqual(1, len(queue))
+        self.assertListEqual(
+            [
+                ('list_switches', {'switches': [
+                    ('Virtual', '1002', 's_start', 0),
+                    ('Virtual', '1000', 's_test', 0),
+                    ('Virtual', '1001', 's_test2', 0),
+                    ('Virtual', '1005', 's_ball_switch_launcher', 0),
+                    ('Virtual', '1003', 's_ball_switch1', 0),
+                    ('Virtual', '1004', 's_ball_switch2', 0),
+                ]}),
             ],
             queue)


### PR DESCRIPTION
This PR adds a new `mode_settings:` option to the Service mode to choose between sorting device lists by their hardware number (default, current behavior) or preserving the order listed in the config files.

When the mode setting `sort_devices_by_number` is `false`, devices listed will preserve the config file order. This applies both to the iteration through devices in the utilities menu (coil test and light test) as well as the list returned to BCP clients using the `list_coils`, `list_switches` and `list_lights` commands.

By default the sort setting is true, so this change causes no regressions for existing machines that do not specify a value.