### PR TITLE
doc: remove double entries

### DIFF
--- a/docs/functions/index.rst
+++ b/docs/functions/index.rst
@@ -1,9 +1,6 @@
 Common functions to use in your code
 ====================================
 
-* :doc:`machine_variables`
-* :doc:`player_variables`
-
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
In https://developer.missionpinball.org/en/dev/functions/index.html the entries of the 'table of contents' are doubled.