### PR TITLE
Enable dynamic speed in show_player and post elapsed time for a sequence_shot completion

### DIFF
--- a/mpf/config_players/show_player.py
+++ b/mpf/config_players/show_player.py
@@ -102,9 +102,10 @@ class ShowPlayer(DeviceConfigPlayer):
         start_step = show_settings['start_step'].evaluate(placeholder_args)
         start_running = show_settings['start_running'].evaluate(placeholder_args)
         show_tokens = {k: v.evaluate(placeholder_args) for k, v in show_settings['show_tokens'].items()}
+        speed = show_settings['speed'].evaluate(placeholder_args)
 
         show_config = self.machine.show_controller.create_show_config(
-            show, show_settings['priority'], show_settings['speed'], show_settings['loops'], show_settings['sync_ms'],
+            show, show_settings['priority'], speed, show_settings['loops'], show_settings['sync_ms'],
             show_settings['manual_advance'], show_tokens, show_settings['events_when_played'],
             show_settings['events_when_stopped'], show_settings['events_when_looped'],
             show_settings['events_when_paused'], show_settings['events_when_resumed'],
@@ -128,9 +129,10 @@ class ShowPlayer(DeviceConfigPlayer):
 
         start_step = show_settings['start_step'].evaluate(placeholder_args)
         show_tokens = {k: v.evaluate(placeholder_args) for k, v in show_settings['show_tokens'].items()}
+        speed = show_settings['speed'].evaluate(placeholder_args)
 
         show_config = self.machine.show_controller.create_show_config(
-            show, show_settings['priority'], show_settings['speed'], show_settings['loops'], show_settings['sync_ms'],
+            show, show_settings['priority'], speed, show_settings['loops'], show_settings['sync_ms'],
             show_settings['manual_advance'], show_tokens, show_settings['events_when_played'],
             show_settings['events_when_stopped'], show_settings['events_when_looped'],
             show_settings['events_when_paused'], show_settings['events_when_resumed'],

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1543,7 +1543,7 @@ show_player:
     action: single|enum(play,stop,pause,resume,advance,step_back,update,queue)|play
     show: single|str|None
     priority: single|int_or_token|0
-    speed: single|float_or_token|1
+    speed: single|template_float_or_token|1
     block_queue: single|bool|false
     start_step: single|template_int|1
     start_running: single|template_bool|True

--- a/mpf/core/config_validator.py
+++ b/mpf/core/config_validator.py
@@ -56,6 +56,7 @@ class ConfigValidator:
             "lstr": self._validate_type_lstr,
             "float": self._validate_type_float,
             "float_or_token": self._validate_type_or_token(self._validate_type_float),
+            "template_float_or_token": self._validate_type_or_token(self._validate_type_template_float),
             "int": self._validate_type_int,
             "int_or_token": self._validate_type_or_token(self._validate_type_int),
             "num": self._validate_type_num,
@@ -454,7 +455,7 @@ class ConfigValidator:
 
         return self.machine.placeholder_manager.build_quoted_string_template(item)
 
-    def _validate_type_template_float(self, item, validation_failure_info):
+    def _validate_type_template_float(self, item, validation_failure_info, param=None):
         if item is None:
             return None
         if not isinstance(item, (str, float, int)):

--- a/mpf/devices/sequence_shot.py
+++ b/mpf/devices/sequence_shot.py
@@ -174,7 +174,10 @@ class SequenceShot(SystemWideDevice, ModeDevice):
 
     def _completed(self):
         #measure the elapsed time between start and completion of the sequence
-        elapsed = self.machine.clock.get_time() - self._start_time
+        if self._start_time is not None:
+            elapsed = self.machine.clock.get_time() - self._start_time
+        else:
+            elapsed = 0
 
         """Post sequence complete event including its elapsed time to complete."""
         self.machine.events.post("{}_hit".format(self.name),elapsed=elapsed)

--- a/mpf/devices/sequence_shot.py
+++ b/mpf/devices/sequence_shot.py
@@ -21,7 +21,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
     collection = 'sequence_shots'
     class_label = 'sequence_shot'
 
-    __slots__ = ["delay", "active_sequences", "active_delays", "_sequence_events", "_delay_events"]
+    __slots__ = ["delay", "active_sequences", "active_delays", "_sequence_events", "_delay_events", "_start_time"]
 
     def __init__(self, machine, name):
         """Initialise sequence shot."""
@@ -33,6 +33,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
 
         self._sequence_events = []      # type: List[str]
         self._delay_events = {}         # type: Dict[str, int]
+        self._start_time = None
 
     @property
     def can_exist_outside_of_game(self):
@@ -131,6 +132,9 @@ class SequenceShot(SystemWideDevice, ModeDevice):
                            self.active_delays)
             return
 
+        #record start time
+        self._start_time = self.machine.clock.get_time()
+
         # create a new sequence
         seq_id = uuid.uuid4()
         next_event = self._sequence_events[1]
@@ -169,8 +173,11 @@ class SequenceShot(SystemWideDevice, ModeDevice):
             self.active_sequences.append(ActiveSequence(sequence.id, current_position_index, next_event))
 
     def _completed(self):
-        """Post sequence complete event."""
-        self.machine.events.post("{}_hit".format(self.name))
+        #measure the elapsed time between start and completion of the sequence
+        elapsed = self.machine.clock.get_time() - self._start_time
+
+        """Post sequence complete event including its elapsed time to complete."""
+        self.machine.events.post("{}_hit".format(self.name),elapsed=elapsed)
         '''event: (name)_hit
         desc: The sequence_shot called (name) was just completed.
         '''


### PR DESCRIPTION
The speed parameter of a show_player did not allow dynamic placeholders. This change allows a show to be played using a variable speed.

It also adds the elapsed time from start to completion of a sequence shot. This can be used in troubleshooting sequence_shot timeouts or for estimating ball speed. The elapsed time is posted in the sequence shot "hit" event so that it can be easily used to trigger other things like a speed calculation.

Both of these enable a concept for an "airspinner"--a virtual spinner that measures ball speed using switches and uses LED strips or rings to create a strobing or spinning effect.