### PR TITLE
Bugfix: FAST timed_enable hold ms/pwm inverted

### DIFF
--- a/mpf/platforms/fast/fast_driver.py
+++ b/mpf/platforms/fast/fast_driver.py
@@ -206,8 +206,8 @@ class FASTDriver(DriverPlatformInterface):
                 self.number,
                 hex_ms_string,
                 self.get_pwm_for_cmd(pulse_settings.power),
-                hold_power,
-                hold_ms
+                hold_ms,
+                hold_power
             )
             self.send(cmd)
         else:

--- a/mpf/tests/test_Fast.py
+++ b/mpf/tests/test_Fast.py
@@ -360,7 +360,7 @@ Board 3 - Model: FP-I/O-1616-2    Firmware: 02.00 Switches: 16 Drivers: 16
     def _test_timed_enable(self):
         # enable command
         self.net_cpu.expected_commands = {
-            "DL:16,89,00,10,14,FF,88,C8,00": "DL:P"
+            "DL:16,89,00,10,14,FF,C8,88,00": "DL:P"
         }
         self.machine.coils["c_timed_enable"].timed_enable()
         self.advance_time_and_run(.1)
@@ -369,7 +369,7 @@ Board 3 - Model: FP-I/O-1616-2    Firmware: 02.00 Switches: 16 Drivers: 16
     def _test_default_timed_enable(self):
         # enable command
         self.net_cpu.expected_commands = {
-            "DL:17,89,00,10,14,FF,88,C8,00": "DL:P"
+            "DL:17,89,00,10,14,FF,C8,88,00": "DL:P"
         }
         self.machine.coils["c_default_timed_enable"].pulse()
         self.advance_time_and_run(.1)

--- a/mpf/tests/test_Fast_V1.py
+++ b/mpf/tests/test_Fast_V1.py
@@ -173,7 +173,7 @@ Board 3 - Model: FP-I/O-1616-2    Firmware: 01.00 Switches: 16 Drivers: 16
     def _test_timed_enable(self):
         # enable command
         self.net_cpu.expected_commands = {
-            "DN:16,89,00,10,14,FF,88,C8,00": "DN:P"
+            "DN:16,89,00,10,14,FF,C8,88,00": "DN:P"
         }
         self.machine.coils["c_timed_enable"].timed_enable()
         self.advance_time_and_run(.1)
@@ -182,7 +182,7 @@ Board 3 - Model: FP-I/O-1616-2    Firmware: 01.00 Switches: 16 Drivers: 16
     def _test_default_timed_enable(self):
         # enable command
         self.net_cpu.expected_commands = {
-            "DN:17,89,00,10,14,FF,88,C8,00": "DN:P"
+            "DN:17,89,00,10,14,FF,C8,88,00": "DN:P"
         }
         self.machine.coils["c_default_timed_enable"].pulse()
         self.advance_time_and_run(.1)


### PR DESCRIPTION
This PR fixes a bug for `timed_enable` pulses on the FAST platform.

The original implementation incorrectly posted the hold PWM argument before the hold duration, but according to the FAST Protocol documentation, the duration should come _before_ the PWM.

```
[DL/DN]:<DRIVER_ID>,<TRIGGER>,<SWITCH_ID>,<10>,<PWM1_ONTIME>,<PWM1>,<PWM2_ONTIME>,<PWM2>,<REST_TIME><CR>
```

I don't know why I inverted the values initially, but now they'll be correct.

![I was inverted](https://64.media.tumblr.com/e3d63294936eb1f52d144cef092357d1/tumblr_puveawn7YK1qg946so1_r1_500.gif)
