### PR TITLE
Add servo support for OPP

### DIFF
--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -14,7 +14,6 @@ from mpf.core.utility_functions import Util
 from mpf.platforms.base_serial_communicator import HEX_FORMAT
 
 from mpf.platforms.interfaces.driver_platform_interface import PulseSettings, HoldSettings
-#from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
 
 from mpf.platforms.opp.opp_coil import OPPSolenoidCard
 from mpf.platforms.opp.opp_incand import OPPIncandCard

--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -14,6 +14,7 @@ from mpf.core.utility_functions import Util
 from mpf.platforms.base_serial_communicator import HEX_FORMAT
 
 from mpf.platforms.interfaces.driver_platform_interface import PulseSettings, HoldSettings
+#from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
 
 from mpf.platforms.opp.opp_coil import OPPSolenoidCard
 from mpf.platforms.opp.opp_incand import OPPIncandCard
@@ -21,9 +22,10 @@ from mpf.platforms.opp.opp_modern_lights import OPPModernLightChannel, OPPNeopix
 from mpf.platforms.opp.opp_serial_communicator import OPPSerialCommunicator, BAD_FW_VERSION
 from mpf.platforms.opp.opp_switch import OPPInputCard
 from mpf.platforms.opp.opp_switch import OPPMatrixCard
+from mpf.platforms.opp.opp_servo import OPPServo
 from mpf.platforms.opp.opp_rs232_intf import OppRs232Intf
-from mpf.core.platform import SwitchPlatform, DriverPlatform, LightsPlatform, SwitchSettings, DriverSettings, \
-    DriverConfig, SwitchConfig, RepulseSettings
+from mpf.core.platform import SwitchPlatform, DriverPlatform, LightsPlatform, ServoPlatform, \
+    SwitchSettings, DriverSettings, DriverConfig, SwitchConfig, RepulseSettings
 
 MYPY = False
 if MYPY:   # pragma: no cover
@@ -33,7 +35,7 @@ if MYPY:   # pragma: no cover
 
 
 # pylint: disable-msg=too-many-instance-attributes
-class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
+class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform, ServoPlatform):
 
     """Platform class for the OPP hardware.
 
@@ -1118,3 +1120,21 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         # are changed, so this might need to be called each time.
         if not coil.hw_driver.switches:
             coil.hw_driver.remove_switch_rule()
+
+    async def configure_servo(self, number) -> OPPServo:
+        chain_serial, card, pin_number = number.split('-')
+
+        if self.min_version[chain_serial] < 0x02020002:
+            self.raise_config_error("Servos not supported on this OPP FW version: {}.".format(
+                self.min_version[chain_serial]), 23)
+        
+        for inputs in self.opp_inputs:
+            if inputs.chain_serial == chain_serial:
+                possible_inputs = self._get_numbers(inputs.mask)
+
+        if 8 <= int(pin_number) < 16 and int(pin_number) in possible_inputs:
+            servo_number = int(pin_number) - 8
+        else:
+            self.raise_config_error("Servo unavailable at this number: {}.".format(number), 24)
+            
+        return OPPServo(chain_serial, servo_number, self)

--- a/mpf/platforms/opp/opp_servo.py
+++ b/mpf/platforms/opp/opp_servo.py
@@ -50,7 +50,7 @@ class OPPServo(ServoPlatformInterface):
                 fade_ms = 65535
 
         msg = bytearray()
-        msg.append(0x20 + int(self.chain_serial))
+        msg.append(0x20)
         msg.append(OppRs232Intf.SERIAL_LED_CMD_FADE)
         msg.append(int(servo_offset / 256))
         msg.append(int(servo_offset % 256))

--- a/mpf/platforms/opp/opp_servo.py
+++ b/mpf/platforms/opp/opp_servo.py
@@ -46,6 +46,8 @@ class OPPServo(ServoPlatformInterface):
             fade_ms = 0
         else:
             fade_ms = 600 * abs(position_numeric - self.current_position) / self.speed
+            if fade_ms > 65535:
+                fade_ms = 65535
 
         msg = bytearray()
         msg.append(0x20 + int(self.chain_serial))

--- a/mpf/platforms/opp/opp_servo.py
+++ b/mpf/platforms/opp/opp_servo.py
@@ -1,0 +1,85 @@
+"""OPP servo implementation."""
+
+from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
+from mpf.platforms.opp.opp_modern_lights import OPPModernLightChannel
+from mpf.platforms.opp.opp_rs232_intf import OppRs232Intf
+import logging
+
+MYPY = False
+if MYPY:  # pragma: no cover
+    from mpf.platforms.opp.opp import OppHardwarePlatform  # pylint: disable-msg=cyclic-import,unused-import
+
+
+class OPPServo(ServoPlatformInterface):
+    """A servo in the OPP platform."""
+
+    __slots__ = ["number", "chain_serial", "platform", "speed", "current_position"] 
+
+    def __init__(self, chain_serial, servo_num, platform: "OppHardwarePlatform"):
+        """Initialise servo."""
+        self.number = servo_num
+        self.platform = platform
+        self.chain_serial = chain_serial
+        self.speed = 0
+        self.current_position = 0
+    
+    def stop(self):
+        """Disable servo.
+        Set position to 0 to disable servo.
+        """
+        self.go_to_position(0)
+
+    def go_to_position(self, position):
+        """Set a servo position.
+        
+        position [0 to 1.0] is converted to position_numeric [0 to 255].
+        position_numeric is measured in 10us intervals, so a position_numeric of 100 is a 1ms pulse
+        and 150 is 1.5ms. A position_numeric of 0 disables the servo. Use caution with extreme
+        position values as it could cause a servo to drive to a position it cannot reach.
+        """
+
+        # convert from [0,1] to [0, 255]
+        position_numeric = int(position * 255)
+        servo_offset = 0x3000 + self.number
+
+        
+        if position_numeric == 0 or self.current_position == 0 or self.speed <= 0:
+            fade_ms = 0
+        else:
+            fade_ms = 600 * abs(position_numeric - self.current_position) / self.speed
+
+        msg = bytearray()
+        msg.append(0x20 + int(self.chain_serial))
+        msg.append(OppRs232Intf.SERIAL_LED_CMD_FADE)
+        msg.append(int(servo_offset / 256))
+        msg.append(int(servo_offset % 256))
+        msg.append(int(0))  #number of servos (high)
+        msg.append(int(1))  #number of servos (low)...only commanding one at a time.
+        msg.append(int(fade_ms / 256))
+        msg.append(int(fade_ms % 256))
+        msg.append(position_numeric)
+        msg.extend(OppRs232Intf.calc_crc8_whole_msg(msg))
+        cmd = bytes(msg)
+
+        self.platform.debug_log("Set servo position on %s: %s", self.chain_serial, "".join(" 0x%02x" % b for b in cmd))
+        
+        self.platform.send_to_processor(self.chain_serial, cmd)
+
+        self.current_position = position_numeric
+        
+
+    def set_speed_limit(self, speed_limit):
+        """Set the speed of this servo
+        
+        For the standard 1ms pulse width change to move a servo between
+        extremes, a speed of 1 will take 1 minute, and a speed of 60 would take
+        1 second. 
+        
+        A speed <= 0 is unrestricted by firmware
+        """
+        self.platform.debug_log("Change servo speed limit on %s: %s", self.chain_serial, int(speed_limit))
+
+        self.speed = speed_limit
+
+    def set_acceleration_limit(self, acceleration_limit):
+        """Not implemented."""

--- a/mpf/platforms/opp/opp_servo.py
+++ b/mpf/platforms/opp/opp_servo.py
@@ -1,7 +1,6 @@
 """OPP servo implementation."""
 
 from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
-from mpf.platforms.opp.opp_modern_lights import OPPModernLightChannel
 from mpf.platforms.opp.opp_rs232_intf import OppRs232Intf
 import logging
 

--- a/mpf/tests/machine_files/opp/config/config_stm32.yaml
+++ b/mpf/tests/machine_files/opp/config/config_stm32.yaml
@@ -60,3 +60,15 @@ lights:
   m0-63:
     number: 2-0-63
     subtype: matrix
+
+servos:
+  servo1:
+    servo_min: 0
+    servo_max: 1
+    speed_limit: 20
+    positions:
+      0.392: servo_up
+      0.784: servo_down
+    reset_position: 0.588
+    reset_events: reset_servo
+    number: 19088743-0-8

--- a/mpf/tests/test_OPP.py
+++ b/mpf/tests/test_OPP.py
@@ -161,6 +161,9 @@ class TestOPPStm32(MpfTestCase):
         self.clock.mock_serial("com2", self.serialMocks["com2"])
 
     def tearDown(self):
+        self.serialMocks["com1"].expected_commands[
+            self._crc_message(b'\x20\x40\x30\x00\x00\x01\x00\x00\x00', False)] = False
+
         for port, mock in self.serialMocks.items():
             self.assertFalse(mock.crashed, "Mock {} crashed".format(port))
         super().tearDown()


### PR DESCRIPTION
Servos can be driven from OPP versions 2.2.0.2 and later. This PR adds support for that. Position and speed limiting are implemented. Acceleration is not something the firmware supports. 

Position has a 10us resolution. Speed is configured so a 1ms pulse transition--often considered "full range" on a servo--will take 1 minute with a speed of 1. The same move with a speed of 60 will take 1 second. Setting the speed <= 0 leads to step changes on position command (unrestricted speed).

Individual servo channels must be enabled in the OPP config or the pin will just act like an input.