### PR TITLE
add support for using * tag to return all devices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ their spare time, unpaid, for the love of pinball!
  * James Cardona
  * Dave Ensminger <dave@ensadi.com>
  * Charles Duncan (nullbuilds)
+ * Eric Selk <ericselk2018@gmail.com>
 
 MPF is inspired by pyprocgame and skeletongame which were written by:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See: http://docs.missionpinball.org/about/contributing_to_mpf.html
+See: https://missionpinball.org/about/contributing_to_mpf/

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -2192,8 +2192,8 @@ widgets:
         rotation: single|int_or_token|0
         scale: single|float_or_token|1.0
         casing: single|str|None
-        # outline_color: single|kivycolor|ffffffff
-        # outline_width: single|int_or_token|0
+        outline_color: single|kivycolor|ffffffff
+        outline_width: single|int_or_token|0
         # text_size: single|int_or_token|None  # sets width of bounding box, not font
         # shorten: single|bool_or_token|None
         # mipmap: single|bool_or_token|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -2192,8 +2192,8 @@ widgets:
         rotation: single|int_or_token|0
         scale: single|float_or_token|1.0
         casing: single|str|None
-        outline_color: single|kivycolor|ffffffff
-        outline_width: single|int_or_token|0
+        # outline_color: single|kivycolor|ffffffff
+        # outline_width: single|int_or_token|0
         # text_size: single|int_or_token|None  # sets width of bounding box, not font
         # shorten: single|bool_or_token|None
         # mipmap: single|bool_or_token|None

--- a/mpf/core/device_manager.py
+++ b/mpf/core/device_manager.py
@@ -306,11 +306,14 @@ class DeviceCollection(dict):
         Args:
         ----
             tag: A string of the tag name which specifies what devices are
-                returned.
+                returned.  A value of "*" returns all devices.
 
         Returns a list of device objects. If no devices are found with that tag, it
         will return an empty list.
         """
+        if tag == "*":
+            return self.values()
+
         items_in_tag_cache = self._tag_cache.get(tag, None)
         if items_in_tag_cache is not None:
             return items_in_tag_cache

--- a/mpf/tests/test_DeviceCollection.py
+++ b/mpf/tests/test_DeviceCollection.py
@@ -38,3 +38,8 @@ class TestDeviceCollection(MpfTestCase):
         self.assertIn(led2, self.machine.lights.items_tagged('tag1'))
         self.assertNotIn(led3, self.machine.lights.items_tagged('tag1'))
         self.assertNotIn(led4, self.machine.lights.items_tagged('tag1'))
+
+        self.assertIn(led1, self.machine.lights.items_tagged('*'))
+        self.assertIn(led2, self.machine.lights.items_tagged('*'))
+        self.assertIn(led3, self.machine.lights.items_tagged('*'))
+        self.assertIn(led4, self.machine.lights.items_tagged('*'))


### PR DESCRIPTION
My use case is to turn off all lights when a skill shot is hit (like Deadpool).  I didn't want to tag every light with a tag like "all" or "*" to accomplish this, but if there is a better way or this feature seems problematic, no worries if this PR is declined.

I didn't see any existing tests on this area -- if there are any, I'm happy to add a new one for this change.
