### PR TITLE
Support for FAST pulse-with-hold, set one-shot bit on pulse commands

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -298,6 +298,8 @@ coils:
     default_pulse_ms: single|template_ms|None
     default_pulse_power: single|float(0,1)|None
     default_hold_power: single|float(0,1)|None
+    pulse_hold_power: single|float|None
+    pulse_hold_ms: single|ms|None
     max_pulse_ms: single|ms|None
     max_pulse_power: single|float(0,1)|1.0
     max_hold_power: single|float(0,1)|None
@@ -342,8 +344,6 @@ opp_coils:
 fast_coils:
     connection: single|enum(network,local,auto)|auto
     recycle_ms: single|ms|None
-    pulse_hold_power: single|float|None
-    pulse_hold_ms: single|ms|None
     hold_pwm_patter: single|str|None
 pkone_coils:
     recycle_ms: single|ms|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -342,6 +342,8 @@ opp_coils:
 fast_coils:
     connection: single|enum(network,local,auto)|auto
     recycle_ms: single|ms|None
+    pulse_hold_power: single|float|None
+    pulse_hold_ms: single|ms|None
     hold_pwm_patter: single|str|None
 pkone_coils:
     recycle_ms: single|ms|None

--- a/mpf/core/platform.py
+++ b/mpf/core/platform.py
@@ -500,7 +500,8 @@ class SwitchPlatform(BasePlatform, metaclass=abc.ABCMeta):
 SwitchSettings = namedtuple("SwitchSettings", ["hw_switch", "invert", "debounce"])
 DriverSettings = namedtuple("DriverSettings", ["hw_driver", "pulse_settings", "hold_settings", "recycle"])
 DriverConfig = namedtuple("DriverConfig", ["name", "default_pulse_ms", "default_pulse_power", "default_hold_power",
-                                           "default_recycle", "max_pulse_ms", "max_pulse_power", "max_hold_power"])
+                                           "default_recycle", "max_pulse_ms", "max_pulse_power", "max_hold_power",
+                                           "pulse_hold_ms", "pulse_hold_power"])
 RepulseSettings = namedtuple("RepulseSettings", ["enable_repulse", "debounce_ms"])
 
 

--- a/mpf/devices/digital_output.py
+++ b/mpf/devices/digital_output.py
@@ -103,7 +103,9 @@ class DigitalOutput(SystemWideDevice):
             default_recycle=False,
             max_pulse_ms=255,
             max_pulse_power=1.0,
-            max_hold_power=1.0)
+            max_hold_power=1.0,
+            pulse_hold_power=None,
+            pulse_hold_ms=None)
 
         if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:
             self.raise_config_error("Digital Output must have a number.", 2)

--- a/mpf/devices/driver.py
+++ b/mpf/devices/driver.py
@@ -97,7 +97,9 @@ class Driver(SystemWideDevice):
             default_recycle=self.config['default_recycle'],
             max_pulse_ms=self.config['max_pulse_ms'],
             max_pulse_power=self.config['max_pulse_power'],
-            max_hold_power=self.config['max_hold_power'])
+            max_hold_power=self.config['max_hold_power'],
+            pulse_hold_power=self.config['pulse_hold_power'],
+            pulse_hold_ms=self.config['pulse_hold_ms'])
         platform_settings = dict(self.config['platform_settings']) if self.config['platform_settings'] else dict()
 
         if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:

--- a/mpf/platforms/fast/fast_driver.py
+++ b/mpf/platforms/fast/fast_driver.py
@@ -181,9 +181,9 @@ class FASTDriver(DriverPlatformInterface):
             self._autofire_cleared = True
 
             # Some coils need an initial pulse + a hold in order to effectively "pulse"
-            if self.platform_settings.get("pulse_hold_power"):
-                hold_power = self.get_hold_pwm_for_cmd(self.platform_settings['pulse_hold_power'])
-                hold_ms = Util.int_to_hex_string(self.platform_settings['pulse_hold_ms'])
+            if self.config.pulse_hold_power is not None:
+                hold_power = self.get_hold_pwm_for_cmd(self.config.pulse_hold_power)
+                hold_ms = Util.int_to_hex_string(self.config.pulse_hold_ms)
             else:
                 hold_power = '00'
                 hold_ms = '00'

--- a/mpf/tests/machine_files/fast/config/config.yaml
+++ b/mpf/tests/machine_files/fast/config/config.yaml
@@ -78,6 +78,12 @@ coils:
         number: 18
         default_pulse_ms: 2000
         max_hold_power: 1.0
+    c_pulse_and_hold:
+        number: 22
+        default_pulse_ms: 20
+        platform_settings:
+            pulse_hold_power: 0.25
+            pulse_hold_ms: 200
     c_flipper_main:
         number: 32
         default_pulse_ms: 10

--- a/mpf/tests/machine_files/fast/config/config.yaml
+++ b/mpf/tests/machine_files/fast/config/config.yaml
@@ -81,9 +81,8 @@ coils:
     c_pulse_and_hold:
         number: 22
         default_pulse_ms: 20
-        platform_settings:
-            pulse_hold_power: 0.25
-            pulse_hold_ms: 200
+        pulse_hold_power: 0.25
+        pulse_hold_ms: 200
     c_flipper_main:
         number: 32
         default_pulse_ms: 10


### PR DESCRIPTION
This PR makes improvements to the driver `pulse()` command for FAST hardware. Includes a test!

### Pulse with hold
This PR adds two platform settings to FAST drivers: `pulse_hold_power` and `pulse_hold_ms`. When provided, these parameters are added to the hardware pulse command. FAST hardware supports a two-phase pulse action, with an initial pulse at PWM1 and a hold at PWM2. Using the hardware commands for this behavior is safer and more time-accurate than a pulse-and-enable followed by a software delay and disable.

### One-shot bit on pulse
This PR changes the pulse command from `81` to `89`. In FAST driver commands the `1 << 3` bit indicates to "one-shot" the driver after the configuration is written. This allows the configuration and pulse to be sent in a single command, which eliminates the need for a subsequent `TN:NN,01` command (which adds network traffic and can sometimes be missed by the hardware).

As a result, the pulse method is updated to send *either* the pulse-and-one-shot command *or* the manual trigger command, not both.

![Here we go!](https://media.giphy.com/media/l1AsFvnN3p9y7xIqs/giphy-downsized.gif)