### PR TITLE
Add "use_dots_for_commas" setting to segment displays

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1348,6 +1348,7 @@ segment_displays:
     size: single|int|7
     integrated_dots: single|bool|false
     integrated_commas: single|bool|false
+    use_dots_for_commas: single|bool|false
     default_color: list|color|white
     default_transition_update_hz: single|float_or_token|30
     platform_settings: single|dict|None

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -100,7 +100,8 @@ class SegmentDisplay(SystemWideDevice):
                                  "See error above.".format(self.name)) from ex
 
         text = SegmentDisplayText.from_str("", self.size, self.config['integrated_dots'],
-                                           self.config['integrated_commas'], self._default_color)
+                                           self.config['integrated_commas'], self.config['use_dots_for_commas'],
+                                           self._default_color)
         self._update_display(SegmentDisplayState(text, FlashingType.NO_FLASH, ''))
 
     def add_virtual_connector(self, virtual_connector):
@@ -240,6 +241,7 @@ class SegmentDisplay(SystemWideDevice):
             transition = TransitionManager.get_transition(self.size,
                                                           self.config['integrated_dots'],
                                                           self.config['integrated_commas'],
+                                                          self.config['use_dots_for_commas'],
                                                           transition_config)
             if previous_text_stack_entry:
                 previous_text = previous_text_stack_entry.text
@@ -278,7 +280,8 @@ class SegmentDisplay(SystemWideDevice):
 
             # update the display
             text = SegmentDisplayText.from_str(new_text, self.size, self.config['integrated_dots'],
-                                               self.config['integrated_commas'], colors)
+                                               self.config['integrated_commas'], self.config['use_dots_for_commas'],
+                                               colors)
             self._update_display(SegmentDisplayState(text, flashing, flash_mask))
 
     def _current_placeholder_changed(self, future=None, **kwargs) -> None:
@@ -291,7 +294,8 @@ class SegmentDisplay(SystemWideDevice):
         new_text, self._current_placeholder_future = self._current_placeholder.evaluate_and_subscribe({})
         self._current_placeholder_future.add_done_callback(self._current_placeholder_changed)
         text = SegmentDisplayText.from_str(new_text, self.size, self.config['integrated_dots'],
-                                           self.config['integrated_commas'], self._current_state.text.get_colors())
+                                           self.config['integrated_commas'], self.config['use_dots_for_commas'],
+                                           self._current_state.text.get_colors())
         self._update_display(SegmentDisplayState(text, self._current_state.flashing,
                                                  self._current_state.flash_mask))
 
@@ -304,7 +308,8 @@ class SegmentDisplay(SystemWideDevice):
         assert isinstance(colors, list)
         assert self.hw_display is not None
         text = SegmentDisplayText.from_str(self._current_state.text.convert_to_str(), self.size,
-                                           self.config['integrated_dots'], self.config['integrated_commas'], colors)
+                                           self.config['integrated_dots'], self.config['integrated_commas'],
+                                           self.config['use_dots_for_commas'], colors)
         self._update_display(SegmentDisplayState(text,
                                                  self._current_state.flashing,
                                                  self._current_state.flash_mask))

--- a/mpf/devices/segment_display/transition_manager.py
+++ b/mpf/devices/segment_display/transition_manager.py
@@ -19,12 +19,14 @@ class TransitionManager:
     __slots__ = []
 
     @staticmethod
-    def get_transition(output_length: int, collapse_dots: bool, collapse_commas: bool, transition_config=None):
+    def get_transition(output_length: int, collapse_dots: bool, collapse_commas: bool, use_dots_for_commas: bool,
+                       transition_config=None):
         """Create a transition instance based on the specified configuration."""
         if transition_config:
             config = transition_config.copy()
             config.pop('type')
-            return TRANSITIONS[transition_config['type']](output_length, collapse_dots, collapse_commas, config)
+            return TRANSITIONS[transition_config['type']](output_length, collapse_dots, collapse_commas, 
+                               use_dots_for_commas, config)
 
         return None
 

--- a/mpf/devices/segment_display/transitions.py
+++ b/mpf/devices/segment_display/transitions.py
@@ -14,14 +14,15 @@ class TransitionBase(metaclass=abc.ABCMeta):
 
     """Base class for text transitions in segment displays."""
 
-    __slots__ = ["output_length", "config", "collapse_dots", "collapse_commas"]
+    __slots__ = ["output_length", "config", "collapse_dots", "collapse_commas", "use_dots_for_commas"]
 
-    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, use_dots_for_commas: bool, config: dict) -> None:
         """Initialize the transition."""
         self.output_length = output_length
         self.config = config
         self.collapse_dots = collapse_dots
         self.collapse_commas = collapse_commas
+        self.use_dots_for_commas = use_dots_for_commas
 
         for key, value in config.items():
             if hasattr(self, key):
@@ -94,19 +95,20 @@ class NoTransition(TransitionBase):
             raise AssertionError(STEP_OUT_OF_RANGE_ERROR)
 
         return SegmentDisplayText.from_str(new_text, self.output_length, self.collapse_dots, self.collapse_commas,
-                                           new_colors)
+                                           self.use_dots_for_commas, new_colors)
 
 
 class PushTransition(TransitionBase):
 
     """Segment display push transition effect."""
 
-    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, use_dots_for_commas: bool, 
+                 config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
         self.text = None
         self.text_color = None
-        super().__init__(output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, use_dots_for_commas, config)
 
         if self.text is None:
             self.text = ''
@@ -124,9 +126,10 @@ class PushTransition(TransitionBase):
             raise AssertionError(STEP_OUT_OF_RANGE_ERROR)
 
         current_display_text = SegmentDisplayText.from_str(current_text, self.output_length, self.collapse_dots,
-                                                           self.collapse_commas, current_colors)
+                                                           self.collapse_commas, self.use_dots_for_commas, 
+                                                           current_colors)
         new_display_text = SegmentDisplayText.from_str(new_text, self.output_length, self.collapse_dots,
-                                                       self.collapse_commas, new_colors)
+                                                       self.collapse_commas, self.use_dots_for_commas, new_colors)
 
         if self.text:
             if new_colors and not self.text_color:
@@ -134,9 +137,10 @@ class PushTransition(TransitionBase):
             else:
                 text_color = self.text_color
             transition_text = SegmentDisplayText.from_str(self.text, len(self.text), self.collapse_dots,
-                                                          self.collapse_commas, text_color)
+                                                          self.collapse_commas, self.use_dots_for_commas, text_color)
         else:
-            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas)
+            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas, 
+                                                          self.use_dots_for_commas)
 
         if self.direction == 'right':
             temp_list = new_display_text
@@ -159,12 +163,13 @@ class CoverTransition(TransitionBase):
 
     """Segment display cover transition effect."""
 
-    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, use_dots_for_commas: bool,
+                 config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
         self.text = None
         self.text_color = None
-        super().__init__(output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, use_dots_for_commas, config)
 
         if self.text is None:
             self.text = ''
@@ -182,9 +187,10 @@ class CoverTransition(TransitionBase):
             raise AssertionError(STEP_OUT_OF_RANGE_ERROR)
 
         current_display_text = SegmentDisplayText.from_str(current_text, self.output_length, self.collapse_dots,
-                                                           self.collapse_commas, current_colors)
+                                                           self.collapse_commas, self.use_dots_for_commas, 
+                                                           current_colors)
         new_display_text = SegmentDisplayText.from_str(new_text, self.output_length, self.collapse_dots,
-                                                       self.collapse_commas, new_colors)
+                                                       self.collapse_commas, self.use_dots_for_commas, new_colors)
 
         if self.text:
             if new_colors and not self.text_color:
@@ -192,9 +198,10 @@ class CoverTransition(TransitionBase):
             else:
                 text_color = self.text_color
             transition_text = SegmentDisplayText.from_str(self.text, len(self.text), self.collapse_dots,
-                                                          self.collapse_commas, text_color)
+                                                          self.collapse_commas, self.use_dots_for_commas, text_color)
         else:
-            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas)
+            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas, 
+                                                          self.use_dots_for_commas,)
 
         if self.direction == 'right':
             new_extended_display_text = new_display_text
@@ -227,12 +234,13 @@ class UncoverTransition(TransitionBase):
 
     """Segment display uncover transition effect."""
 
-    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, use_dots_for_commas: bool,
+                 config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
         self.text = None
         self.text_color = None
-        super().__init__(output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, use_dots_for_commas, config)
 
         if self.text is None:
             self.text = ''
@@ -250,9 +258,10 @@ class UncoverTransition(TransitionBase):
             raise AssertionError(STEP_OUT_OF_RANGE_ERROR)
 
         current_display_text = SegmentDisplayText.from_str(current_text, self.output_length, self.collapse_dots,
-                                                           self.collapse_commas, current_colors)
+                                                           self.collapse_commas, self.use_dots_for_commas, 
+                                                           current_colors)
         new_display_text = SegmentDisplayText.from_str(new_text, self.output_length, self.collapse_dots,
-                                                       self.collapse_commas, new_colors)
+                                                       self.collapse_commas, self.use_dots_for_commas, new_colors)
 
         if self.text:
             if new_colors and not self.text_color:
@@ -260,9 +269,10 @@ class UncoverTransition(TransitionBase):
             else:
                 text_color = self.text_color
             transition_text = SegmentDisplayText.from_str(self.text, len(self.text), self.collapse_dots,
-                                                          self.collapse_commas, text_color)
+                                                          self.collapse_commas, self.use_dots_for_commas, text_color)
         else:
-            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas)
+            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas, 
+                                                          self.use_dots_for_commas)
 
         if self.direction == 'right':
             current_extended_display_text = transition_text
@@ -295,12 +305,13 @@ class WipeTransition(TransitionBase):
 
     """Segment display wipe transition effect."""
 
-    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, use_dots_for_commas: bool,
+                 config: dict) -> None:
         """Class initializer."""
         self.direction = 'right'
         self.text = None
         self.text_color = None
-        super().__init__(output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, use_dots_for_commas, config)
 
         if self.text is None:
             self.text = ''
@@ -318,9 +329,10 @@ class WipeTransition(TransitionBase):
             raise AssertionError(STEP_OUT_OF_RANGE_ERROR)
 
         current_display_text = SegmentDisplayText.from_str(current_text, self.output_length, self.collapse_dots,
-                                                           self.collapse_commas, current_colors)
+                                                           self.collapse_commas, self.use_dots_for_commas,
+                                                           current_colors)
         new_display_text = SegmentDisplayText.from_str(new_text, self.output_length, self.collapse_dots,
-                                                       self.collapse_commas, new_colors)
+                                                       self.collapse_commas, self.use_dots_for_commas, new_colors)
 
         if self.text:
             if new_colors and not self.text_color:
@@ -328,9 +340,10 @@ class WipeTransition(TransitionBase):
             else:
                 text_color = self.text_color
             transition_text = SegmentDisplayText.from_str(self.text, len(self.text), self.collapse_dots,
-                                                          self.collapse_commas, text_color)
+                                                          self.collapse_commas, self.use_dots_for_commas, text_color)
         else:
-            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas)
+            transition_text = UncoloredSegmentDisplayText([], self.collapse_dots, self.collapse_commas, 
+                                                          self.use_dots_for_commas)
 
         if self.direction == 'right':
             if step < len(self.text):
@@ -367,11 +380,12 @@ class SplitTransition(TransitionBase):
 
     """Segment display split transition effect."""
 
-    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, config: dict) -> None:
+    def __init__(self, output_length: int, collapse_dots: bool, collapse_commas: bool, use_dots_for_commas: bool,
+                 config: dict) -> None:
         """Class initializer."""
         self.direction = 'out'
         self.mode = 'push'
-        super().__init__(output_length, collapse_dots, collapse_commas, config)
+        super().__init__(output_length, collapse_dots, collapse_commas, use_dots_for_commas, config)
 
     def get_step_count(self):
         """Return the total number of steps required for the transition."""
@@ -386,9 +400,10 @@ class SplitTransition(TransitionBase):
             raise AssertionError(STEP_OUT_OF_RANGE_ERROR)
 
         current_display_text = SegmentDisplayText.from_str(current_text, self.output_length, self.collapse_dots,
-                                                           self.collapse_commas, current_colors)
+                                                           self.collapse_commas, self.use_dots_for_commas,
+                                                           current_colors)
         new_display_text = SegmentDisplayText.from_str(new_text, self.output_length, self.collapse_dots,
-                                                       self.collapse_commas, new_colors)
+                                                       self.collapse_commas, self.use_dots_for_commas, new_colors)
 
         if self.mode == 'push':
             if self.direction == 'out':

--- a/mpf/tests/test_SegmentDisplay.py
+++ b/mpf/tests/test_SegmentDisplay.py
@@ -317,7 +317,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
            "._set_text")
     def test_software_flash_platform_interface(self, mock_set_text):
         display = SegmentDisplaySoftwareFlashPlatformInterface("1")
-        text = SegmentDisplayText.from_str("12345 ABCDE", 10, True, True)
+        text = SegmentDisplayText.from_str("12345 ABCDE", 10, True, True, False)
         display.set_text(text, FlashingType.NO_FLASH, '')
         display.set_software_flash(False)
         self.assertTrue(mock_set_text.called)
@@ -328,21 +328,21 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         display.set_text(text, FlashingType.FLASH_ALL, '')
         display.set_software_flash(False)
         self.assertTrue(mock_set_text.called)
-        mock_set_text.assert_has_calls([call(SegmentDisplayText.from_str("", 10, True, True))])
+        mock_set_text.assert_has_calls([call(SegmentDisplayText.from_str("", 10, True, True, False))])
         display.set_software_flash(True)
         mock_set_text.reset_mock()
 
         display.set_text(text, FlashingType.FLASH_MATCH, '')
         display.set_software_flash(False)
         self.assertTrue(mock_set_text.called)
-        mock_set_text.assert_has_calls([call(SegmentDisplayText.from_str("12345 ABC  ", 10, True, True))])
+        mock_set_text.assert_has_calls([call(SegmentDisplayText.from_str("12345 ABC  ", 10, True, True, False))])
         display.set_software_flash(True)
         mock_set_text.reset_mock()
 
         display.set_text(text, FlashingType.FLASH_MASK, "FFFFF______")
         display.set_software_flash(False)
         self.assertTrue(mock_set_text.called)
-        mock_set_text.assert_has_calls([call(SegmentDisplayText.from_str("      ABCDE", 10, True, True))])
+        mock_set_text.assert_has_calls([call(SegmentDisplayText.from_str("      ABCDE", 10, True, True, False))])
         display.set_software_flash(True)
         mock_set_text.reset_mock()
 
@@ -350,25 +350,25 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         """Test the SegmentDisplayText class."""
 
         # text equal to display length
-        test_text = SegmentDisplayText.from_str("test", 4, False, False)
+        test_text = SegmentDisplayText.from_str("test", 4, False, False, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(4, len(test_text))
         self.assertEqual("test", test_text.convert_to_str())
 
         # text longer than display
-        test_text = SegmentDisplayText.from_str("testing", 4, False, False)
+        test_text = SegmentDisplayText.from_str("testing", 4, False, False, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(4, len(test_text))
         self.assertEqual("ting", test_text.convert_to_str())
 
         # text shorter than display
-        test_text = SegmentDisplayText.from_str("test", 7, False, False)
+        test_text = SegmentDisplayText.from_str("test", 7, False, False, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(7, len(test_text))
         self.assertEqual("   test", test_text.convert_to_str())
 
         # collapse commas
-        test_text = SegmentDisplayText.from_str("25,000", 7, False, True)
+        test_text = SegmentDisplayText.from_str("25,000", 7, False, True, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(7, len(test_text))
         self.assertTrue(test_text[3].comma)
@@ -377,8 +377,28 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertEqual(ord("0"), test_text[4].char_code)
         self.assertEqual("  25,000", test_text.convert_to_str())
 
+        # collapse commas and use dots for commas
+        test_text = SegmentDisplayText.from_str("25,000", 7, False, True, True)
+        self.assertTrue(isinstance(test_text, SegmentDisplayText))
+        self.assertEqual(7, len(test_text))
+        self.assertTrue(test_text[3].dot)
+        self.assertEqual(ord("5"), test_text[3].char_code)
+        self.assertFalse(test_text[4].dot)
+        self.assertEqual(ord("0"), test_text[4].char_code)
+        self.assertEqual("  25.000", test_text.convert_to_str())
+
+        # use dots for commas
+        test_text = SegmentDisplayText.from_str("25,000", 7, False, False, True)
+        self.assertTrue(isinstance(test_text, SegmentDisplayText))
+        self.assertEqual(7, len(test_text))
+        self.assertTrue(test_text[3].dot)
+        self.assertEqual(ord("5"), test_text[3].char_code)
+        self.assertFalse(test_text[4].dot)
+        self.assertEqual(ord("0"), test_text[4].char_code)
+        self.assertEqual("  25.000", test_text.convert_to_str())
+
         # do not collapse commas
-        test_text = SegmentDisplayText.from_str("25,000", 7, False, False)
+        test_text = SegmentDisplayText.from_str("25,000", 7, False, False, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(7, len(test_text))
         self.assertFalse(test_text[2].comma)
@@ -388,7 +408,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertEqual(" 25,000", test_text.convert_to_str())
 
         # collapse dots
-        test_text = SegmentDisplayText.from_str("25.000", 7, True, False)
+        test_text = SegmentDisplayText.from_str("25.000", 7, True, False, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(7, len(test_text))
         self.assertTrue(test_text[3].dot)
@@ -398,7 +418,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertEqual("  25.000", test_text.convert_to_str())
 
         # do not collapse dots
-        test_text = SegmentDisplayText.from_str("25.000", 7, False, False)
+        test_text = SegmentDisplayText.from_str("25.000", 7, False, False, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(7, len(test_text))
         self.assertFalse(test_text[2].dot)
@@ -408,14 +428,14 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertEqual(" 25.000", test_text.convert_to_str())
 
         # no colors
-        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False)
+        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False, False)
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(5, len(test_text))
         colors = test_text.get_colors()
         self.assertIsNone(colors)
 
         # single color
-        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False, [RGBColor("ffffff")])
+        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False, False, [RGBColor("ffffff")])
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(5, len(test_text))
         colors = test_text.get_colors()
@@ -423,7 +443,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertEqual(5, colors.count(RGBColor("ffffff")))
 
         # multiple colors
-        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False,
+        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False, False,
                                                 [RGBColor("white"), RGBColor("red"), RGBColor("green"),
                                                  RGBColor("blue"),
                                                  RGBColor("cyan")])
@@ -435,7 +455,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                           RGBColor("blue"), RGBColor("cyan")], colors)
 
         # multiple colors (fewer colors than letters)
-        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False,
+        test_text = SegmentDisplayText.from_str("COLOR", 5, False, False, False,
                                                 [RGBColor("white"), RGBColor("red")])
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(5, len(test_text))
@@ -445,7 +465,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                           RGBColor("red"), RGBColor("red")], colors)
 
         # multiple colors (fewer colors than letters and fewer letters than characters)
-        test_text = SegmentDisplayText.from_str("COLOR", 8, False, False,
+        test_text = SegmentDisplayText.from_str("COLOR", 8, False, False, False,
                                                 [RGBColor("white"), RGBColor("red")])
         self.assertTrue(isinstance(test_text, SegmentDisplayText))
         self.assertEqual(8, len(test_text))
@@ -466,7 +486,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
     def _test_no_transition(self):
         """Test no transition."""
         # no transition (with colors)
-        transition = NoTransition(5, False, False, {'direction': 'right'})
+        transition = NoTransition(5, False, False, False, {'direction': 'right'})
         self.assertEqual(1, transition.get_step_count())
         self.assertEqual("ABCDE",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -480,7 +500,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
     def _test_push_transition(self):
         """Test push transition."""
         # push right (with colors)
-        transition = PushTransition(5, False, False, {'direction': 'right'})
+        transition = PushTransition(5, False, False, False, {'direction': 'right'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("E1234",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -514,7 +534,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                                                         [RGBColor("green")]).get_colors())
 
         # push left
-        transition = PushTransition(5, False, False, {'direction': 'left'})
+        transition = PushTransition(5, False, False, False, {'direction': 'left'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("2345A",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -528,7 +548,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "12345", "ABCDE").convert_to_str())
 
         # push right (display larger than text)
-        transition = PushTransition(8, False, False, {'direction': 'right'})
+        transition = PushTransition(8, False, False, False, {'direction': 'right'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual("E   1234",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -548,7 +568,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(7, "12345", "ABCDE").convert_to_str())
 
         # push left (display larger than text)
-        transition = PushTransition(8, False, False, {'direction': 'left'})
+        transition = PushTransition(8, False, False, False, {'direction': 'left'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual("  12345 ",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -568,7 +588,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(7, "12345", "ABCDE").convert_to_str())
 
         # push right (collapse commas)
-        transition = PushTransition(5, False, True, {'direction': 'right'})
+        transition = PushTransition(5, False, True, False, {'direction': 'right'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("0 1,00",
                          transition.get_transition_step(0, "1,000", "25,000").convert_to_str())
@@ -582,7 +602,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "1,000", "25,000").convert_to_str())
 
         # push left (collapse commas)
-        transition = PushTransition(5, False, True, {'direction': 'left'})
+        transition = PushTransition(5, False, True, False, {'direction': 'left'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("1,0002",
                          transition.get_transition_step(0, "1,000", "25,000").convert_to_str())
@@ -596,7 +616,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "1,000", "25,000").convert_to_str())
 
         # push right (with text and colors)
-        transition = PushTransition(5, False, False,
+        transition = PushTransition(5, False, False, False,
                                     {'direction': 'right', 'text': '-->', 'text_color': [RGBColor("yellow")]})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual(">1234",
@@ -649,7 +669,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                                                         [RGBColor("green")]).get_colors())
 
         # push right (with text that has color = None and colors)
-        transition = PushTransition(5, False, False,
+        transition = PushTransition(5, False, False, False,
                                     {'direction': 'right', 'text': '-->', 'text_color': None})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual(">1234",
@@ -702,7 +722,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                                                         [RGBColor("green")]).get_colors())
 
         # push left (with text)
-        transition = PushTransition(5, False, False, {'direction': 'left', 'text': "<--"})
+        transition = PushTransition(5, False, False, False, {'direction': 'left', 'text': "<--"})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual("2345<",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -724,7 +744,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
     def _test_cover_transition(self):
         """Test cover transition."""
         # cover right
-        transition = CoverTransition(5, False, False, {'direction': 'right'})
+        transition = CoverTransition(5, False, False, False, {'direction': 'right'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("E2345",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -738,7 +758,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "12345", "ABCDE").convert_to_str())
 
         # cover right (with text)
-        transition = CoverTransition(5, False, False, {'direction': 'right', 'text': '-->'})
+        transition = CoverTransition(5, False, False, False, {'direction': 'right', 'text': '-->'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual(">2345",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -758,7 +778,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(7, "12345", "ABCDE").convert_to_str())
 
         # cover left
-        transition = CoverTransition(5, False, False, {'direction': 'left'})
+        transition = CoverTransition(5, False, False, False, {'direction': 'left'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("1234A",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -772,7 +792,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "12345", "ABCDE").convert_to_str())
 
         # cover left (with text)
-        transition = CoverTransition(5, False, False, {'direction': 'left', 'text': '<--'})
+        transition = CoverTransition(5, False, False, False, {'direction': 'left', 'text': '<--'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual("1234<",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -794,7 +814,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
     def _test_uncover_transition(self):
         """Test uncover transition."""
         # uncover right
-        transition = UncoverTransition(5, False, False, {'direction': 'right'})
+        transition = UncoverTransition(5, False, False, False, {'direction': 'right'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("A1234",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -808,7 +828,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "12345", "ABCDE").convert_to_str())
 
         # uncover right (with text)
-        transition = UncoverTransition(5, False, False, {'direction': 'right', 'text': '-->'})
+        transition = UncoverTransition(5, False, False, False, {'direction': 'right', 'text': '-->'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual(">1234",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -828,7 +848,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(7, "12345", "ABCDE").convert_to_str())
 
         # uncover left
-        transition = UncoverTransition(5, False, False, {'direction': 'left'})
+        transition = UncoverTransition(5, False, False, False, {'direction': 'left'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("2345E",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -842,7 +862,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "12345", "ABCDE").convert_to_str())
 
         # uncover left (with text)
-        transition = UncoverTransition(5, False, False, {'direction': 'left', 'text': '<--'})
+        transition = UncoverTransition(5, False, False, False, {'direction': 'left', 'text': '<--'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual("2345<",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -864,7 +884,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
     def _test_wipe_transition(self):
         """Test wipe transition."""
         # wipe right
-        transition = WipeTransition(5, False, False, {'direction': 'right'})
+        transition = WipeTransition(5, False, False, False, {'direction': 'right'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("A2345",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -878,7 +898,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "12345", "ABCDE").convert_to_str())
 
         # wipe right (with text)
-        transition = WipeTransition(5, False, False, {'direction': 'right', 'text': '-->'})
+        transition = WipeTransition(5, False, False, False, {'direction': 'right', 'text': '-->'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual(">2345",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -898,7 +918,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(7, "12345", "ABCDE").convert_to_str())
 
         # wipe left
-        transition = WipeTransition(5, False, False, {'direction': 'left'})
+        transition = WipeTransition(5, False, False, False, {'direction': 'left'})
         self.assertEqual(5, transition.get_step_count())
         self.assertEqual("1234E",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -912,7 +932,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(4, "12345", "ABCDE").convert_to_str())
 
         # wipe left (with text)
-        transition = WipeTransition(5, False, False, {'direction': 'left', 'text': '<--'})
+        transition = WipeTransition(5, False, False, False, {'direction': 'left', 'text': '<--'})
         self.assertEqual(8, transition.get_step_count())
         self.assertEqual("1234<",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -933,7 +953,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
 
     def _test_split_transition(self):
         # split push out (odd display length)
-        transition = SplitTransition(5, False, False, {'direction': 'out', 'mode': 'push'})
+        transition = SplitTransition(5, False, False, False, {'direction': 'out', 'mode': 'push'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("23C45",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -943,7 +963,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(2, "12345", "ABCDE").convert_to_str())
 
         # split push out (even display length)
-        transition = SplitTransition(6, False, False, {'direction': 'out', 'mode': 'push'})
+        transition = SplitTransition(6, False, False, False, {'direction': 'out', 'mode': 'push'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("23CD45",
                          transition.get_transition_step(0, "123456", "ABCDEF").convert_to_str())
@@ -953,7 +973,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(2, "123456", "ABCDEF").convert_to_str())
 
         # split push in (odd display length)
-        transition = SplitTransition(5, False, False, {'direction': 'in', 'mode': 'push'})
+        transition = SplitTransition(5, False, False, False, {'direction': 'in', 'mode': 'push'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("C234D",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -963,7 +983,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(2, "12345", "ABCDE").convert_to_str())
 
         # split push in (even display length)
-        transition = SplitTransition(6, False, False, {'direction': 'in', 'mode': 'push'})
+        transition = SplitTransition(6, False, False, False, {'direction': 'in', 'mode': 'push'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("C2345D",
                          transition.get_transition_step(0, "123456", "ABCDEF").convert_to_str())
@@ -973,7 +993,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(2, "123456", "ABCDEF").convert_to_str())
 
         # split wipe out (odd output length)
-        transition = SplitTransition(5, False, False, {'direction': 'out', 'mode': 'wipe'})
+        transition = SplitTransition(5, False, False, False, {'direction': 'out', 'mode': 'wipe'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("12C45",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -983,7 +1003,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(2, "12345", "ABCDE").convert_to_str())
 
         # split wipe out (even output length)
-        transition = SplitTransition(6, False, False, {'direction': 'out', 'mode': 'wipe'})
+        transition = SplitTransition(6, False, False, False, {'direction': 'out', 'mode': 'wipe'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("12CD56",
                          transition.get_transition_step(0, "123456", "ABCDEF").convert_to_str())
@@ -993,7 +1013,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(2, "123456", "ABCDEF").convert_to_str())
 
         # split wipe in (odd output length)
-        transition = SplitTransition(5, False, False, {'direction': 'in', 'mode': 'wipe'})
+        transition = SplitTransition(5, False, False, False, {'direction': 'in', 'mode': 'wipe'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("A234E",
                          transition.get_transition_step(0, "12345", "ABCDE").convert_to_str())
@@ -1003,7 +1023,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
                          transition.get_transition_step(2, "12345", "ABCDE").convert_to_str())
 
         # split wipe in (even output length)
-        transition = SplitTransition(6, False, False, {'direction': 'in', 'mode': 'wipe'})
+        transition = SplitTransition(6, False, False, False, {'direction': 'in', 'mode': 'wipe'})
         self.assertEqual(3, transition.get_step_count())
         self.assertEqual("A2345F",
                          transition.get_transition_step(0, "123456", "ABCDEF").convert_to_str())
@@ -1015,7 +1035,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
     def test_transition_runner(self):
         """Test the transition runner using an iterator."""
         transition_iterator = iter(TransitionRunner(self.machine,
-                                                    PushTransition(5, False, False, {'direction': 'right'}),
+                                                    PushTransition(5, False, False, False, {'direction': 'right'}),
                                                     "12345", "ABCDE"))
         self.assertEqual("E1234",
                          next(transition_iterator).convert_to_str())
@@ -1035,7 +1055,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.machine.variables.set_machine_var("segment_display_test_value", 0)
 
         transition_iterator = iter(TransitionRunner(self.machine,
-                                                    PushTransition(5, False, True, {'direction': 'right'}),
+                                                    PushTransition(5, False, True, False, {'direction': 'right'}),
                                                     "ABCDE", "{machine.segment_display_test_value:,d}"))
 
         self.assertEqual("0ABCD",
@@ -1069,7 +1089,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
 
         mock_set_text.assert_has_calls(
             [call(
-                SegmentDisplayText.from_str_with_color('       ', 7, True, True, [red] * 7),
+                SegmentDisplayText.from_str_with_color('       ', 7, True, True, False, [red] * 7),
                 flash_mask='', flashing=FlashingType.NO_FLASH)])
         mock_set_text.reset_mock()
 
@@ -1078,7 +1098,7 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
 
         mock_set_text.assert_has_calls(
             [call(
-                SegmentDisplayText.from_str_with_color('       ', 7, True, True, [wht] * 7),
+                SegmentDisplayText.from_str_with_color('       ', 7, True, True, False, [wht] * 7),
                 flash_mask='', flashing=FlashingType.NO_FLASH)])
         mock_set_text.reset_mock()
 
@@ -1090,64 +1110,64 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         # incoming text is centered so has spaces before and after the new text)
         mock_set_text.assert_has_calls([
             call(
-                SegmentDisplayText.from_str_with_color('          ', 10, True, True, [red] * 1 + [wht] * 9),
+                SegmentDisplayText.from_str_with_color('          ', 10, True, True, False, [red] * 1 + [wht] * 9),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('          ', 10, True, True, [red] * 2 + [wht] * 8),
+                SegmentDisplayText.from_str_with_color('          ', 10, True, True, False, [red] * 2 + [wht] * 8),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('L         ', 10, True, True, [red] * 3 + [wht] * 7),
+                SegmentDisplayText.from_str_with_color('L         ', 10, True, True, False, [red] * 3 + [wht] * 7),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('LL        ', 10, True, True, [red] * 4 + [wht] * 6),
+                SegmentDisplayText.from_str_with_color('LL        ', 10, True, True, False, [red] * 4 + [wht] * 6),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('OLL       ', 10, True, True, [red] * 5 + [wht] * 5),
+                SegmentDisplayText.from_str_with_color('OLL       ', 10, True, True, False, [red] * 5 + [wht] * 5),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('ROLL      ', 10, True, True, [red] * 6 + [wht] * 4),
+                SegmentDisplayText.from_str_with_color('ROLL      ', 10, True, True, False, [red] * 6 + [wht] * 4),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('CROLL     ', 10, True, True, [red] * 7 + [wht] * 3),
+                SegmentDisplayText.from_str_with_color('CROLL     ', 10, True, True, False, [red] * 7 + [wht] * 3),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('SCROLL    ', 10, True, True, [red] * 8 + [wht] * 2),
+                SegmentDisplayText.from_str_with_color('SCROLL    ', 10, True, True, False, [red] * 8 + [wht] * 2),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color(' SCROLL   ', 10, True, True, [red] * 9 + [wht] * 1),
+                SegmentDisplayText.from_str_with_color(' SCROLL   ', 10, True, True, False, [red] * 9 + [wht] * 1),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('  SCROLL  ', 10, True, True, [red] * 10 + [wht] * 0),
+                SegmentDisplayText.from_str_with_color('  SCROLL  ', 10, True, True, False, [red] * 10 + [wht] * 0),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color(' SCROLL   ', 10, True, True, [red] * 9 + [wht] * 1),
+                SegmentDisplayText.from_str_with_color(' SCROLL   ', 10, True, True, False, [red] * 9 + [wht] * 1),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('SCROLL    ', 10, True, True, [red] * 8 + [wht] * 2),
+                SegmentDisplayText.from_str_with_color('SCROLL    ', 10, True, True, False, [red] * 8 + [wht] * 2),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('CROLL     ', 10, True, True, [red] * 7 + [wht] * 3),
+                SegmentDisplayText.from_str_with_color('CROLL     ', 10, True, True, False, [red] * 7 + [wht] * 3),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('ROLL      ', 10, True, True, [red] * 6 + [wht] * 4),
+                SegmentDisplayText.from_str_with_color('ROLL      ', 10, True, True, False, [red] * 6 + [wht] * 4),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('OLL       ', 10, True, True, [red] * 5 + [wht] * 5),
+                SegmentDisplayText.from_str_with_color('OLL       ', 10, True, True, False, [red] * 5 + [wht] * 5),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('LL        ', 10, True, True, [red] * 4 + [wht] * 6),
+                SegmentDisplayText.from_str_with_color('LL        ', 10, True, True, False, [red] * 4 + [wht] * 6),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('L         ', 10, True, True, [red] * 3 + [wht] * 7),
+                SegmentDisplayText.from_str_with_color('L         ', 10, True, True, False, [red] * 3 + [wht] * 7),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('          ', 10, True, True, [red] * 2 + [wht] * 8),
+                SegmentDisplayText.from_str_with_color('          ', 10, True, True, False, [red] * 2 + [wht] * 8),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('          ', 10, True, True, [red] * 1 + [wht] * 9),
+                SegmentDisplayText.from_str_with_color('          ', 10, True, True, False, [red] * 1 + [wht] * 9),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
             call(
-                SegmentDisplayText.from_str_with_color('          ', 10, True, True, [red] * 0 + [wht] * 10),
+                SegmentDisplayText.from_str_with_color('          ', 10, True, True, False, [red] * 0 + [wht] * 10),
                 flash_mask='', flashing=FlashingType.NO_FLASH),
         ])
         mock_set_text.reset_mock()
@@ -1157,15 +1177,15 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertTrue(mock_set_text.called)
         self.assertEqual(5, mock_set_text.call_count)
         mock_set_text.assert_has_calls([
-            call(SegmentDisplayText.from_str_with_color('    45    ', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('    45    ', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('   3456   ', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('   3456   ', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('  234567  ', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('  234567  ', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color(' 12345678 ', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color(' 12345678 ', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('0123456789', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('0123456789', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
         ])
         mock_set_text.reset_mock()
@@ -1175,25 +1195,25 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertTrue(mock_set_text.called)
         self.assertEqual(10, mock_set_text.call_count)
         mock_set_text.assert_has_calls([
-            call(SegmentDisplayText.from_str_with_color('A012345678', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('A012345678', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('AB01234567', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('AB01234567', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABC0123456', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABC0123456', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABCD012345', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABCD012345', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABCDE01234', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABCDE01234', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABCDEF0123', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABCDEF0123', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABCDEFG012', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABCDEFG012', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABCDEFGH01', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABCDEFGH01', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABCDEFGHI0', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABCDEFGHI0', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
-            call(SegmentDisplayText.from_str_with_color('ABCDEFGHIJ', 10, True, True, [wht] * 10),
+            call(SegmentDisplayText.from_str_with_color('ABCDEFGHIJ', 10, True, True, False, [wht] * 10),
                  flash_mask='', flashing=FlashingType.NO_FLASH),
         ])
         mock_set_text.reset_mock()


### PR DESCRIPTION
The segment mappings assume you have a dot (dp). The dot on my displays makes a comma by default since commas are more relevant to pinball for things like thousands separators. I needed a way to convert commas into dots so they would display correctly. Some people may find this useful who have dots only on there segment displays, but want to take advantage of having thousands separators...even if they are dots

![IMG_20220811_225600618](https://user-images.githubusercontent.com/1877729/184293512-9eb45cd7-aaf9-42bf-bffc-daca3302ac7e.jpg)
.