### PR TITLE
Add support for NeoSeg display configuration

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -787,6 +787,7 @@ light_stripes:
     __type__: device
     number_start: single|int|0
     start_channel: single|str|None
+    previous: single|machine(lights)|None
     number_template: single|str|None
     start_x: single|float|None
     start_y: single|float|None
@@ -799,12 +800,24 @@ light_rings:
     __type__: device
     number_start: single|int|0
     start_channel: single|str|None
+    previous: single|machine(lights)|None
     number_template: single|str|None
     center_x: single|float|None
     center_y: single|float|None
     start_angle: single|float|0
     radius: single|float|None
     count: single|int|
+    light_template: single|subconfig(lights,device)|
+neoseg_displays:
+    __valid_in__: machine
+    __type__: device
+    number_start: single|int|0
+    start_channel: single|str|None
+    previous: single|machine(lights)|None
+    number_template: single|str|None
+    start_x: single|float|None
+    start_y: single|float|None
+    size: single|enum(2digit,8digit)|8digit
     light_template: single|subconfig(lights,device)|
 lights:
     __valid_in__: machine
@@ -1354,7 +1367,8 @@ segment_displays:
     platform_settings: single|dict|None
     platform: single|str|None
 light_segment_displays_device:
-    lights: list|dict(str:machine(lights))|
+    lights: list|dict(str:machine(lights))|None
+    light_groups: list|machine(neoseg_displays)|None
     type: single|enum(7segment,bcd,8segment,14segment,16segment)|
 segment_display_player:
     __valid_in__: machine, mode, show

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -71,6 +71,7 @@ mpf:
         rgb_dmds: mpf.devices.rgb_dmd.RgbDmd
         light_stripes: mpf.devices.light_group.LightStrip
         light_rings: mpf.devices.light_group.LightRing
+        neoseg_displays: mpf.devices.light_group.NeoSegDisplay
         magnets: mpf.devices.magnet.Magnet
         kickbacks: mpf.devices.kickback.Kickback
         combo_switches: mpf.devices.combo_switch.ComboSwitch

--- a/mpf/tests/machine_files/light/config/light_groups.yaml
+++ b/mpf/tests/machine_files/light/config/light_groups.yaml
@@ -36,3 +36,17 @@ light_rings:
     center_x: 100
     center_y: 50
     debug: True
+
+neoseg_displays:    
+  neoSeg_0:
+    start_channel: 0-0-0
+    size: 8digit
+    light_template:
+      type: w
+      subtype: led
+  neoSeg_1:
+    start_channel: 0-0-120
+    size: 2digit
+    light_template:
+      type: w
+      subtype: led

--- a/mpf/tests/machine_files/light_segment_displays/config/config.yaml
+++ b/mpf/tests/machine_files/light_segment_displays/config/config.yaml
@@ -65,6 +65,20 @@ lights:
   segment5_h:
     number:
 
+neoseg_displays:
+  neoSeg_0:
+    start_channel: 0-0-0
+    size: 8digit
+    light_template:
+      type: w
+      subtype: led
+  neoSeg_1:
+    start_channel: 0-0-120
+    size: 8digit
+    light_template:
+      type: w
+      subtype: led
+
 segment_displays:
   display1:
     number: 1
@@ -114,6 +128,17 @@ segment_displays:
           g: segment5_g
           h: segment5_h
       type: 8segment
+  neoSegTop:
+    number: 1
+    size: 16
+    integrated_dots: true
+    use_dots_for_commas: true
+    default_transition_update_hz: 30
+    platform_settings:
+      light_groups:
+         - neoSeg_0
+         - neoSeg_1
+      type: 14segment
 
 segment_display_player:
   show_1337:
@@ -136,3 +161,6 @@ segment_display_player:
   remove_text_display1:
     display1:
       action: remove
+  show_centered_11:
+    neoSegTop:
+      text: "       11       "

--- a/mpf/tests/test_LightGroups.py
+++ b/mpf/tests/test_LightGroups.py
@@ -66,3 +66,31 @@ class TestLightGroups(MpfTestCase):
         # 360/0 degree
         self.assertEqual(100, self.machine.lights["ring1_light_9"].config['x'])
         self.assertEqual(53, self.machine.lights["ring1_light_9"].config['y'])
+
+        # neoSeg_0
+        self.assertEqual("led-0-0-0", self.machine.lights["neoSeg_0_light_0"].hw_drivers["white"][0].number)
+        self.assertEqual("led-led-0-0-0+1", self.machine.lights["neoSeg_0_light_1"].hw_drivers["white"][0].number)
+        self.assertEqual("led-led-led-0-0-0+1+1", self.machine.lights["neoSeg_0_light_2"].hw_drivers["white"][0].number)
+        self.assertEqual("neoSeg_0_light_119", self.machine.lights["neoSeg_0_light_119"].name)
+        # sanity check order...not 100%
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[0].name, self.machine.lights["neoSeg_0_light_95"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[20].name, self.machine.lights["neoSeg_0_light_103"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[40].name, self.machine.lights["neoSeg_0_light_66"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[60].name, self.machine.lights["neoSeg_0_light_5"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[80].name, self.machine.lights["neoSeg_0_light_13"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[100].name, self.machine.lights["neoSeg_0_light_36"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[119].name, self.machine.lights["neoSeg_0_light_35"].name)
+
+        # neoSeg_1
+        self.assertEqual("led-0-0-120", self.machine.lights["neoSeg_1_light_0"].hw_drivers["white"][0].number)
+        self.assertEqual("led-led-0-0-120+1", self.machine.lights["neoSeg_1_light_1"].hw_drivers["white"][0].number)
+        self.assertEqual("led-led-led-0-0-120+1+1", self.machine.lights["neoSeg_1_light_2"].hw_drivers["white"][0].number)
+        self.assertEqual("neoSeg_1_light_29", self.machine.lights["neoSeg_1_light_29"].name)
+        # sanity check order...not 100%
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[0].name, self.machine.lights["neoSeg_1_light_5"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[5].name, self.machine.lights["neoSeg_1_light_29"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[10].name, self.machine.lights["neoSeg_1_light_21"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[15].name, self.machine.lights["neoSeg_1_light_14"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[20].name, self.machine.lights["neoSeg_1_light_13"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[25].name, self.machine.lights["neoSeg_1_light_15"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[29].name, self.machine.lights["neoSeg_1_light_20"].name)

--- a/mpf/tests/test_LightSegmentDisplays.py
+++ b/mpf/tests/test_LightSegmentDisplays.py
@@ -164,6 +164,24 @@ class TestLightSegmentDisplays(MpfTestCase):
         self.assertLightColor("segment5_g", "off")
         self.assertLightColor("segment5_h", "on")
 
+        # show 11 centered on neoseg display
+        self.post_event("show_centered_11")
+        self.advance_time_and_run()
+
+        self.assertLightColor("neoSeg_0_light_30", "on")
+        self.assertLightColor("neoSeg_0_light_31", "on")
+        self.assertLightColor("neoSeg_0_light_34", "on")
+        self.assertLightColor("neoSeg_1_light_81", "on")
+        self.assertLightColor("neoSeg_1_light_90", "on")
+        self.assertLightColor("neoSeg_1_light_93", "on")
+        self.assertLightColor("neoSeg_0_light_29", "off")
+        self.assertLightColor("neoSeg_0_light_32", "off")
+        self.assertLightColor("neoSeg_0_light_35", "off")
+        self.assertLightColor("neoSeg_1_light_82", "off")
+        self.assertLightColor("neoSeg_1_light_91", "off")
+        self.assertLightColor("neoSeg_1_light_92", "off")
+
+
     @test_config("config_dots.yaml")
     def test_dots(self):
         """Check that embedded dots work properly."""


### PR DESCRIPTION
NeoSeg displays are light_segment_displays but they were a pain to configure manually because so many lights needed to be generated and linked to the display. This PR creates a neoseg_display light_group and uses that to generate a correctly ordered list of lights. Also light_groups were added as a config option to light_segment_displays, so you could list the neoseg_displays to be used as one display. MPF Docs updates must surely follow.