### PR TITLE
Steppers: relative positions and home events

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1931,8 +1931,10 @@ steppers:
     ball_search_max: single|int|1
     ball_search_wait: single|ms|5s
     include_in_ball_search: single|bool|true
+    relative_positions: dict|float:str|None
     reset_position: single|int|0
     reset_events: event_handler|event_handler:ms|machine_reset_phase_3, ball_starting, ball_will_end, service_mode_entered
+    rollover_position: single|int|0
     number: single|str|
     platform: single|str|None
     platform_settings: single|dict|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1936,7 +1936,6 @@ steppers:
     relative_positions: dict|float:str|None
     reset_position: single|int|0
     reset_events: event_handler|event_handler:ms|machine_reset_phase_3, ball_starting, ball_will_end, service_mode_entered
-    rollover_position: single|int|0
     number: single|str|
     platform: single|str|None
     platform_settings: single|dict|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -2320,6 +2320,7 @@ widgets:
         force_complete_event: single|event_handler|None
         block_events: list|event_handler|None
         release_events: list|event_handler|None
+        bitmap_font: single|bool_or_token|false
         bold: single|bool_or_token|false
         italic: single|bool_or_token|false
         number_grouping: single|bool_or_token|false

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1921,6 +1921,7 @@ steppers:
     __valid_in__: machine
     __type__: device
     named_positions: dict|float:str|None
+    home_events: event_handler|event_handler:ms|None
     homing_mode: single|enum(hardware,switch)|hardware
     homing_switch: single|machine(switches)|None
     homing_direction: single|enum(clockwise,counterclockwise)|clockwise

--- a/mpf/tests/machine_files/stepper/config/config.yaml
+++ b/mpf/tests/machine_files/stepper/config/config.yaml
@@ -5,6 +5,7 @@ steppers:
         number: 1
         pos_min:   -5 #user units (negative is behind home flag)
         pos_max: 1000 #user units
+        home_events: test_home
         homing_direction: clockwise
         homing_mode: hardware
         reset_position: 0

--- a/mpf/tests/machine_files/stepper/config/config.yaml
+++ b/mpf/tests/machine_files/stepper/config/config.yaml
@@ -15,6 +15,10 @@ steppers:
             -5: test_00
             999: test_01
             500: test_10
+        relative_positions:
+            -2: test_rel_00
+            25: test_rel_01
+            100: test_rel_02
 
 
 # this is needed to test ball search

--- a/mpf/tests/test_Stepper.py
+++ b/mpf/tests/test_Stepper.py
@@ -114,6 +114,13 @@ class TestStepper(MpfTestCase):
         self.machine.clock.loop.run_until_complete(event_future)
         self.assertEqual(500.0, stepper._current_position, 0)
 
+        # post a home event
+        event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
+        self.post_event("test_home")
+        self.machine.clock.loop.run_until_complete(event_future)
+        # should go to reset position
+        self.assertEqual(0.0, stepper._current_position)
+
     def test_ball_search(self):
         stepper = self.machine.steppers["linearAxis_stepper"]
 

--- a/mpf/tests/test_Stepper.py
+++ b/mpf/tests/test_Stepper.py
@@ -96,19 +96,19 @@ class TestStepper(MpfTestCase):
         # should go to reset position
         self.assertEqual(0.0, stepper._current_position)
 
-        # post another defined event
+        # post a named_position defined event
         event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
         self.post_event("test_00")
         self.machine.clock.loop.run_until_complete(event_future)
         self.assertEqual(-5.0, stepper._current_position, 0)
 
-        # post another defined event
+        # post a named_position defined event
         event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
         self.post_event("test_01")
         self.machine.clock.loop.run_until_complete(event_future)
         self.assertEqual(999.0, stepper._current_position, 0)
 
-        # post another defined event
+        # post a named_position defined event
         event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
         self.post_event("test_10")
         self.machine.clock.loop.run_until_complete(event_future)
@@ -120,6 +120,24 @@ class TestStepper(MpfTestCase):
         self.machine.clock.loop.run_until_complete(event_future)
         # should go to reset position
         self.assertEqual(0.0, stepper._current_position)
+
+        # post a relative_position defined event
+        event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
+        self.post_event("test_rel_00")
+        self.machine.clock.loop.run_until_complete(event_future)
+        self.assertEqual(-2.0, stepper._current_position, 0)
+
+        # post a relative_position defined event
+        event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
+        self.post_event("test_rel_01")
+        self.machine.clock.loop.run_until_complete(event_future)
+        self.assertEqual(23.0, stepper._current_position, 0)
+
+        # post a relative_position defined event
+        event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
+        self.post_event("test_rel_02")
+        self.machine.clock.loop.run_until_complete(event_future)
+        self.assertEqual(124.0, stepper._current_position, 0)
 
     def test_ball_search(self):
         stepper = self.machine.steppers["linearAxis_stepper"]

--- a/mpf/tests/test_Stepper.py
+++ b/mpf/tests/test_Stepper.py
@@ -137,7 +137,7 @@ class TestStepper(MpfTestCase):
         event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")
         self.post_event("test_rel_02")
         self.machine.clock.loop.run_until_complete(event_future)
-        self.assertEqual(124.0, stepper._current_position, 0)
+        self.assertEqual(123.0, stepper._current_position, 0)
 
     def test_ball_search(self):
         stepper = self.machine.steppers["linearAxis_stepper"]


### PR DESCRIPTION
This PR adds support for two new configuration options for Stepper motors: _home_events_ and _relative_positions_.

### Home Events
Stepper motors can be configured with a `home_events:` section that defines event names that will cause the stepper motor to re-home itself. This is different from using `reset_events` and `reset_position`, which could be used to the same effect. However, some stepper motors (like Pololu) only support a forced direction during the home command. For users whose steppers cannot run both directions, using `home_events` (in combination with `homing_direction`) instead of `reset_events` is the only way to guarantee the motor turns in the desired direction.

_Syntax:_
```
steppers:
  unidirectional_stepper:
    home_events: home_stepper, ball_starting, ball_will_end
    reset_events: []
```

Note that the default config option for steppers includes `reset_events` for the following: _machine_reset_phase_3, ball_starting, ball_will_end, service_mode_entered_. To prevent these events from also attempting a reset, the config should explicitly define reset events as an empty list (example above).

### Relative Positions
Stepper motors already include a `named_positions` config option that defines a key/value dictionary of absolute motor positions and event names to trigger a move to those locations. This PR adds a parallel config option `relative_positions`, which defines key/value pairs of _relative_ motor positions and event names to trigger the corresponding moves. 

This new configuration allows steppers to move by a fixed amount on a given event, regardless of its current position.

_Syntax:_
```
steppers:
  long_running_stepper:
    relative_positions:
      -10: move_stepper_back_ten
      10: move_stepper_forward_ten
      50: move_stepper_forward_fifty
```

### Testing
Unit tests are included to cover the new functionality, and the `relative_positions` logic has been used privately by Steve Kondris (Led Zepplin) for over a year.

Additionally, these changes are on top of existing functionality and don't change the underlying behavior, so users with existing steppers should not have any impact.

![Step carefully](https://media.giphy.com/media/14aLuWEyopPrFK/giphy.gif)