### PR TITLE
Add linear_gradient config spec

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ their spare time, unpaid, for the love of pinball!
  * Avery Tummons
  * James Cardona
  * Dave Ensminger <dave@ensadi.com>
+ * Charles Duncan (nullbuilds)
 
 MPF is inspired by pyprocgame and skeletongame which were written by:
 

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -548,6 +548,9 @@ effects:
         size: single|float|4.0
     invert_colors:
         none: ignore
+    linear_gradient:
+        color_stops: dict|float:kivycolor|None
+        angle: single|float|0.0
     monochrome:
         luminosity: list|float|.299, .587, .114
     pixelate:


### PR DESCRIPTION
## Overview

Adds the configuration spec of the new linear_gradient effect. See the [mpf-mc pr](https://github.com/missionpinball/mpf-mc/pull/435) for more details.

## Related PRs

* [mpf-mc #435](https://github.com/missionpinball/mpf-mc/pull/435)
* [mpf-docs #432](https://github.com/missionpinball/mpf-docs/pull/432)