### PR TITLE
Syncs up chimes with reel coil pulse

### DIFF
--- a/mpf/devices/score_reel.py
+++ b/mpf/devices/score_reel.py
@@ -152,7 +152,9 @@ class ScoreReel(SystemWideDevice):
         self.log.debug("Advancing reel to value %s (current value: %s repeat_pulse_time: %sms)",
                        self._destination_value, self.assumed_value, self.config['repeat_pulse_time'])
         while self._destination_value != self.assumed_value:
+            self.machine.events.post('reel_{}_will_advance'.format(self.name))
             wait_ms = self.config['coil_inc'].pulse(max_wait_ms=500)
+            self.machine.events.post('reel_{}_advancing'.format(self.name))
             previous_value = self.assumed_value
 
             await asyncio.sleep((wait_ms + self.config['repeat_pulse_time']) / 1000)
@@ -163,8 +165,8 @@ class ScoreReel(SystemWideDevice):
             self.check_hw_switches()
 
             if previous_value != self.assumed_value and self.assumed_value >= 0:
-                self.machine.events.post('reel_{}_advance'.format(self.name))
-                '''event: reel_(name)_advance
+                self.machine.events.post('reel_{}_advanced'.format(self.name))
+                '''event: reel_(name)_advanced
 
                 desc: The reel (name) advanced to the next position.
                 '''

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -67,7 +67,7 @@ class ScoreReelGroup(SystemWideDevice):
             if self.config['chimes'][i]:
                 if not self.reels[i]:
                     self.raise_config_error("Invalid reel for chime {}".format(self.config['chimes'][i]), 1)
-                self.machine.events.add_handler(event='reel_' + self.reels[i].name + '_advance',
+                self.machine.events.add_handler(event='reel_' + self.reels[i].name + '_advancing',
                                                 handler=self.chime,
                                                 chime=self.config['chimes'][i])
 


### PR DESCRIPTION
Adds conssitency for the will_xx _xxing and _xxed format to the
advancement of the score reel.  Changed the event handler for chime
pulses to be the _advancing event, which triggers at the same time as
the coil advance pulse.

The only potential break is if someone is queueing custom events off the
reel_(name)_advance event as this is now _advanceD (past tense).