### PR TITLE
Production bundle args: without MC, with custom machine_path

### DIFF
--- a/mpf/commands/build.py
+++ b/mpf/commands/build.py
@@ -36,6 +36,10 @@ class Command(MpfCommandLineParser):
                                  "via a comma-"
                                  "separated list (no spaces between)")
 
+        parser.add_argument("-b",
+                            action="store_false", dest="mc", default=True,
+                            help="Builds a production config for MPF only, without MC.")
+
         self.args = parser.parse_args(remaining_args)
         self.args.configfile = Util.string_to_event_list(self.args.configfile)
 
@@ -46,8 +50,10 @@ class Command(MpfCommandLineParser):
         """Create a production bundle."""
         config_loader = YamlMultifileConfigLoader(self.machine_path, self.args.configfile, False, False)
         mpf_config = config_loader.load_mpf_config()
-        mc_config = config_loader.load_mc_config()
+        if self.args.mc:
+            mc_config = config_loader.load_mc_config()
 
         pickle.dump(mpf_config, open(ProductionConfigLoader.get_mpf_bundle_path(self.machine_path), "wb"))
-        pickle.dump(mc_config, open(ProductionConfigLoader.get_mpf_mc_bundle_path(self.machine_path), "wb"))
+        if self.args.mc:
+            pickle.dump(mc_config, open(ProductionConfigLoader.get_mpf_mc_bundle_path(self.machine_path), "wb"))
         print("Success.")

--- a/mpf/commands/build.py
+++ b/mpf/commands/build.py
@@ -40,6 +40,11 @@ class Command(MpfCommandLineParser):
                             action="store_false", dest="mc", default=True,
                             help="Builds a production config for MPF only, without MC.")
 
+        parser.add_argument("--dest-path",
+                            action="store", dest="dest_path", default=False,
+                            help="Path to set as machine_path on the production bundle. May "
+                                "be different than the machine_path on the current machine.")
+
         self.args = parser.parse_args(remaining_args)
         self.args.configfile = Util.string_to_event_list(self.args.configfile)
 
@@ -52,6 +57,9 @@ class Command(MpfCommandLineParser):
         mpf_config = config_loader.load_mpf_config()
         if self.args.mc:
             mc_config = config_loader.load_mc_config()
+
+        if self.args.dest_path:
+            mpf_config.set_machine_path(self.args.dest_path)
 
         pickle.dump(mpf_config, open(ProductionConfigLoader.get_mpf_bundle_path(self.machine_path), "wb"))
         if self.args.mc:

--- a/mpf/commands/build.py
+++ b/mpf/commands/build.py
@@ -43,7 +43,7 @@ class Command(MpfCommandLineParser):
         parser.add_argument("--dest-path",
                             action="store", dest="dest_path", default=False,
                             help="Path to set as machine_path on the production bundle. May "
-                                "be different than the machine_path on the current machine.")
+                                 "be different than the machine_path on the current machine.")
 
         self.args = parser.parse_args(remaining_args)
         self.args.configfile = Util.string_to_event_list(self.args.configfile)

--- a/mpf/core/config_loader.py
+++ b/mpf/core/config_loader.py
@@ -36,6 +36,10 @@ class MpfConfig:
         """Return machine path."""
         return self._machine_path
 
+    def set_machine_path(self, value):
+        """Set a new machine path."""
+        self._machine_path = value
+
     def get_config_spec(self):
         """Return config spec."""
         return self._config_spec


### PR DESCRIPTION
This PR adds two new command-line args for building MPF production bundles.

### `-b` for MPF-only bundles
By calling `mpf build production_bundle -b`, the additional `-b` argument instructs MPF to only package the MPF machine configs in the bundle and not to attempt an MC bundle. This is useful for games that don't use MC for their display, but use something else (e.g. Unity, Godot).

### `--dest-path` for explicit machine paths
By calling `mpf build production_bundle --dest-path="/path/on/target/machine"`, the additional `--dest-path` argument bakes an explicit `machine_path` value into the bundle. This value will overwrite whatever path the machine folder uses in the current machine, which is useful for running production bundles on computers with a different directory structure than the development computer.

While the `machine_path` value is saved to the machine config, the current code does not expose a method for setting the machine path with an explicit value. This PR adds a setter method, to enable the `--dest-path` feature to work. 