### PR TITLE
Bugfix settings machine vars not persisting on subsequent data writes

### DIFF
--- a/mpf/core/machine_vars.py
+++ b/mpf/core/machine_vars.py
@@ -45,7 +45,8 @@ class MachineVariables(LogMixin):
 
                 continue
 
-            self.set_machine_var(name=name, value=settings['value'])
+            # Any value that was persisted before should be persisted again
+            self.set_machine_var(name=name, value=settings['value'], persist=True)
 
         self._load_initial_machine_vars()
 
@@ -169,7 +170,7 @@ class MachineVariables(LogMixin):
             self.machine_vars[name]['expire_secs'] = expire_secs
             self.machine_vars[name]['timeout'] = timeout
 
-    def set_machine_var(self, name: str, value: Any) -> None:
+    def set_machine_var(self, name: str, value: Any, persist=False) -> None:
         """Set the value of a machine variable.
 
         Args:
@@ -178,7 +179,7 @@ class MachineVariables(LogMixin):
             value: The value you're setting. This can be any Type.
         """
         if name not in self.machine_vars:
-            self.configure_machine_var(name=name, persist=False)
+            self.configure_machine_var(name=name, persist=persist)
             prev_value = None
             change = True
         else:


### PR DESCRIPTION
This PR fixes a bug that would occasionally (okay, _often_) forget saved machine vars and cause operator-configured settings to reset to default. After much digging and consternation, I believe I've figured out the cause and it's a simple fix.

### The Background
When MPF initializes, it first reads all machine variables from the _machine_vars.yaml_ file and then appends those with the (default) variables from the `machine_variables:` config section. All settings values are backed under-the-hood by machine variables, so this logic covers operator-adjustable settings as well.

### The Bug
While the code flow for loading machine vars from config section includes the configuration of a `persist` value, loading machine vars from the data file does _not_, which means all saved settings are defaulted to `persist: False`. Which is okay for a short while, but eventually something else is going to write an update to the persisted data (a new setting adjustment, or a player score, or something).

### The Impact
The way the logic of writing the data works is that the code looks through all the machine vars, finds all of the ones that are `persist: True`, and writes a complete new data file with those values. Remember from before that values previously loaded from the data file are `persist: False`, so all of those values get wiped.

### The Fix
This PR tweaks the flow for loading persisted values from a data file, explicitly flagging them each as `persist: True` in the machine variables controller. After all, if the value was persisted before, it should be persisted still, right?

The updated persistence logic takes place _after_ data validation and expiration checks, so it shouldn't impact data retention policies, and it fixes the issue of saved settings being forgotten on subsequent data writes.

![machine vars be forgettin](https://media.giphy.com/media/c6VvfoYhiUzIjoBkyi/giphy.gif)