### PR TITLE
EventPlayer: Bugfix multiple conditionals

### DIFF
--- a/mpf/config_players/event_player.py
+++ b/mpf/config_players/event_player.py
@@ -47,15 +47,16 @@ class EventPlayer(FlatConfigPlayer):
         if not value:
             return
 
-        for event, s in settings.items():
-            if s["condition"] and not s["condition"].evaluate({}):
-                continue
+        for event, event_configs in settings.items():
+            for s in event_configs:
+                if s["condition"] and not s["condition"].evaluate({}):
+                    continue
 
-            if s["number"] is not None:
-                self.delay.add(callback=self._post_event, ms=s["number"],
-                               event=event, priority=s["priority"], params=s["params"])
-            else:
-                self._post_event(event, s["priority"], s["params"])
+                if s["number"] is not None:
+                    self.delay.add(callback=self._post_event, ms=s["number"],
+                                event=event, priority=s["priority"], params=s["params"])
+                else:
+                    self._post_event(event, s["priority"], s["params"])
 
     def _post_event(self, event, priority, params, **kwargs):
         if "(" in event:

--- a/mpf/config_players/event_player.py
+++ b/mpf/config_players/event_player.py
@@ -31,7 +31,7 @@ class EventPlayer(FlatConfigPlayer):
 
                 if s["number"] is not None:
                     self.delay.add(callback=self._post_event, ms=s["number"],
-                                event=event, priority=s["priority"], params=s["params"], **kwargs)
+                                   event=event, priority=s["priority"], params=s["params"], **kwargs)
                 else:
                     self._post_event(event, s["priority"], s["params"], **kwargs)
 
@@ -75,7 +75,7 @@ class EventPlayer(FlatConfigPlayer):
         final_config = {}
         for event, s in config.items():
             if "(" in event:
-                if not event in final_config:
+                if event not in final_config:
                     final_config[event] = []
                 final_config[event].append({
                     "condition": None,
@@ -85,7 +85,7 @@ class EventPlayer(FlatConfigPlayer):
                 })
             else:
                 var = self._parse_and_validate_conditional(event, name)
-                if not var.name in final_config:
+                if var.name not in final_config:
                     final_config[var.name] = []
                 final_config[var.name].append({
                     "condition": var.condition,

--- a/mpf/tests/machine_files/event_players/config/test_event_player.yaml
+++ b/mpf/tests/machine_files/event_players/config/test_event_player.yaml
@@ -35,6 +35,13 @@ event_player:
         - event_always
         - event_if_modeactive{mode.mode1.active}
         - event_if_modestopping{mode.mode1.stopping}
+    test_conditional_multiples:
+      conditional_response{value==0}:
+        amount: zero
+      conditional_response{value==1}:
+        amount: one
+      conditional_response{value>1}:
+        amount: greater
     play_placeholder_event:
       - my_event_(machine.test)_123
     play_placeholder_args:

--- a/mpf/tests/test_EventPlayer.py
+++ b/mpf/tests/test_EventPlayer.py
@@ -144,6 +144,19 @@ class TestEventPlayer(MpfTestCase):
         self.assertEqual(1, self._events["event_if_modeactive"])
         self.assertEqual(1, self._events["event_if_modestopping"])
 
+    def test_conditional_multiples(self):
+        self.mock_event("conditional_response")
+        self.post_event_with_params("test_conditional_multiples", value=-8)
+        self.assertEqual(0, self._events["conditional_response"])
+        self.post_event_with_params("test_conditional_multiples", value=1)
+        self.assertEqual(1, self._events["conditional_response"])
+        self.assertEqual({"amount": "one", "priority": 0}, self._last_event_kwargs['conditional_response'])
+
+        self.post_event_with_params("test_conditional_multiples", value=20)
+        self.assertEqual({"amount": "greater", "priority": 0}, self._last_event_kwargs['conditional_response'])
+        self.post_event_with_params("test_conditional_multiples", value=0)
+        self.assertEqual({"amount": "zero", "priority": 0}, self._last_event_kwargs['conditional_response'])
+
     def test_event_time_delays(self):
         self.mock_event('td1')
         self.mock_event('td2')


### PR DESCRIPTION
### SUMMARY

This PR fixes a regression where an EventPlayer configuration meant to post the same event under different conditions would only successfully post when the _last_ condition was true.

### DETAILS

Performance optimizations in https://github.com/missionpinball/mpf/commit/aa725f21dfbc749bddab4ffab576eea8c75b9275 restructured the parsing of EventPlayer configs to initialization, and uses a dictionary to store the configs for each event to be posted. By moving from an iteration to a dict lookup, runtime performance is improved—however the same event appearing multiple times (with different conditions) would be overwritten because the dictionary key is only the event itself, _not_ the conditions attached.

This PR tweaks the behavior to store the dict value as a *list* of configs, rather than a single config. When an event is to be posted, the list of configs is iterated and evaluated.

**Performance Implications**
I did a `timeit` comparison between (1) always making the dict value a list and iterating, even when there's only one entry, and (2) checking whether the dict value is a list and only iterating if it is. The results were not significantly different, but the all-lists approach performed slightly better.
```
def test_lists():
    test_var = None
    for event, items in dict_only_lists.items():
        for item in items:
            test_var = item["name"]

def test_mixed():
    test_var = None
    for event, s in dict_mixed.items():
        if isinstance(s, list):
            for item in s:
                test_var = item["name"]
        else:
            test_var = s["name"]
```
```
Checking for 10,000 iterations
 - Every value a list: 0.005966
 - Mixed lists and configs: 0.006381
Checking for 50,000 iterations
 - Every value a list: 0.024976
 - Mixed lists and configs: 0.025874
Checking for 100,000 iterations
 - Every value a list: 0.045673
 - Mixed lists and configs: 0.051380
```

I chose the all-list approach not really because of the performance difference, but because it's easier and more predictable code when all values are the same shape.

### TESTING
I wrote some tests to cover the scenario, and verified that they failed in the current dev and passed on this branch. I also ran _Mass Effect 2_ against this branch and verified that the regressions no longer reproed.

![Duplicates!](https://media.giphy.com/media/9S706ievhjXVfG9s9Q/giphy.gif)