### PR TITLE
Update match.py to keep winner_number

### DIFF
--- a/mpf/modes/match/code/match.py
+++ b/mpf/modes/match/code/match.py
@@ -62,6 +62,8 @@ class Match(AsyncMode):
             "winner_number": winner_number,
             "winners": winners
         }
+        
+        self.machine.variables.set_machine_var('match_number', winner_number)
 
         for i in range(0, self.machine.game.max_players):
             event_args["match_number{}".format(i)] = match_numbers[i] if len(match_numbers) > i else ""


### PR DESCRIPTION
added a single line to temporarily create a machine variable 'match_number' so the winner number would be accessible during attract mode after match mode ended for the purpose of keeping the match light lit on an em.  I tried to figure out how to have it store this in machine_vars.yaml and reload it next time you start the machine (as em machines do show the prior match after turning on the machine), but that is way way over my head.  not sure if info_lights could work with this as well, but we would only want it lit during attract mode/game not running.