### PR TITLE
Simplifies attr check related to IMC

### DIFF
--- a/mpf/config_players/plugin_player.py
+++ b/mpf/config_players/plugin_player.py
@@ -52,8 +52,8 @@ class PluginPlayer(DeviceConfigPlayer):
         events = super().register_player_events(config, mode, priority)
         # when bcp is disabled do not register plugin_player
         if self.machine.options['bcp']:
-            # hasattr check is for IMC to work
-            if hasattr(self.machine, 'is_shutting_down') and self.machine.is_shutting_down:
+            # getattr check is for IMC to work
+            if getattr(self.machine, 'is_shutting_down', False):
                 return events
             self.bcp_client = self._get_bcp_client(config)
 


### PR DESCRIPTION
Users getattr instead of hasattr to remove one boolean.  Sets a default value to false if the attribute doesn't exist.