### PR TITLE
Auditor checks if events exist before setting to 0

### DIFF
--- a/mpf/core/file_interface.py
+++ b/mpf/core/file_interface.py
@@ -1,7 +1,7 @@
 """Interface for config file loaders."""
 import logging
 import os
-from typing import Union, Tuple, Optional
+from typing import Tuple, Optional
 
 MYPY = False
 if MYPY:    # pragma: no cover
@@ -24,7 +24,7 @@ class FileInterface:
     def find_file(self, filename) -> Tuple[Optional[str], Optional[str]]:
         """Test whether the passed file is valid.
 
-        If the file does not have an externsion, this method will test for files with that base name with
+        If the file does not have an extension, this method will test for files with that base name with
         all the extensions it can read.
 
         Args:

--- a/mpf/plugins/auditor.py
+++ b/mpf/plugins/auditor.py
@@ -77,8 +77,9 @@ class Auditor:
         self.switchnames_to_audit = {x.name for x in self.machine.switches.values()
                                      if 'no_audit' not in x.tags}
 
-        for event in self.config["events"]:
-            self.current_audits["events"][event] = 0
+        for event in self.config['events']:
+            if event not in self.current_audits['events']:
+                self.current_audits['events'][event] = 0
 
         # Make sure we have all the player stuff in our audit dict
         if 'player' in self.config['audit']:

--- a/mpf/tests/test_Auditor.py
+++ b/mpf/tests/test_Auditor.py
@@ -64,7 +64,7 @@ class TestAuditor(MpfFakeGameTestCase):
                           'my_var': {'top': [200, 0], 'average': 100.0, 'total': 2}},
                          auditor.data_manager.written_data["player"])
 
-    def test_auditor_switches(self):
+    def test_auditor_switches_events(self):
         auditor = self.machine.plugins[0]
         self.assertIsInstance(auditor, Auditor)
         data_manager = auditor.data_manager
@@ -149,3 +149,5 @@ class TestAuditor(MpfFakeGameTestCase):
 
         self.assertEqual(0, auditor.current_audits['switches']['s_test'])
         self.assertEqual(0, data_manager.written_data['switches']['s_test'])
+        self.assertEqual(0, auditor.current_audits['events']['game_started'])
+        self.assertEqual(0, data_manager.written_data['events']['game_started'])


### PR DESCRIPTION
The _load_defaults was setting all events that were configured to 0 when
this was called (which happens on every _initiatlize.  This changes it
to be the same logic as switches and players.  It checks if the event is
already in the list.  If it is not, it creates it and sets it to 0.  If
it is in the list, it is ignored.  This also works for the reset because
it blanks the entire list out first, then recreates.  So when it does
this, all values would be missing, and thus are created with a value of
0.