### PR TITLE
Update text_ui.py

### DIFF
--- a/mpf/core/text_ui.py
+++ b/mpf/core/text_ui.py
@@ -327,7 +327,6 @@ class TextUi(MpfController):
 
         names = self.config.get('player_vars', player_vars.keys())
         for name in names:
-            self.machine.events.replace_handler('player_' + name, self._update_player)
             self._player_widgets.append(Label("{}: {}".format(name, player_vars[name])))
 
         self._layout_change = True

--- a/mpf/core/text_ui.py
+++ b/mpf/core/text_ui.py
@@ -327,6 +327,10 @@ class TextUi(MpfController):
 
         names = self.config.get('player_vars', player_vars.keys())
         for name in names:
+            try:
+                self.machine.events.replace_handler('player_' + name, self._update_player)
+            except ValueError:
+                pass
             self._player_widgets.append(Label("{}: {}".format(name, player_vars[name])))
 
         self._layout_change = True


### PR DESCRIPTION
Reverts back to where it used to be.  This change throws an error (maybe an issue upstream) where various events players will error out.  This makes Text_UI have the issue from before where it won't update player variables unless score, ball, or player changes.  But better than breaking.  At some point I will dig into a real fix to make Text_UI match what is expected for all scenarios.