### PR TITLE
Add check in RGBColor constructor to account for integer colors

### DIFF
--- a/mpf/core/rgb_color.py
+++ b/mpf/core/rgb_color.py
@@ -169,14 +169,18 @@ class RGBColor:
 
     __slots__ = ["_color"]
 
-    def __init__(self, color: Union["RGBColor", str, int, List[int], Tuple[int, int, int]] = None) -> None:
+    def __init__(self, color: Union["RGBColor", str, List[int], Tuple[int, int, int]] = None) -> None:
         """Initialise color."""
         if isinstance(color, RGBColor):
             self._color = color.rgb
         elif isinstance(color, str):
             self._color = RGBColor.string_to_rgb(color)
         elif isinstance(color, int):
-            self._color = RGBColor.string_to_rgb(str(color))
+            raise TypeError("Invalid integer RGB color value provided: " +
+                            "{}".format(color) + ". If you are trying " +
+                            "to specify an RGB hex value then it must be " +
+                            "wrapped in quotation marks in your config: " +
+                            '"{}"'.format(color))
         elif color:
             self._color = (color[0], color[1], color[2])
         else:

--- a/mpf/core/rgb_color.py
+++ b/mpf/core/rgb_color.py
@@ -169,7 +169,7 @@ class RGBColor:
 
     __slots__ = ["_color"]
 
-    def __init__(self, color: Union["RGBColor", str, List[int], Tuple[int, int, int]] = None) -> None:
+    def __init__(self, color: Union["RGBColor", str, int, List[int], Tuple[int, int, int]] = None) -> None:
         """Initialise color."""
         if isinstance(color, RGBColor):
             self._color = color.rgb

--- a/mpf/core/rgb_color.py
+++ b/mpf/core/rgb_color.py
@@ -175,6 +175,8 @@ class RGBColor:
             self._color = color.rgb
         elif isinstance(color, str):
             self._color = RGBColor.string_to_rgb(color)
+        elif isinstance(color, int):
+            self._color = RGBColor.string_to_rgb(str(color))
         elif color:
             self._color = (color[0], color[1], color[2])
         else:

--- a/mpf/tests/test_RGBColor.py
+++ b/mpf/tests/test_RGBColor.py
@@ -31,8 +31,8 @@ class TestRGBColor(unittest.TestCase):
         self.assertEqual("red", color.name)
 
     def test_int_color(self):
-        color = RGBColor(990000)
-        self.assertEqual((153, 0, 0), color.rgb)
+        with self.assertRaises(TypeError):
+            RGBColor(990000)
 
     def test_off_color(self):
         # Tests the 'Off' color (nicely readable in LED show files)

--- a/mpf/tests/test_RGBColor.py
+++ b/mpf/tests/test_RGBColor.py
@@ -30,6 +30,10 @@ class TestRGBColor(unittest.TestCase):
         self.assertEqual(128, color.opacity)
         self.assertEqual("red", color.name)
 
+    def test_int_color(self):
+        color = RGBColor(990000)
+        self.assertEqual((153, 0, 0), color.rgb)
+
     def test_off_color(self):
         # Tests the 'Off' color (nicely readable in LED show files)
         color = RGBColor('Off')


### PR DESCRIPTION
I ran into this issue while trying to add some particular colors to my `named_colors` configuration.  Values such as `990000` will be interpreted by MPFs YamlInterface as an integer rather than a string and will cause the following error when an RGBColor is instantiated with an integer value:

```
Traceback (most recent call last):
  File "/home/sean/dev/mpf/mpf/tests/test_RGBColor.py", line 34, in test_int_color
    color = RGBColor(990000)
  File "/home/sean/dev/mpf/mpf/core/rgb_color.py", line 181, in __init__
    self._color = (color[0], color[1], color[2])
TypeError: 'int' object is not subscriptable
```

Added a check in the constructor of RGBColor to fix this particular issue.