### PR TITLE
feat: Floor division support in dynamic values

### DIFF
--- a/mpf/core/placeholder_manager.py
+++ b/mpf/core/placeholder_manager.py
@@ -20,7 +20,7 @@ if MYPY:   # pragma: no cover
 
 
 # supported operators
-OPERATORS = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
+OPERATORS = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul, ast.FloorDiv: op.floordiv,
              ast.Div: op.truediv, ast.Pow: op.pow, ast.BitXor: op.xor,
              ast.USub: op.neg, ast.Not: op.not_, ast.Mod: op.mod}
 

--- a/mpf/tests/machine_files/variable_player/modes/mode3/config/mode3.yaml
+++ b/mpf/tests/machine_files/variable_player/modes/mode3/config/mode3.yaml
@@ -27,6 +27,8 @@ variable_player:
         multiplier:
             float: 1.5
             action: set
+    score_floordiv:
+        score: 123456 // 100 * 100
     set_player7:
         score:
             int: 10

--- a/mpf/tests/test_VariablePlayer.py
+++ b/mpf/tests/test_VariablePlayer.py
@@ -144,6 +144,9 @@ class TestVariablePlayer(MpfFakeGameTestCase):
         self.post_event("score_float3")
         self.assertPlayerVarEqual(2394, "score")
 
+        self.post_event("score_floordiv")
+        self.assertPlayerVarEqual(125794, "score")
+
         # should not crash
         self.post_event("set_player7")
         self.post_event("add_player7")


### PR DESCRIPTION
This PR adds floor division functionality to dynamic values, useful for rounding arbitrary numbers to clean multiples. 

For example, calculating a point score based on a timer count (hurryup) or a multiplier can yield tens and ones of digits, or even floats. Many pinball games like to have a minimum score multiple of 10 (e.g. no single-digit points) or even 100, and this PR enables a dynamic value to crop to the nearest iteration using the standard syntax of floor division * divisor.
```
variable_player:
  jackpot_shot_hit:
    score: current_player.jackpot_value * current_player.float_multiplier // 100 * 100
```

The placeholder templating engine uses native python operations so it inherently understands that `//` means floor division, but the code module wasn't mapping the `op.floordiv` method for executing it. This PR simply maps the method, and it works. Tests added to verify and prevent regressions.

![division is great](https://media.giphy.com/media/TH19MpZn0G5kjjsO3e/giphy.gif)