### PR TITLE
prevent ball search from marking playfield active

### DIFF
--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -79,6 +79,7 @@ class DropTarget(SystemWideDevice):
 
     def _ball_search_phase1(self):
         if not self.complete and self.reset_coil:
+            self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
             self.reset_coil.pulse()
             return True
         # if down. knock down again
@@ -91,6 +92,7 @@ class DropTarget(SystemWideDevice):
         if self.reset_coil and self.knockdown_coil:
             self._in_ball_search = True
             if self.complete:
+                self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
                 self.reset_coil.pulse()
                 self.delay.add(100, self._ball_search_knockdown)
             else:
@@ -104,6 +106,7 @@ class DropTarget(SystemWideDevice):
     def _ball_search_phase3(self):
         if self.complete:
             if self.reset_coil:
+                self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
                 self.reset_coil.pulse()
                 if self.knockdown_coil:
                     self._in_ball_search = True
@@ -131,6 +134,7 @@ class DropTarget(SystemWideDevice):
         self.delay.add(100, self._ball_search_iteration_finish)
 
     def _ball_search_reset(self):
+        self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
         self.reset_coil.pulse()
         self.delay.add(100, self._ball_search_iteration_finish)
 

--- a/mpf/tests/machine_files/drop_targets/config/test_drop_targets.yaml
+++ b/mpf/tests/machine_files/drop_targets/config/test_drop_targets.yaml
@@ -79,6 +79,7 @@ drop_targets:
     switch: switch9
    center1:
     switch: switch10
+    ball_search_order: 1
     ignore_switch_ms: 1000
     reset_events: reset_center1
     reset_coil: coil6

--- a/mpf/tests/test_DropTargets.py
+++ b/mpf/tests/test_DropTargets.py
@@ -255,6 +255,69 @@ class TestDropTargets(MpfTestCase):
         self.advance_time_and_run(1)
         self.assertEventCalled('drop_target_center1_down')
 
+    def test_drop_target_ignore_ms_ball_search(self):
+
+        self.machine.playfields["playfield"].config['enable_ball_search'] = True
+        self.machine.playfields["playfield"].balls += 1
+
+        self.mock_event('drop_target_center1_down')
+        self.mock_event('drop_target_center1_up')
+
+        #self.hit_switch_and_run('switch10', 1)
+        self.assertSwitchState('switch10', False)  # ###############
+
+        # wait until ball search phase 1
+        event_future = self.machine.events.wait_for_event("ball_search_phase_1")
+        self.machine.clock.loop.run_until_complete(event_future)
+        
+        self.advance_time_and_run(.25)
+
+        self.hit_switch_and_run('switch10', .1)
+        self.release_switch_and_run('switch10', .1)
+        self.assertSwitchState('switch10', False)
+
+        self.advance_time_and_run(.5)
+
+        # reset happened in the ignore window so this event should not be
+        # called
+        self.assertEventNotCalled('drop_target_center1_down')
+        self.assertEventNotCalled('drop_target_center1_up')
+
+        # wait until ball search phase 2
+        event_future = self.machine.events.wait_for_event("ball_search_phase_2")
+        self.machine.clock.loop.run_until_complete(event_future)
+        
+        self.advance_time_and_run(.25)
+
+        self.hit_switch_and_run('switch10', .1)
+        self.release_switch_and_run('switch10', .1)
+        self.assertSwitchState('switch10', False)
+
+        self.advance_time_and_run(.5)
+
+        # reset happened in the ignore window so this event should not be
+        # called
+        self.assertEventNotCalled('drop_target_center1_down')
+        self.assertEventNotCalled('drop_target_center1_up')
+
+        # wait until ball search phase 3
+        event_future = self.machine.events.wait_for_event("ball_search_phase_3")
+        self.machine.clock.loop.run_until_complete(event_future)
+        
+        self.advance_time_and_run(.25)
+
+        self.hit_switch_and_run('switch10', .1)
+        self.release_switch_and_run('switch10', .1)
+        self.assertSwitchState('switch10', False)
+
+        self.advance_time_and_run(.5)
+
+        # reset happened in the ignore window so this event should not be
+        # called
+        self.assertEventNotCalled('drop_target_center1_down')
+        self.assertEventNotCalled('drop_target_center1_up')
+
+
     def test_drop_target_bank_ignore_ms(self):
         self.mock_event('drop_target_bank_right_bank_down')
         self.mock_event('drop_target_bank_right_bank_mixed')


### PR DESCRIPTION
Added ignore_switch_ms to ball search resets to prevent a ball search from cancelling itself because of erroneous switch reads during reset.