### PR TITLE
Add priority to credits mode reset events

### DIFF
--- a/mpf/modes/credits/code/credits.py
+++ b/mpf/modes/credits/code/credits.py
@@ -51,10 +51,10 @@ class Credits(Mode):
             section_name='credits')
 
         for event in self.credits_config['reset_earnings_events']:
-            self.machine.events.add_handler(event, self._reset_earnings)
+            self.machine.events.add_handler(event, self._reset_earnings, priority=1)
 
         for event in self.credits_config['reset_credits_events']:
-            self.machine.events.add_handler(event, self._reset_credits)
+            self.machine.events.add_handler(event, self._reset_credits, priority=2)
 
         # add setting
         self.machine.settings.add_setting(SettingEntry("free_play", "Free Play", 500,


### PR DESCRIPTION
This PR adds explicit priority values to the Credits mode `_reset_earnings` and `_reset_credits` events. 

Currently, these events have default priority and are both bound to the _factory_reset_ event. As a result, an unordered handler warning appears when the credits mode starts.

```
2022-01-02 12:27:28,622 : INFO : EventManager : Unordered handler for class <Mode.credits> 
on event factory_reset with priority 1. Handlers: 
  [RegisteredHandler(callback=<bound method Credits._reset_earnings of <Mode.credits>>, 
  priority=1, kwargs={}, key=UUID('abcf555c-8783-46b0-9e9b-44461d7d9967'), condition=None, 
  blocking_facility=None), 
  RegisteredHandler(callback=<bound method Credits._reset_credits of <Mode.credits>>, 
  priority=1, kwargs={}, key=UUID('770885e2-6b39-4898-b420-2a88fbfc9cec'), condition=None, 
  blocking_facility=None)]. 
The order of those handlers is not defined and they will be executed in random order. This 
might lead to race conditions and potential bugs.
```

This PR adds priorities to the handlers so that the order is predictable, eliminating this warning. That's all!