### PR TITLE
Post timer_(name)_tick event on restart when already running

### DIFF
--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -252,7 +252,12 @@ class Timer(ModeDevice):
         """
         del kwargs
         self.reset()
-        self.start()
+        # If the timer is not running, start it
+        if not self.running:
+            self.start()
+        # If the timer is running, post an updated tick event
+        else:
+            self._post_tick_events()
 
     def stop(self, **kwargs):
         """Stop the timer and posts the 'timer_<name>_stopped' event.
@@ -363,8 +368,7 @@ class Timer(ModeDevice):
 
             self.debug_log("Restart on complete: True")
 
-            self.reset()
-            self.start()
+            self.restart()
 
     def _timer_tick(self):
         # Automatically called by the core clock each tick

--- a/mpf/tests/test_Timer.py
+++ b/mpf/tests/test_Timer.py
@@ -337,6 +337,13 @@ class TestTimer(MpfFakeGameTestCase):
         self.advance_time_and_run()
         self.assertEqual(5, timer.ticks)
 
+        # Ensure that we get the 0 tick when it restarts
+        self.mock_event("timer_timer_up_tick")
+        self.post_event('restart_timer_up')
+        self.assertEqual(0, timer.ticks)
+        self.assertEventCalledWith("timer_timer_up_tick",
+                                   ticks=0, ticks_remaining=10)
+
     def test_interrupt_timer_by_mode_stop_with_player(self):
         self.machine.events.add_handler("timer_timer_down_tick", self._timer_tick)
         self.machine.events.add_handler("timer_timer_down_started", self._timer_start)


### PR DESCRIPTION
This PR fixes a bug in Timers' `restart` behavior.

The `restart()` method calls `reset()` and `start()`, but if the Timer is already running then the `start` method exits immediately. There is a bug here because the start method is meant to post the _timer_name_tick_ event, but the early exit prevents that code path. As a result, calling `restart()` on a *stopped* Timer will post the _timer_name_tick_ event but calling `restart()` on a *running* Timer will not post the event, and it will be another full tick before any listeners know that the timer tick has changed.

This PR tweaks the `restart()` behavior to only call `start()` the timer is not running, and otherwise post the event directly. For safety, an instance elsewhere of calling `reset()` then `start()` was replaced with a call to `restart()`.

Also, a test!

![timey wimey](https://c.tenor.com/EwDRQdh7G04AAAAC/doctorwho-davidtennant.gif)