### PR TITLE
Adds a feature to jump to a state of shot profile

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1445,7 +1445,13 @@ shots:
     restart_events: event_handler|event_handler:ms|None
     advance_events: event_handler|event_handler:ms|None
     hit_events: event_handler|event_handler:ms|None
+    jump_states: list|subconfig(shot_jump_states)|None
     show_tokens: dict|str:template_str|None
+shot_jump_states:
+    events: list|event_handler|
+    state: single|int|0
+    force: single|bool|true
+    force_show: single|bool|false
 shot_groups:
     __valid_in__: mode
     __type__: device

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1449,7 +1449,7 @@ shots:
     show_tokens: dict|str:template_str|None
 shot_control_events:
     events: list|event_handler|
-    state: single|int|0
+    state: single|int|
     force: single|bool|true
     force_show: single|bool|false
 shot_groups:

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1445,9 +1445,9 @@ shots:
     restart_events: event_handler|event_handler:ms|None
     advance_events: event_handler|event_handler:ms|None
     hit_events: event_handler|event_handler:ms|None
-    jump_states: list|subconfig(shot_jump_states)|None
+    control_events: list|subconfig(shot_control_events)|None
     show_tokens: dict|str:template_str|None
-shot_jump_states:
+shot_control_events:
     events: list|event_handler|
     state: single|int|0
     force: single|bool|true

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -49,7 +49,7 @@ class Shot(EnableDisableMixin, ModeDevice):
         for switch in self.config['switches'] + list(self.config['delay_switch'].keys()):
             # mark the playfield active no matter what
             switch.add_handler(self._mark_active)
-        self._register_jump_state_handlers()
+        self._register_control_event_handlers()
 
     def _mark_active(self, **kwargs):
         """Mark playfield active."""
@@ -267,7 +267,6 @@ class Shot(EnableDisableMixin, ModeDevice):
         """
         super().device_removed_from_mode(mode)
         self._remove_switch_handlers()
-        self._remove_jump_state_handlers()
         if self.running_show:
             self.running_show.stop()
             self.running_show = None
@@ -414,22 +413,19 @@ class Shot(EnableDisableMixin, ModeDevice):
     def _release_delay(self, switch):
         self.active_delays.remove(switch)
 
-    def _register_jump_state_handlers(self):
-        for jump_state in self.config['jump_states']:
-            for event in jump_state['events']:
-                self._handlers.append(self.machine.events.add_handler(event, self._jump_states,
-                                                                      jump_state_config=jump_state))
-
-    def _remove_jump_state_handlers(self):
-        self.machine.events.remove_handlers_by_keys(self._handlers)
+    def _register_control_event_handlers(self):
+        for control_event in self.config['control_events']:
+            for event in control_event['events']:
+                self._handlers.append(self.machine.events.add_handler(event, self._control_events,
+                                                                      control_event_config=control_event))
 
     @event_handler(7)
-    def _jump_states(self, jump_state_config, **kwargs):
-        """Takes in a jump_state event to move the state of the given shot to a specific state. (Default = State 0)"""
+    def _control_events(self, control_event_config, **kwargs):
+        """Takes in a control_event to move the shot to a specific state."""
         del kwargs
-        self.jump(jump_state_config['state'],
-                  jump_state_config['force'],
-                  jump_state_config['force_show'])
+        self.jump(control_event_config['state'],
+                  control_event_config['force'],
+                  control_event_config['force_show'])
 
     def jump(self, state, force=True, force_show=False):
         """Jump to a certain state in the active shot profile.

--- a/mpf/tests/machine_files/shots/config/test_shots.yaml
+++ b/mpf/tests/machine_files/shots/config/test_shots.yaml
@@ -2,6 +2,7 @@
 
 modes:
   - base2
+  - base3
   - mode1
   - mode2
 

--- a/mpf/tests/machine_files/shots/modes/base3/config/base3.yaml
+++ b/mpf/tests/machine_files/shots/modes/base3/config/base3.yaml
@@ -12,8 +12,8 @@ shots:
     profile: state_toggle
     advance_events: advance_event1
     reset_events: reset_event1
-    jump_states:
-      - events: state_event1
+    control_events:
+      - events: state_event1, state_event10
         state: 1
   shot_state_2:
     switch: switch_2
@@ -24,7 +24,7 @@ shots:
     reset_events: reset_event2
     enable_events: enable_event2
     disable_events: disable_event2
-    jump_states:
+    control_events:
       - events: state_event2
         state: 0
         force: false

--- a/mpf/tests/machine_files/shots/modes/base3/config/base3.yaml
+++ b/mpf/tests/machine_files/shots/modes/base3/config/base3.yaml
@@ -1,0 +1,46 @@
+#config_version=5
+mode:
+    start_events: player_turn_started
+    stop_events: player_turn_stopped
+    priority: 50
+
+shots:
+  shot_state_1:
+    switch: switch_1
+    show_tokens:
+      light: light_1
+    profile: state_toggle
+    advance_events: advance_event1
+    reset_events: reset_event1
+    jump_states:
+      - events: state_event1
+        state: 1
+  shot_state_2:
+    switch: switch_2
+    show_tokens:
+      light: light_2
+    profile: state_loop_3
+    advance_events: advance_event2
+    reset_events: reset_event2
+    enable_events: enable_event2
+    disable_events: disable_event2
+    jump_states:
+      - events: state_event2
+        state: 0
+        force: false
+      - events: state_event3
+        state: 0
+      - events: state_event4
+        state: 2
+
+shot_profiles:
+    state_toggle:
+        states:
+        - name: unlit
+        - name: lit
+    state_loop_3:
+      loop: True
+      states:
+        - name: one
+        - name: two
+        - name: three

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -954,9 +954,10 @@ class TestShots(MpfTestCase):
         self.mock_event("state_event1")
         self.mock_event("advance_event1")
         self.mock_event("reset_event1")
+        self.mock_event("reset_event10")
         # Shot 1 tests
         self.assertEqual("unlit", shot1.state_name)
-        self.post_event("state_event1")
+        self.post_event("state_event10")
         self.assertEqual("lit", shot1.state_name)
         self.post_event("reset_event1")
         self.assertEqual("unlit", shot1.state_name)

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -942,3 +942,56 @@ class TestShots(MpfTestCase):
         shot.jump(0, True, True)
         # Should see the color of the new profile at the same state
         self.assertLightColor("led_20", "purple")
+
+    def test_jump_states(self):
+        """Test jump_states config"""
+        self.start_game()
+        self.machine.modes["base3"].start()
+        shot1 = self.machine.device_manager.collections["shots"]["shot_state_1"]
+        shot2 = self.machine.device_manager.collections["shots"]["shot_state_2"]
+
+        # Shot 1 - setup events
+        self.mock_event("state_event1")
+        self.mock_event("advance_event1")
+        self.mock_event("reset_event1")
+        # Shot 1 tests
+        self.assertEqual("unlit", shot1.state_name)
+        self.post_event("state_event1")
+        self.assertEqual("lit", shot1.state_name)
+        self.post_event("reset_event1")
+        self.assertEqual("unlit", shot1.state_name)
+        self.post_event("advance_event1")
+        self.assertEqual("lit", shot1.state_name)
+        self.post_event("state_event1")
+        self.assertEqual("lit", shot1.state_name)
+
+        # Shot 2 - setup events
+        self.mock_event("state_event2")
+        self.mock_event("state_event3")
+        self.mock_event("state_event4")
+        self.mock_event("advance_event2")
+        self.mock_event("reset_event2")
+        self.mock_event("enable_event2")
+        self.mock_event("disable_event2")
+        # Shot 2 tests
+        self.assertEqual("one", shot2.state_name)
+        self.post_event("enable_event2")
+        self.post_event("advance_event2")
+        self.assertEqual("two", shot2.state_name)
+        self.post_event("disable_event2")
+        self.post_event("state_event2")
+        self.assertEqual("two", shot2.state_name)
+        self.post_event("state_event3")
+        self.assertEqual("one", shot2.state_name)
+        self.post_event("state_event4")
+        self.assertEqual("three", shot2.state_name)
+        self.post_event("enable_event2")
+        self.post_event("advance_event2")
+        self.assertEqual("one", shot2.state_name)
+        self.post_event("state_event4")
+        self.assertEqual("three", shot2.state_name)
+        # Disable mode and verify jump doesn't process
+        self.machine.modes["base3"].stop()
+        self.advance_time_and_run()
+        self.post_event("state_event2")
+        self.assertEqual("None", shot2.state_name)


### PR DESCRIPTION
This feature lets a user have a list of events that will jump a shot to a
specific state of its shot profile when fired.  This can be done even
when the shot is disabled based on the arguments provided.