### PR TITLE
Audits: store average player score as int

### DIFF
--- a/mpf/plugins/auditor.py
+++ b/mpf/plugins/auditor.py
@@ -224,7 +224,7 @@ class Auditor:
                         self.current_audits['player'][item]['top'],
                         self.config['num_player_top_records']))
 
-                self.current_audits['player'][item]['average'] = (
+                self.current_audits['player'][item]['average'] = int(
                     ((self.current_audits['player'][item]['total'] *
                       self.current_audits['player'][item]['average']) +
                      self.machine.game.player[item]) /

--- a/mpf/tests/machine_files/auditor/modes/base/config/base.yaml
+++ b/mpf/tests/machine_files/auditor/modes/base/config/base.yaml
@@ -9,3 +9,5 @@ variable_player:
       my_var: 100
     add_not_audited:
       not_audited: 100
+    add_score_odd:
+      score: 123

--- a/mpf/tests/test_Auditor.py
+++ b/mpf/tests/test_Auditor.py
@@ -64,6 +64,18 @@ class TestAuditor(MpfFakeGameTestCase):
                           'my_var': {'top': [200, 0], 'average': 100.0, 'total': 2}},
                          auditor.data_manager.written_data["player"])
 
+        # test rounding the average to an integer
+        self.start_game()
+
+        self.post_event("add_score")
+        self.post_event("add_score_odd")
+        self.assertPlayerVarEqual(223, "score")
+
+        self.drain_all_balls()
+        self.assertGameIsNotRunning()
+
+        self.assertEqual(174, auditor.current_audits['player']['score']['average'])
+
     def test_auditor_switches_events(self):
         auditor = self.machine.plugins[0]
         self.assertIsInstance(auditor, Auditor)


### PR DESCRIPTION
This PR makes a simple change to the Auditor plugin that stores the average player score as an integer. This will round out floats which would be common (and irrelevant) when averaging large numbers, and makes display onscreen simpler without long strings of digits.

![Just average](https://media.giphy.com/media/l0K3ZRJ1IXfxgmMQU/giphy.gif)