### PR TITLE
Save High Score Variables in high_scores.yaml

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -725,6 +725,7 @@ high_score:
     enter_initials_timeout: single|secs|20s
     reverse_sort: list|str|None
     reset_high_scores_events: list|event_handler|high_scores_reset,factory_reset
+    vars: dict|str:list|None
 info_lights:
     __valid_in__: machine                            # todo add to validator
     __type__: config

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -142,14 +142,9 @@ class HighScore(AsyncMode):
 
                     if len(hs_vars) > 0:
                         for k, v in hs_vars[0].items():
-                            if 'player' in k:
-                                self.machine.variables.set_machine_var(
-                                    name=category + str(position + 1) + '_' + str(k),
-                                    value=v)
-                            else:
-                                self.machine.variables.set_machine_var(
-                                    name=category + str(position + 1) + '_' + str(k),
-                                    value=v)
+                            self.machine.variables.set_machine_var(
+                                name=category + str(position + 1) + '_' + str(k),
+                                value=v)
 
                     '''machine_var: (high_score_category)(position)_(variable)
 
@@ -205,21 +200,10 @@ class HighScore(AsyncMode):
                             del new_list[i]
                             # no entry when the player missed the timeout
                             continue
-                    player_num_index = player.number - 1
                     # get vars from config
                     self._load_vars()
-                    # create dictionary of the variable name and its value, then load it for the category
-                    var_dict = dict()
                     if category_name in self.vars:
-                        j = 0
-                        while j < len(self.vars[category_name]) and bool(self.vars[category_name]):
-                            if 'player' in self.vars[category_name][j][0]:
-                                var_dict[self.vars[category_name][j][0] + '.' + self.vars[category_name][j][1]] \
-                                      = self.machine.game.player_list[player_num_index][self.vars[category_name][j][1]]
-                            else:
-                                var_dict[self.vars[category_name][j][0] + '.' + self.vars[category_name][j][1]] \
-                                   = self.machine.variables.get_machine_var(self.vars[category_name][j][1])
-                            j += 1
+                        var_dict = self._assign_vars(category_name, player)
                         # add high score with variables
                         new_list[i] = (player.initials, value, var_dict)
                     else:
@@ -238,6 +222,23 @@ class HighScore(AsyncMode):
         self.high_scores = new_high_score_list
         self._write_scores_to_disk()
         self._create_machine_vars()
+
+    def _assign_vars(self, category_name, player):
+        """Define all vars that are for the given category, and assign their values."""
+        # create dictionary of the variable name and its value, then load it for the category
+        player_num_index = player.number - 1
+        var_dict = dict()
+        j = 0
+        while j < len(self.vars[category_name]) and bool(self.vars[category_name]):
+            if 'player' in self.vars[category_name][j][0]:
+                var_dict[self.vars[category_name][j][0] + '.' + self.vars[category_name][j][1]] \
+                    = self.machine.game.player_list[player_num_index][self.vars[category_name][j][1]]
+            else:
+                var_dict[self.vars[category_name][j][0] + '.' + self.vars[category_name][j][1]] \
+                    = self.machine.variables.get_machine_var(self.vars[category_name][j][1])
+            j += 1
+        # return the dictionary of items for this specific player and category entry
+        return var_dict
 
     # pylint: disable-msg=too-many-arguments
     async def _ask_player_for_initials(self, player: Player, award_label: str, value: int) -> str:

--- a/mpf/tests/machine_files/high_score_vars/config/high_score.yaml
+++ b/mpf/tests/machine_files/high_score_vars/config/high_score.yaml
@@ -1,0 +1,10 @@
+#config_version=5
+
+modes:
+  - high_score
+  - tilt
+
+switches:
+  s_tilt:
+    tags: tilt_warning
+    number:

--- a/mpf/tests/machine_files/high_score_vars/modes/high_score/config/high_score.yaml
+++ b/mpf/tests/machine_files/high_score_vars/modes/high_score/config/high_score.yaml
@@ -1,0 +1,31 @@
+#config_version=5
+high_score:
+  _overwrite: True
+  categories: !!omap
+  - score:
+      - GRAND CHAMPION
+      - HIGH SCORE 1
+      - HIGH SCORE 2
+      - HIGH SCORE 3
+      - HIGH SCORE 4
+  - loops:
+      - LOOP CHAMP
+  - hits:
+      - MOST HITS
+  defaults:
+    score:
+      - BRI: 4242
+      - GHK: 2323
+      - JK: 1337
+      - QC: 42
+      - MPF: 23
+    loops:
+      - JK: 42
+    hits:
+      - A: 1
+  vars:
+    loops:
+      - player: number
+    hits:
+      - player: number
+      - machine: credits_string

--- a/mpf/tests/test_HighScoreModeWithVars.py
+++ b/mpf/tests/test_HighScoreModeWithVars.py
@@ -1,0 +1,100 @@
+"""Test high score mode."""
+from collections import OrderedDict
+
+from unittest.mock import MagicMock
+from mpf.tests.MpfBcpTestCase import MpfBcpTestCase
+
+
+class TestHighScoreMode(MpfBcpTestCase):
+
+    def get_config_file(self):
+        return 'high_score.yaml'
+
+    def get_machine_path(self):
+        return 'tests/machine_files/high_score_vars/'
+
+    def start_game(self, num_players=1):
+        self._bcp_client.send = MagicMock()
+
+        self.machine.playfield.add_ball = MagicMock()
+        self.machine.events.post('game_start')
+        self.advance_time_and_run()
+        self.machine.game.balls_in_play = 1
+        self.assertIsNotNone(self.machine.game)
+
+        while self.machine.game.num_players < num_players:
+            self.machine.game.request_player_add()
+            self.advance_time_and_run()
+
+    def test_high_score_one_var(self):
+        self.advance_time_and_run()
+        self.mock_event("high_score_enter_initials")
+        self.mock_event("loops_award_display")
+        # tests loop award with additional variables
+        self.machine.modes["high_score"].high_scores = OrderedDict()
+        self.machine.modes["high_score"].high_scores['loops'] = [('BIL', 2)]
+
+        self.start_game(1)
+        self.machine.game.player_list[0].loops = 50
+        self.machine.game.end_game()
+        self.advance_time_and_run()
+        self.assertTrue(self.machine.modes["high_score"].active)
+
+        # Award initials
+        self.assertEqual(1, self._events['high_score_enter_initials'])
+        self._bcp_client.send.reset_mock()
+
+        self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
+        self.advance_time_and_run(.5)
+
+        self.assertEventCalledWith("loops_award_display", award='LOOP CHAMP', player_name='NEW', value=50,
+                                   player_num=1, category_name='loops')
+        self.advance_time_and_run(4)
+
+        # High score done
+        self.assertFalse(self.machine.modes["high_score"].active)
+
+        # verify the data is accurate
+
+        new_score_data = {'score': [], 'loops': [('NEW', 50, {'player.number': 1})], 'hits': []}
+
+        self.assertEqual(new_score_data,
+                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)
+
+    def test_high_score_multiple_vars(self):
+        self.advance_time_and_run()
+        self.mock_event("high_score_enter_initials")
+        self.mock_event("hits_award_display")
+        # tests loop award with additional variables
+        self.machine.modes["high_score"].high_scores = OrderedDict()
+        self.machine.modes["high_score"].high_scores['hits'] = [('AAA', 2)]
+
+        self.start_game(1)
+        self.machine.game.player_list[0].hits = 50
+        self.machine.game.end_game()
+        self.advance_time_and_run()
+        self.assertTrue(self.machine.modes["high_score"].active)
+
+        # Award initials
+        self.assertEqual(1, self._events['high_score_enter_initials'])
+        self._bcp_client.send.reset_mock()
+
+        self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
+        self.advance_time_and_run(.5)
+
+        self.assertEventCalledWith("hits_award_display", award='MOST HITS', player_name='NEW', value=50,
+                                   player_num=1, category_name='hits')
+        self.advance_time_and_run(4)
+
+        # High score done
+        self.assertFalse(self.machine.modes["high_score"].active)
+
+        # verify the data is accurate
+
+        new_score_data = {'score': [], 'loops': [], 'hits': [('NEW', 50, {'player.number': 1, 'machine.credits_string':
+                          'FREE PLAY'})]}
+
+        self.assertEqual(new_score_data,
+                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)


### PR DESCRIPTION
This extends the high score mode to allow the user to define vars that they want to be saved along with the initials and title of the high score that is achieved.  The user can define any number of player or machine vars that should be saved along with the files.  These are written into the high_scores.yaml file as a third tuple.  The code parses the list and for those with two elements (no vars) or three elements (with vars) it will create the machine variables so that it can be used on attract mode, etc.  Then it will save to the file and update the machine vars after the game ends.