### PR TITLE
Bugfix orphaned handlers on shot groups

### DIFF
--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -767,7 +767,8 @@ class MachineController(LogMixin):
         except RuntimeError:
             print("Failed to stop all tasks")
 
-        self.events.stop()
+        if hasattr(self, "events"):
+            self.events.stop()
         self.clock.loop.stop()
         self.clock.loop.run_forever()
         self.clock.loop.close()

--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -54,6 +54,7 @@ class ShotGroup(ModeDevice):
         """Disable device when mode stops."""
         super().device_removed_from_mode(mode)
         self.machine.events.remove_handler(self._hit)
+        self.machine.events.remove_handler(self._check_for_complete)
 
     def get_common_state(self):
         """Return common state if all shots in this group are in the same state.

--- a/mpf/tests/test_ShotGroups.py
+++ b/mpf/tests/test_ShotGroups.py
@@ -438,3 +438,20 @@ class TestShotGroups(MpfFakeGameTestCase):
 
         # shot should turn off after game
         self.assertLightChannel("l_special_left", 0)
+
+    def test_shot_handlers(self):
+        self.mock_event("test_group_complete")
+        self.mock_event("test_group_hit")
+
+        shot_group = self.machine.shot_groups['test_group']
+        self.assertFalse(self.machine.events.does_event_exist('shot_1_hit'))
+        self.assertFalse(self.machine.events.does_event_exist('player_shot_shot_1'))
+
+        self.start_game()
+        self.assertTrue(self.machine.events.does_event_exist('shot_1_hit'))
+        self.assertTrue(self.machine.events.does_event_exist('player_shot_shot_1'))
+
+        self.machine.events.post('player_turn_stopped')
+        self.advance_time_and_run()
+        self.assertFalse(self.machine.events.does_event_exist('shot_1_hit'))
+        self.assertFalse(self.machine.events.does_event_exist('player_shot_shot_1'))

--- a/mpf/tests/test_ShotGroups.py
+++ b/mpf/tests/test_ShotGroups.py
@@ -440,10 +440,6 @@ class TestShotGroups(MpfFakeGameTestCase):
         self.assertLightChannel("l_special_left", 0)
 
     def test_shot_handlers(self):
-        self.mock_event("test_group_complete")
-        self.mock_event("test_group_hit")
-
-        shot_group = self.machine.shot_groups['test_group']
         self.assertFalse(self.machine.events.does_event_exist('shot_1_hit'))
         self.assertFalse(self.machine.events.does_event_exist('player_shot_shot_1'))
 


### PR DESCRIPTION
This PR fixes a bug created in https://github.com/missionpinball/mpf/commit/58d3df636f6b1027d68024ba196e3cb852ca59a9 that causes shot groups to continually add event handlers.

The change in https://github.com/missionpinball/mpf/commit/58d3df636f6b1027d68024ba196e3cb852ca59a9 introduces new handlers for the ShotGroup's `self._check_for_complete` when the device is added to a mode, but these handlers are never removed. The next time the mode starts, they are all added again.

This PR removes these handlers in the ShotGroup's `self.device_removed_from_mode()` method, and adds a test to prevent regression.

_Also, this PR adds a catch during shutdown. During a catastrophic failure, e.g. a syntax error in an MPF file that prevents startup, `self.events` is undefined and that subsequent error blocks the stacktrace of the underlying syntax error. This catch allows the machine to gracefully shutdown and display a useful stacktrace._