### PR TITLE
Add Player Vars to High Score Mode

### DIFF
--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -184,7 +184,8 @@ class HighScore(AsyncMode):
                     # add high score
                     new_list[i] = (player.initials, value)
                     # show award slide
-                    await self._show_award_slide(player.initials, award_names[i], value)
+                    player_num = player.number
+                    await self._show_award_slide(player_num, player.initials, category_name, award_names[i], value)
 
                 # next entry
                 i += 1
@@ -214,7 +215,7 @@ class HighScore(AsyncMode):
 
         return event_result["text"] if "text" in event_result else ''
 
-    async def _show_award_slide(self, player_name: str, award: str, value: int) -> None:
+    async def _show_award_slide(self, player_num, player_name: str, category_name: str, award: str, value: int) -> None:
         if not self.high_score_config['award_slide_display_time']:
             return
 
@@ -226,6 +227,13 @@ class HighScore(AsyncMode):
         self.machine.events.post(
             '{}_award_display'.format(award),
             player_name=player_name,
+            award=award,
+            value=value)
+        self.machine.events.post(
+            '{}_award_display'.format(category_name),
+            player_num=player_num,
+            player_name=player_name,
+            category_name=category_name,
             award=award,
             value=value)
         await asyncio.sleep(self.high_score_config['award_slide_display_time'] / 1000)

--- a/mpf/modes/high_score/config/high_score.yaml
+++ b/mpf/modes/high_score/config/high_score.yaml
@@ -28,10 +28,28 @@ high_score:
       - MPF: 23
 
 slide_player:
-  high_score_enter_initials: high_score_enter_initials
+  high_score_enter_initials:
+    high_score_enter_initials:
+        action: play
+    high_score_award_display:
+        action: remove
+    #Make sure to remove any slides you add under this high_score_enter_initials slide, or it will continue to
+    #show the award slide instead of initials for another player that also earned a high score.
+    score_award_display:
+        action: remove
   high_score_award_display:
     high_score_award_display:
         action: play
+    high_score_enter_initials:
+        action: remove
+  #This is used to show the slide for a specific award and show additional parameters.  This can include any
+  #static lables as well as dynamic player and machine variables.
+  #You will need to generate this block again and swap the name for any subsequent categories that you want
+  #to show unique additional values.
+  score_award_display:
+    score_award_display:
+        action: play
+        priority: 1
     high_score_enter_initials:
         action: remove
 
@@ -83,5 +101,38 @@ slides:
     text: (value)
     color: ffffff
     number_grouping: true
+    style: medium
+    y: center - 33%
+
+  #This is the slide for a specific category (in this case "score"), where you can include any values you want.
+  #This can include both player and machine vars. Player vars must have a number associated, otherwise it will
+  #pull from the last user who had a turn, not the user for which the player var applies.
+  #Player Var Syntax: (player(player_num)|variable) where you swap the variable, but do not change before the |
+  #Machine Var Syntax: (machine|variable) where you swap the variable, but do not change before the |
+  score_award_display:
+  - type: text
+    text: (player_name)
+    color: ffffff
+    style: big
+    y: center + 33%
+  - type: text
+    text: (award)
+    color: ffffff
+    style: medium
+    y: center + 15%
+  - type: text
+    text: (value)
+    color: ffffff
+    number_grouping: true
+    style: medium
+    y: center
+  - type: text
+    text: (player(player_num)|ball)
+    color: ffffff
+    style: medium
+    y: center - 15%
+  - type: text
+    text: (machine|credits_string)
+    color: ffffff
     style: medium
     y: center - 33%


### PR DESCRIPTION
This updates the high_score.py file to pass through both the player_num and the category of the award.  This is pushed through a new unique event (to prevent breaking existing games). The high_score.yaml file is updated as well to show how to use these new features to create a new specific slide for the awards where player and machine variables should be shown.