### PR TITLE
Fix direct fade not stopping running corutine

### DIFF
--- a/mpf/platforms/interfaces/light_platform_interface.py
+++ b/mpf/platforms/interfaces/light_platform_interface.py
@@ -97,6 +97,7 @@ class LightPlatformDirectFade(LightPlatformInterface, metaclass=abc.ABCMeta):
         else:
             if self.task:
                 self.task.cancel()
+                self.task = None
             self.set_brightness_and_fade(target_brightness, max(fade_ms, 0))
 
     async def _fade(self, start_brightness, start_time, target_brightness, target_time):

--- a/mpf/platforms/interfaces/light_platform_interface.py
+++ b/mpf/platforms/interfaces/light_platform_interface.py
@@ -95,6 +95,8 @@ class LightPlatformDirectFade(LightPlatformInterface, metaclass=abc.ABCMeta):
             self.task = self.loop.create_task(self._fade(start_brightness, start_time, target_brightness, target_time))
             self.task.add_done_callback(Util.raise_exceptions)
         else:
+            if self.task:
+                self.task.cancel()
             self.set_brightness_and_fade(target_brightness, max(fade_ms, 0))
 
     async def _fade(self, start_brightness, start_time, target_brightness, target_time):


### PR DESCRIPTION
The direct fade class does not stop running corutines when a light update that is able to run in a single `set_brightness_and_fade` call is executed.
This causes "race" conditions, ending up with unpredictable and wrong behavior.

I've only tested it on my own machine and it works just like the mpf monitor suggests (which was not true previously).