### PR TITLE
Support machine_path arg in MC production builds

### DIFF
--- a/mpf/commands/build.py
+++ b/mpf/commands/build.py
@@ -54,12 +54,15 @@ class Command(MpfCommandLineParser):
     def production_bundle(self):
         """Create a production bundle."""
         config_loader = YamlMultifileConfigLoader(self.machine_path, self.args.configfile, False, False)
-        mpf_config = config_loader.load_mpf_config()
-        if self.args.mc:
-            mc_config = config_loader.load_mc_config()
 
+        mpf_config = config_loader.load_mpf_config()
         if self.args.dest_path:
             mpf_config.set_machine_path(self.args.dest_path)
+
+        if self.args.mc:
+            mc_config = config_loader.load_mc_config()
+            if self.args.dest_path:
+                mc_config.set_machine_path(self.args.dest_path)
 
         pickle.dump(mpf_config, open(ProductionConfigLoader.get_mpf_bundle_path(self.machine_path), "wb"))
         if self.args.mc:

--- a/mpf/core/config_loader.py
+++ b/mpf/core/config_loader.py
@@ -95,6 +95,10 @@ class MpfMcConfig:
         """Return machine path."""
         return self._machine_path
 
+    def set_machine_path(self, value):
+        """Set a new machine path."""
+        self._machine_path = value
+
     def get_config_spec(self):
         """Return config spec."""
         return self._config_spec


### PR DESCRIPTION
This PR extends the work done in #1612 , which added support for `machine_path` as a command line argument when building production bundles and the option to build and MPF bundle _without_ MC.

An oversight in that PR was that the `machine_path` arg was not passed to MC, obviously because I wasn't using MC at the time (hence the option to skip the MC build). But for projects that _do_ use MC, they need to have the custom `machine_path` in that bundle too.

This PR extends the custom `machine_path` functionality to the MC bundle, so that when both bundles are built they both use the custom path.

![machines making machines](https://media.giphy.com/media/mYqaRkXyoGbcY/giphy.gif)