### PR TITLE
Adds speed option to achievement shows

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -61,6 +61,7 @@ achievements:
     show_when_disabled: single|machine(shows)|None
     show_when_selected: single|machine(shows)|None
     sync_ms: single|int|None
+    speed: single|float|1
 
 animations:
     __valid_in__: machine, mode                 # todo add to validator

--- a/mpf/devices/achievement.py
+++ b/mpf/devices/achievement.py
@@ -259,12 +259,13 @@ class Achievement(ModeDevice):
 
         if show:
             self.debug_log('Playing show: %s. Priority: %s. Loops: -1. '
-                           'Show tokens: %s', show.name, self._mode.priority,
-                           self.config['show_tokens'])
+                           'Show tokens: %s', 'Speed: %s', show.name, self._mode.priority,
+                           self.config['show_tokens'], self.config['speed'])
 
             self._show = show.play(
                 priority=self._mode.priority,
                 loops=-1, sync_ms=self.config['sync_ms'],
+                speed=self.config['speed'],
                 show_tokens=self.config['show_tokens'])
 
     def device_loaded_in_mode(self, mode: Mode, player: Player):


### PR DESCRIPTION
Allows the user to set a speed parameter for shows that are played for
any of the achievement stages.