### PR TITLE
Fixes issue with no player_vars in config

### DIFF
--- a/mpf/core/text_ui.py
+++ b/mpf/core/text_ui.py
@@ -144,8 +144,13 @@ class TextUi(MpfController):
             self.machine.events.add_handler("mode_{}_started".format(mode.name), self._mode_change)
             self.machine.events.add_handler("mode_{}_stopped".format(mode.name), self._mode_change)
 
-        for player_var in self.machine.config['player_vars']:
-            self.machine.events.add_handler("player_{}".format(player_var), self._update_player)
+        if 'player_vars' in self.machine.config:
+            for player_var in self.machine.config['player_vars']:
+                self.machine.events.add_handler("player_{}".format(player_var), self._update_player)
+        else:
+            self.machine.events.add_handler('player_number', self._update_player)
+            self.machine.events.add_handler('player_ball', self._update_player)
+            self.machine.events.add_handler('player_score', self._update_player)
 
         self.machine.switch_controller.add_monitor(self._update_switches)
         self.machine.register_monitor("machine_vars", self._update_machine_vars)

--- a/mpf/core/text_ui.py
+++ b/mpf/core/text_ui.py
@@ -117,6 +117,9 @@ class TextUi(MpfController):
                                         self._bcp_connected)
         self.machine.events.add_handler('shutdown', self.stop)
         self.machine.add_crash_handler(self.stop)
+        self.machine.events.add_handler('player_number', self._update_player)
+        self.machine.events.add_handler('player_ball', self._update_player)
+        self.machine.events.add_handler('player_score', self._update_player)
         self.machine.events.add_handler('ball_ended',
                                         self._update_player)
 
@@ -143,14 +146,6 @@ class TextUi(MpfController):
         for mode in self.machine.modes.values():
             self.machine.events.add_handler("mode_{}_started".format(mode.name), self._mode_change)
             self.machine.events.add_handler("mode_{}_stopped".format(mode.name), self._mode_change)
-
-        if 'player_vars' in self.machine.config:
-            for player_var in self.machine.config['player_vars']:
-                self.machine.events.add_handler("player_{}".format(player_var), self._update_player)
-        else:
-            self.machine.events.add_handler('player_number', self._update_player)
-            self.machine.events.add_handler('player_ball', self._update_player)
-            self.machine.events.add_handler('player_score', self._update_player)
 
         self.machine.switch_controller.add_monitor(self._update_switches)
         self.machine.register_monitor("machine_vars", self._update_machine_vars)
@@ -332,6 +327,7 @@ class TextUi(MpfController):
 
         names = self.config.get('player_vars', player_vars.keys())
         for name in names:
+            self.machine.events.replace_handler('player_' + name, self._update_player)
             self._player_widgets.append(Label("{}: {}".format(name, player_vars[name])))
 
         self._layout_change = True


### PR DESCRIPTION
This fixes an error when there are no player_vars defined in the main config file.  It causes an error on startup.  This goes through the advanced routine  if player_vars exist, but reverts to the simplified routine of just adding the three main handlers if none are identified.