### PR TITLE
Allow kwargs or player variable events, default "source" kwarg in variable_player

### DIFF
--- a/mpf/config_players/variable_player.py
+++ b/mpf/config_players/variable_player.py
@@ -109,29 +109,29 @@ class VariablePlayer(ConfigPlayer):
         if entry['action'] == "add":
             assert self.machine.game is not None
             assert self.machine.game.player is not None
+            # default to current player
+            player = self.machine.game.player
             if entry['player']:
                 # specific player
                 try:
-                    self.machine.game.player_list[entry['player'] - 1][var] += value
+                    player = self.machine.game.player_list[entry['player'] - 1]
                 except IndexError:
                     self.warning_log("Failed to set player var %s for player %s. There are only %s players.",
                                      var, entry['player'] - 1, self.machine.game.num_players)
-            else:
-                # default to current player
-                self.machine.game.player[var] += value
+            player.add_with_kwargs(var, value, source=context)
         elif entry['action'] == "set":
             assert self.machine.game is not None
             assert self.machine.game.player is not None
+            # default to current player
+            player = self.machine.game.player
             if entry['player']:
                 # specific player
                 try:
-                    self.machine.game.player_list[entry['player'] - 1][var] = value
+                    player = self.machine.game.player_list[entry['player'] - 1]
                 except IndexError:
                     self.warning_log("Failed to set player var %s for player %s. There are only %s players.",
                                      var, entry['player'] - 1, self.machine.game.num_players)
-            else:
-                # default to current player
-                self.machine.game.player[var] = value
+            player.set_with_kwargs(var, value, source=context)
         elif entry['action'] == "add_machine":
             old_value = self.machine.variables.get_machine_var(var)
             if old_value is None:

--- a/mpf/core/player.py
+++ b/mpf/core/player.py
@@ -157,9 +157,21 @@ class Player:
                     self._send_variable_event(name, value, value, 0, self.vars['number'])
 
     def add_with_kwargs(self, name: str, value, **kwargs):
+        """Add a value to a player variable and include kwargs in the update event.
+
+        :param name: The player variable name
+        :param value: The value to add to the existing value
+        :param kwargs: Arguments to include in the posted player_<name> event
+        """
         self.__setattr__(name, self[name] + value, **kwargs)
 
     def set_with_kwargs(self, name: str, value, **kwargs):
+        """Set a value to a player variable and include kwargs in the update event.
+
+        :param name: The player variable name
+        :param value: The value to set
+        :param kwargs: Arguments to include in the posted player_<name> event
+        """
         self.__setattr__(name, value, **kwargs)
 
     # pylint: disable-msg=too-many-arguments
@@ -221,6 +233,8 @@ class Player:
         player_num: The player number this variable just changed for,
         starting with 1. (e.g. Player 1 will have *player_num=1*, Player 4
         will have *player_num=4*, etc.)
+
+        kwargs: Additional keyword arguments to include in the event args.
 
         '''
 

--- a/mpf/core/player.py
+++ b/mpf/core/player.py
@@ -156,8 +156,14 @@ class Player:
                 else:
                     self._send_variable_event(name, value, value, 0, self.vars['number'])
 
+    def add_with_kwargs(self, name: str, value, **kwargs):
+        self.__setattr__(name, self[name] + value, **kwargs)
+
+    def set_with_kwargs(self, name: str, value, **kwargs):
+        self.__setattr__(name, value, **kwargs)
+
     # pylint: disable-msg=too-many-arguments
-    def _send_variable_event(self, name: str, value, prev_value, change, player_num: int):
+    def _send_variable_event(self, name: str, value, prev_value, change, player_num: int, **kwargs):
         """Send a player variable event performs any monitor callbacks if configured.
 
         :param name: The player variable name
@@ -170,7 +176,8 @@ class Player:
                                  value=value,
                                  prev_value=prev_value,
                                  change=change,
-                                 player_num=player_num)
+                                 player_num=player_num,
+                                 **kwargs)
         '''event: player_(name)
         config_section: player_vars
         class_label: player_var
@@ -238,7 +245,7 @@ class Player:
 
         return 0
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value, **kwargs):
         """Set value and post event to inform about the change."""
         # prevent events for internal variables
         if name in self.__dict__:
@@ -264,7 +271,7 @@ class Player:
                            name, self.vars[name], prev_value, change)
 
             if self._events_enabled:
-                self._send_variable_event(name, self.vars[name], prev_value, change, self.vars['number'])
+                self._send_variable_event(name, self.vars[name], prev_value, change, self.vars['number'], **kwargs)
 
     def __getitem__(self, name):
         """Allow array get access."""

--- a/mpf/tests/test_PlayerVars.py
+++ b/mpf/tests/test_PlayerVars.py
@@ -33,3 +33,27 @@ class TestPlayerVars(MpfGameTestCase):
 
         self.assertEqual(4, self.machine.variables.get_machine_var("test1"))
         self.assertEqual('5', self.machine.variables.get_machine_var("test2"))
+
+    def test_event_kwargs(self):
+        self.fill_troughs()
+        self.start_game()
+        self.assertEqual(self.machine.game.player.some_var, 4)
+
+        self.mock_event('player_some_var')
+        self.machine.game.player.add_with_kwargs('some_var', 6, foo='bar')
+        self.advance_time_and_run()
+        self.assertEventCalledWith('player_some_var',
+                                    value=10,
+                                    prev_value=4,
+                                    change=6,
+                                    player_num=1,
+                                    foo='bar')
+
+        self.machine.game.player.set_with_kwargs('some_var', 1, bar='foo')
+        self.advance_time_and_run()
+        self.assertEventCalledWith('player_some_var',
+                                    value=1,
+                                    prev_value=10,
+                                    change=-9,
+                                    player_num=1,
+                                    bar='foo')

--- a/mpf/tests/test_VariablePlayer.py
+++ b/mpf/tests/test_VariablePlayer.py
@@ -251,3 +251,29 @@ class TestVariablePlayer(MpfFakeGameTestCase):
         self.machine.variables.set_machine_var("test5", "123")
         self.advance_time_and_run(.1)
         self.assertMachineVarEqual("123-suffix", "test6")
+
+    def test_event_kwargs(self):
+        self.start_game()
+        self.post_event('start_mode1')
+        self.assertTrue(self.machine.mode_controller.is_active('mode1'))
+        self.post_event('start_mode3')
+        self.assertTrue(self.machine.mode_controller.is_active('mode3'))
+
+        self.mock_event('player_score')
+        self.post_event('test_event1')
+        self.advance_time_and_run()
+        self.assertEventCalledWith('player_score',
+                                    value=100,
+                                    prev_value=0,
+                                    change=100,
+                                    player_num=1,
+                                    source='mode1')
+
+        self.post_event('score_player1')
+        self.advance_time_and_run()
+        self.assertEventCalledWith('player_score',
+                                    value=142,
+                                    prev_value=100,
+                                    change=42,
+                                    player_num=1,
+                                    source='mode3')


### PR DESCRIPTION
## Player Var-Event Kwargs
This PR proposes the addition of kwargs to player variable changes, and implements them by default on changes triggered by `variable_player:` events.

```
INFO : Event: ==='player_score'=== 
Args={'value': 1500, 'prev_value': 500, 'change': 1000, 'player_num': 1, 'source': 'skillshot'}
```

### Adding Kwargs and New Methods
This proposal adds two new methods to the Player class: 
* `add_with_kwargs(name, value, **kwargs)` will add the `value` to the player's `name` property and include kwargs
* `set_with_kwargs(name, value **kwargs)` will set the player's `name` property to the `value` and include kwargs

The Player class `__setattr__()` method modified to include kwargs, and those are passed to `_send_variable_event()` and included on the posted variable change event.

### Variable Player Includes Context
This proposal extends the Variable Player to automatically include the `context` value of its triggering events as the `"source"` kwarg in posted events.

### Use Cases
This proposal is targeted towards multipliers and jackpots that accrue value based on other modes' scoring. 

For example, a playfield multiplier may want to increase all scoring by a given multiple, but the multiplier adding to the score would itself increase the score, triggering the multiplier again, for infinite scores. By checking the `"source"`, the multiplier mode could listen to _player_score_ events and ignore those whose `source` is itself.

For another example, a jackpot may grow proportional to all points scored in a given mode. By checking the `"source"` kwarg, the jackpot could listen to _player_score_ events and catch those triggered by the mode it uses to grow—while ignoring scoring from all other modes.

Each of these use cases is possible already, but requires additional player variables and workarounds. This proposal just makes it easy to do score (and other player_var) filtering with conditional events and no custom code.