### PR TITLE
Correct delayed kick timing for OPP

### DIFF
--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -981,8 +981,8 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         if delay_ms <= 0:
             raise AssertionError("set_delayed_pulse_on_hit_rule should be used with a positive delay "
                                  "not {}".format(delay_ms))
-        if delay_ms > 255:
-            raise AssertionError("set_delayed_pulse_on_hit_rule is limited to max 255ms "
+        if delay_ms > 30:
+            raise AssertionError("set_delayed_pulse_on_hit_rule is limited to max 30ms "
                                  "(was {})".format(delay_ms))
 
         self._write_hw_rule(enable_switch, coil, use_hold=False, can_cancel=False, delay_ms=int(delay_ms))

--- a/mpf/platforms/opp/opp_coil.py
+++ b/mpf/platforms/opp/opp_coil.py
@@ -193,7 +193,7 @@ class OPPSolenoid(DriverPlatformInterface):
         msg.append(cmd)
         msg.append(pulse_len)
         if self.switch_rule and self.switch_rule.delay_ms:
-            msg.append(self.switch_rule.delay_ms)
+            msg.append(int(self.switch_rule.delay_ms / 2))
         else:
             msg.append(hold + (minimum_off << 4))
         msg.extend(OppRs232Intf.calc_crc8_whole_msg(msg))

--- a/mpf/tests/test_OPP.py
+++ b/mpf/tests/test_OPP.py
@@ -732,7 +732,7 @@ LEDs:
         self._wait_for_processing()
         self.assertFalse(self.serialMock.expected_commands)
 
-        self.serialMock.expected_commands[self._crc_message(b'\x20\x14\x00\x0b\x17\x14')] = False
+        self.serialMock.expected_commands[self._crc_message(b'\x20\x14\x00\x0b\x17\x0a')] = False
         self.machine.autofire_coils["ac_delayed_kickback"].enable()
         self._wait_for_processing()
         self.assertFalse(self.serialMock.expected_commands)


### PR DESCRIPTION
The commands for coil_pulse_delay are off by a factor of 2 in the OPP implementation. Also, OPP can only do a coil_pulse_delay up to 30ms but the code currently only checks to make sure the setting is <=255. 

This is a work in progress. Stand by.