### PR TITLE
System11 AC Relay Improvements

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1857,7 +1857,9 @@ system11:
     __valid_in__: machine
     __type__: config
     ac_relay_delay_ms: single|ms|75ms
+    ac_relay_debounce_ms: single|ms|0
     ac_relay_driver: single|machine(coils)|
+    ac_relay_switch: single|machine(switches)|None
     prefer_a_side_event: single|event_handler|game_ended
     prefer_c_side_event: single|event_handler|game_will_start
     queue_c_side_while_preferred: single|bool|true

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1860,7 +1860,9 @@ system11:
     ac_relay_driver: single|machine(coils)|
     prefer_a_side_event: single|event_handler|game_ended
     prefer_c_side_event: single|event_handler|game_will_start
+    queue_c_side_while_preferred: single|bool|true
     platform: single|str|None
+    debug: single|bool|false
     console_log: single|enum(none,basic,full)|none
     file_log: single|enum(none,basic,full)|basic
 text_strings:

--- a/mpf/devices/driver.py
+++ b/mpf/devices/driver.py
@@ -379,7 +379,8 @@ class Driver(SystemWideDevice):
         pulse_power = self.get_and_verify_pulse_power(pulse_power)
         hold_duration = self.get_and_verify_timed_enable_ms(timed_enable_ms)
         hold_power = self.get_and_verify_hold_power(hold_power)
-        wait_ms = self._notify_psu_and_get_wait_ms(pulse_duration, max_wait_ms)
+        # Let the PSU wait for both the pulse _and_ the timed enable
+        wait_ms = self._notify_psu_and_get_wait_ms(pulse_duration + hold_duration, max_wait_ms)
 
         # TODO: Detect a NotImplementedError and simulate a timed_enable
         #       with a software timer and enable+disable

--- a/mpf/platforms/system11.py
+++ b/mpf/platforms/system11.py
@@ -250,7 +250,7 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
         self.platform.clear_hw_rule(switch, coil)
 
     def driver_action(self, driver, pulse_settings: Optional[PulseSettings], hold_settings: Optional[HoldSettings],
-                      side: str):
+                      side: str, timed_enable: bool = False):
         """Add a driver action for a switched driver to the queue (for either the A-side or C-side queue).
 
         Args:
@@ -264,20 +264,20 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
         """
         if self.prefer_a_side:
             if side == "A":
-                self.a_side_queue.add((driver, pulse_settings, hold_settings))
+                self.a_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
                 self._service_a_side()
             elif side == "C":
-                self.c_side_queue.add((driver, pulse_settings, hold_settings))
+                self.c_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
                 if not self.ac_relay_in_transition and not self.a_side_busy:
                     self._service_c_side()
             else:
                 raise AssertionError("Invalid side {}".format(side))
         else:
             if side == "C":
-                self.c_side_queue.add((driver, pulse_settings, hold_settings))
+                self.c_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
                 self._service_c_side()
             elif side == "A":
-                self.a_side_queue.add((driver, pulse_settings, hold_settings))
+                self.a_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
                 if not self.ac_relay_in_transition and not self.c_side_busy:
                     self._service_a_side()
             else:
@@ -354,9 +354,14 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
             return
 
         while self.a_side_queue:
-            driver, pulse_settings, hold_settings = self.a_side_queue.pop()
+            driver, pulse_settings, hold_settings, timed_enable = self.a_side_queue.pop()
 
-            if hold_settings is None and pulse_settings:
+            if timed_enable:
+                driver.timed_enable(pulse_settings, hold_settings)
+                self.a_side_done_time = max(self.a_side_done_time,
+                                            self.machine.clock.get_time() + (pulse_settings.duration / 1000.0))
+
+            elif hold_settings is None and pulse_settings:
                 driver.pulse(pulse_settings)
                 self.a_side_done_time = max(self.a_side_done_time,
                                             self.machine.clock.get_time() + (pulse_settings.duration / 1000.0))
@@ -429,9 +434,14 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
             return
 
         while self.c_side_queue:
-            driver, pulse_settings, hold_settings = self.c_side_queue.pop()
+            driver, pulse_settings, hold_settings, timed_enable = self.c_side_queue.pop()
 
-            if hold_settings is None and pulse_settings:
+            if timed_enable:
+                driver.timed_enable(pulse_settings, hold_settings)
+                self.c_side_done_time = max(self.c_side_done_time,
+                                            self.machine.clock.get_time() + (pulse_settings.duration / 1000.0))
+
+            elif hold_settings is None and pulse_settings:
                 driver.pulse(pulse_settings)
                 self.c_side_done_time = max(self.c_side_done_time,
                                             self.machine.clock.get_time() + (pulse_settings.duration / 1000.0))
@@ -510,4 +520,4 @@ class System11Driver(DriverPlatformInterface):
 
     def timed_enable(self, pulse_settings: PulseSettings, hold_settings: HoldSettings):
         """Pulse and enable the coil for an explicit duration."""
-        self.overlay.driver_action(self.platform_driver, pulse_settings, hold_settings, self.side)
+        self.overlay.driver_action(self.platform_driver, pulse_settings, hold_settings, self.side, True)

--- a/mpf/platforms/system11.py
+++ b/mpf/platforms/system11.py
@@ -265,7 +265,8 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
         if self.prefer_a_side:
             if side == "A":
                 self.a_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
-                self._service_a_side()
+                if not self.ac_relay_in_transition:
+                    self._service_a_side()
             elif side == "C":
                 self.c_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
                 if not self.ac_relay_in_transition and not self.a_side_busy:
@@ -274,8 +275,13 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
                 raise AssertionError("Invalid side {}".format(side))
         else:
             if side == "C":
+                # Sometimes it doesn't make sense to queue the C side (flashers) and play them after
+                # switching to the A side (coils) and back. In which case, just ignore this driver action.
+                if not self.c_side_enabled and not self.system11_config['queue_c_side_while_preferred']:
+                    return
                 self.c_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
-                self._service_c_side()
+                if not self.ac_relay_in_transition:
+                    self._service_c_side()
             elif side == "A":
                 self.a_side_queue.add((driver, pulse_settings, hold_settings, timed_enable))
                 if not self.ac_relay_in_transition and not self.c_side_busy:
@@ -297,6 +303,9 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
         self.ac_relay_in_transition = True
         self.a_side_enabled = False
         self.c_side_enabled = False
+        # Clear out the C side queue if we don't want to hold onto it for later
+        if not self.system11_config['queue_c_side_while_preferred']:
+            self.c_side_queue.clear()
         self.delay.add(ms=self.system11_config['ac_relay_delay_ms'],
                        callback=self._a_side_enabled,
                        name='disable_ac_relay')
@@ -357,14 +366,14 @@ class System11OverlayPlatform(DriverPlatform, SwitchPlatform):
             driver, pulse_settings, hold_settings, timed_enable = self.a_side_queue.pop()
 
             if timed_enable:
-                driver.timed_enable(pulse_settings, hold_settings)
-                self.a_side_done_time = max(self.a_side_done_time,
-                                            self.machine.clock.get_time() + (pulse_settings.duration / 1000.0))
+                wait_ms = driver.timed_enable(pulse_settings, hold_settings) or 0
+                wait_secs = (pulse_settings.duration + wait_ms) / 1000.0
+                self.a_side_done_time = max(self.a_side_done_time, self.machine.clock.get_time() + wait_secs)
 
             elif hold_settings is None and pulse_settings:
-                driver.pulse(pulse_settings)
-                self.a_side_done_time = max(self.a_side_done_time,
-                                            self.machine.clock.get_time() + (pulse_settings.duration / 1000.0))
+                wait_ms = driver.pulse(pulse_settings) or 0
+                wait_secs = (pulse_settings.duration + wait_ms) / 1000.0
+                self.a_side_done_time = max(self.a_side_done_time, self.machine.clock.get_time() + wait_secs)
 
             elif hold_settings and pulse_settings:
                 driver.enable(pulse_settings, hold_settings)

--- a/mpf/platforms/system11.py
+++ b/mpf/platforms/system11.py
@@ -510,4 +510,4 @@ class System11Driver(DriverPlatformInterface):
 
     def timed_enable(self, pulse_settings: PulseSettings, hold_settings: HoldSettings):
         """Pulse and enable the coil for an explicit duration."""
-        self.overlay.driver_action(self.platform.driver, pulse_settings, hold_settings, self.side)
+        self.overlay.driver_action(self.platform_driver, pulse_settings, hold_settings, self.side)

--- a/mpf/tests/test_Snux.py
+++ b/mpf/tests/test_Snux.py
@@ -52,10 +52,10 @@ class TestSnux(MpfFakeGameTestCase):
         c_ac_relay.enable = MagicMock()
         c_ac_relay.disable = MagicMock()
 
-        driver_11.pulse = MagicMock()
+        driver_11.pulse = MagicMock(return_value=0)
         driver_11.enable = MagicMock()
         driver_11.disable = MagicMock()
-        driver_12.pulse = MagicMock()
+        driver_12.pulse = MagicMock(return_value=0)
         driver_12.enable = MagicMock()
         driver_12.disable = MagicMock()
 


### PR DESCRIPTION
This PR adds some improvements and fixes some logical gaps in the System11 AC Relay behavior.

## New Features

### New config option `ac_relay_debounce_ms`
The AC Relay configuration already has an option `ac_relay_delay_ms`, which is the desired delay between changing the relay state and pulsing the coils. However there is no option for the inverse: a desired delay _after_ the coils are pulsed _before_ the relay changes back.

The new `ac_relay_debounce_ms` config option is a time duration that is added to the calculated coil completion time, which provides a safety buffer to ensure that the relay is not switched over while a coil still has power.

### New config option `ac_relay_switch`
Later System11 machines include a switch that reflects the real-time state of the AC relay. Using this switch provides a much more accurate assessment of when it is safe to fire relayed coils. The existing method, using `ac_relay_delay_ms`, is vulnerable to queue and serial bus delays because the delay is calculated from when the relay coil is _scheduled_, which may be some time before the actual command is _sent_.

With a long platform queue, such as during a ball start, it's even possible for the AC relay switch over, coil fire, and switch back events to be sent to the platform within 5-10ms of each other if the queue is longer than the `ac_relay_delay_ms`.

This new config option updates the System11 platform to use a switch instead of a delay, if the `ac_relay_switch` value is provided. Instead of a delay timeout, the platform will listen to switch state changes and trigger the appropriate A/C side behavior.

### New config option `queue_c_side_while_preferred`
Most of the bugs and logic improvements (listed below) are caused by competing coil events on both the A and C sides. Even with the below fixes, certain game designs may still drive excessive relay back-and-forth if the preferred C side (flashers) is trying to fire repeatedly while the A side (coils) has a series of coils to fire.

> Example: a spinner has a corresponding flasher on the C side that pulses with each spinner hit. 
> 1. The player hits the spinner on the way to a drain with ball save, wherein the outhole coil needs to fire to the trough and the trough coil needs to fire to the plunger. 
> 2. The relay switches to the A side to fire the outhole, while the inertia from the spinner stacks up a bunch of flashes on the C side queue. 
> 3. The outhole fires and the relay switches back to the C side, and the A side is then queued for the trough eject. 
> 4. The flasher flashes repeatedly (because it has many hits stacked) 
> 5. The relay switches back to the A side to fire the trough, while the spinner stacks up a few more flashes on the C side queue
> 5. The trough fires and the relay switches back to the C side
> 6. The flasher flashes repeatedly to clear the queue, even though the spinner has stopped.

This new configuration option `queue_c_side_while_preferred` is for games where the designer does not care about queueing C side events during gameplay. Because the C side is typically used for flashers and is typically "preferred" during gameplay, this option ignores all C-side triggers while the A side is active. The result is immediate firing of A side coils—even multiple in a row—and no lagging flashes after.

## Logic Improvements and Bug Fixes

### Prioritize switched side queue over preferred
A bug exists in the System11 logic where during relay switches from the preferred side to the other side, any triggers sent to the preferred side  will _immediately_ be serviced, causing a switch back to the preferred side and never getting around to firing what the relay originally switched over to fire.

This PR adds a safety check to check for the relay being in transition before attempting to service a trigger, therefore allowing the switchover to complete and the non-preferred side to fire before restoring the preferred side.

### Include hold/timed_enable duration in coil timing calculation
A bug exists where the time calculation for how long to hold the relay on a non-preferred side are based exclusively on the pulse time, which can lead to the relay switching over while a coil is still powered for a hold or timed_enable. 

This PR updates the time calculation to include both `pulse_settings.duration` and `hold_settings.duration`, to help prevent relay switches while switched coils are hot.

### Explicit `timed_enable` argument for pulse actions
A bug exists with the recent timed_enable implementation based on how System11 platforms determine their behavior. A simple boolean check for `hold_settings` triggered either `pulse()` (if no hold settings) or `enable()` (if yes hold settings). This bug could lead to unintended enabling of coils intended for a timed enable.

This PR updates adds an explicit `timed_enable` argument that takes priority over the true/false presence of `hold_settings`, allowing a timed enable to be performed instead of a hold.
