### PR TITLE
Extend Service Menu

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ their spare time, unpaid, for the love of pinball!
  * James Cardona
  * Dave Ensminger <dave@ensadi.com>
  * Charles Duncan (nullbuilds)
+ * Grace Henke
 
 MPF is inspired by pyprocgame and skeletongame which were written by:
 

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -414,6 +414,8 @@ credits_events:
 credits_pricing_tiers:
     price: single|template_float|.50
     credits: single|template_int|1
+match:
+    match_percentage: single|float_or_token|1.0
 device:     # base for all devices
     label: single|str|%
     tags: list|str|None

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -141,12 +141,21 @@ class TestServiceMode(MpfFakeGameTestCase):
 
         self.hit_and_release_switch("s_service_up")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
+        self.assertEventCalledWith("service_menu_selected", label='Pricing Menu')
 
         self.hit_and_release_switch("s_service_down")
         self.advance_time_and_run()
         self.assertEventCalledWith("service_menu_selected", label='Utilities Menu')
 
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+        self.assertEventCalledWith("service_menu_selected", label='Pricing Menu')
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
+
+        
     def test_utilities_reset(self):
         self.hit_and_release_switch("s_service_esc")
         self.advance_time_and_run(.1)
@@ -589,3 +598,50 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.advance_time_and_run()
 
         self.assertEventCalled("service_settings_stop")
+
+    def test_pricing(self):
+        self.mock_event("service_menu_selected")
+        
+        # enter menu
+        self.hit_and_release_switch("s_service_enter")
+        self.advance_time_and_run()
+
+        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+
+        # enter pricing menu
+        self.assertEventCalledWith("service_menu_selected", label='Pricing Menu')
+        self.hit_and_release_switch("s_service_enter")
+        self.advance_time_and_run()
+
+
+        # check that each pricing menu exists
+        self.assertEventCalledWith("service_menu_selected", label="Credits Per Game")
+
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+
+        self.assertEventCalledWith("service_menu_selected", label="Match Percentage")
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+
+        self.assertEventCalledWith("service_menu_selected", label="Toggle Free Play/Credit Mode")
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
+        
+        self.assertEventCalledWith("service_menu_selected", label="Max Credits")
+


### PR DESCRIPTION
Extends the abilities of the service menu. Abilites implemented: change credits per game, match percentage, toggle between free play and credit mode, and lastly change the number of max credits. Also implemented some early testing of these abilities. Works on Issue #693