### PR TITLE
Enable Speedometer Devices

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1761,6 +1761,8 @@ sound_marker:
     time: single|secs|
     events: list|event_posted|
 speedometers:
+    __valid_in__: machine, mode
+    __type__: device
     start_switch: single|machine(switches)|None
     stop_switch: single|machine(switches)|None
 spi_bit_bang:

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1760,6 +1760,9 @@ sound_ducking:
 sound_marker:
     time: single|secs|
     events: list|event_posted|
+speedometers:
+    start_switch: single|machine(switches)|None
+    stop_switch: single|machine(switches)|None
 spi_bit_bang:
     __valid_in__: machine
     __type__: config

--- a/mpf/devices/speedometer.py
+++ b/mpf/devices/speedometer.py
@@ -37,4 +37,5 @@ class Speedometer(SystemWideDevice):
             delta = self.config['stop_switch'].last_change - self.time_start
             self.time_start = None
             print(delta)
+            self.machine.events.post("{}_hit".format(self.name), delta = delta)
             # TODO: post event

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -85,6 +85,7 @@ mpf:
         timers: mpf.devices.timer.Timer
         segment_displays: mpf.devices.segment_display.segment_display.SegmentDisplay
         sequence_shots: mpf.devices.sequence_shot.SequenceShot
+        speedometers: mpf.devices.speedometer.Speedometer
         hardware_sound_systems: mpf.devices.hardware_sound_system.HardwareSoundSystem
         steppers: mpf.devices.stepper.Stepper
         state_machines: mpf.devices.state_machine.StateMachine


### PR DESCRIPTION
A speedometer device was added back in 2021, but it was never tested or used. Here I am enabling it in its most basic form before making further enhancements.

Concern areas: 
- The MPF system clock may have too much jitter and too low a resolution to be an effective speedometer if the switches are too close together
- Hardware timestamps may be required, but many systems do not support timestamps or handle them differently. OPP has a 1ms timestamp that restarts every 65 seconds, for example. Also, getting the timestamps is a separate transaction from getting the switch states. We may only want to grab hardware timestamps when absolutely required rather than burdening all switch updates with timestamp requests.