### PR TITLE
Timer bugfix: set current player before updating tick values

### DIFF
--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -94,6 +94,7 @@ class Timer(ModeDevice):
     def device_loaded_in_mode(self, mode: Mode, player: Player):
         """Set up control events when mode is loaded."""
         del mode
+        self.player = player
         self.tick_secs = self.config['tick_interval'].evaluate([])
 
         try:
@@ -107,7 +108,6 @@ class Timer(ModeDevice):
         self.start_value = self.config['start_value'].evaluate([])
         self.ticks = self.start_value
 
-        self.player = player
         if self.config['control_events']:
             self._setup_control_events(self.config['control_events'])
 

--- a/mpf/tests/test_Timer.py
+++ b/mpf/tests/test_Timer.py
@@ -441,3 +441,40 @@ class TestTimer(MpfFakeGameTestCase):
         self.assertEqual(7, timer.ticks)
         self.advance_time_and_run(1)
         self.assertEqual(8, timer.ticks)
+
+    def test_timer_player_vars_with_multiplayer(self):
+        # add a fake player
+        self.start_two_player_game()
+
+        self.assertPlayerNumber(1)
+        self.assertBallNumber(1)
+        self.advance_time_and_run(.1)
+
+        timer = self.machine.timers['timer_start_with_game']
+        # In this test scenario, the timer is at 2 ticks by the time we get here
+        self.assertEqual(2, timer.ticks)
+
+        self.advance_time_and_run(1)
+        self.assertEqual(self.machine.game.player_list[0].mode_with_timers2_timer_start_with_game_tick, 3)
+        self.advance_time_and_run(1)
+        self.assertEqual(self.machine.game.player_list[0].mode_with_timers2_timer_start_with_game_tick, 4)
+
+        self.machine.events.post('stop_mode_with_timers2')
+        self.drain_all_balls()
+        self.advance_time_and_run()
+        self.assertPlayerNumber(2)
+        self.assertBallNumber(1)
+        self.machine.events.post('start_mode_with_timers')
+        self.advance_time_and_run(.1)
+
+        self.assertEqual(self.machine.game.player_list[0].mode_with_timers2_timer_start_with_game_tick, 4)
+        self.assertEqual(self.machine.game.player_list[1].mode_with_timers2_timer_start_with_game_tick, 2)
+        self.advance_time_and_run(1)
+        self.assertEqual(self.machine.game.player_list[0].mode_with_timers2_timer_start_with_game_tick, 4)
+        self.assertEqual(self.machine.game.player_list[1].mode_with_timers2_timer_start_with_game_tick, 3)
+        self.advance_time_and_run(1)
+        self.assertEqual(self.machine.game.player_list[0].mode_with_timers2_timer_start_with_game_tick, 4)
+        self.assertEqual(self.machine.game.player_list[1].mode_with_timers2_timer_start_with_game_tick, 4)
+        self.advance_time_and_run(1)
+        self.assertEqual(self.machine.game.player_list[0].mode_with_timers2_timer_start_with_game_tick, 4)
+        self.assertEqual(self.machine.game.player_list[1].mode_with_timers2_timer_start_with_game_tick, 5)


### PR DESCRIPTION
### SUMMARY

This PR fixes a bug in the _Timer_ class related to multiplayer games and persisted tick values. This bug would trigger variable updates and events using the wrong player number, which could create unexpected downstream effects.

### DETAILS
When added to a mode, a _Timer_ instance sets `self.player = player` to track the current player—which it uses for saving the tick values as player variables, to be consumed by many others.

There is a bug where the `self.player` value is set at the *end* of the mode setup logic, *after* the various timer values and ticks have been set. In a multiplayer game, this means that the values are being written to the _previous_ player, instead of the current one.

This PR fixes the bug by setting `self.player = player` at the top of the mode setup logic, so that all subsequent calls will use the correct player.

![tick tock](https://media.giphy.com/media/xT5LMqSHTLCKWtcQLu/giphy.gif)