### PR TITLE
Audio Service Menu and FAST Audio Board Support

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1812,6 +1812,7 @@ sound_system:
 sound_system_tracks:
     type: single|enum(standard,sound_loop,playlist)|standard
     volume: single|gain|0.5
+    label: single|str|None
     events_when_played: list|event_posted|None
     events_when_stopped: list|event_posted|None
     events_when_paused: list|event_posted|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -663,6 +663,7 @@ fast_aud:
     port: list|str|auto
     baud: single|int|230400
     debug: single|bool|false
+    optional: single|bool|false
     console_log: single|enum(none,basic,full)|none
     file_log: single|enum(none,basic,full)|basic
     pin1_pulse_time: single|ms|100

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -692,7 +692,7 @@ fast_aud:
     headphones_levels_list: list|int|None
     headphones_level: single|enum(headphones,line)|headphones
     mute_speakers_with_headphones: single|bool|true
-    link_main_to_main: single|bool|true
+    link_main_to_main: single|bool|false
     link_sub_to_main: single|bool|true
     link_headphones_to_main: single|bool|false
 

--- a/mpf/modes/service_dmd/config/service_dmd.yaml
+++ b/mpf/modes/service_dmd/config/service_dmd.yaml
@@ -93,6 +93,21 @@ slide_player:
     service_settings:
       action: remove
 
+  # volume:
+  service_volume_start:
+    service_settings:
+      action: play
+      priority: 2
+    service_settings_edit:
+      action: remove
+  service_volume_edit:
+    service_settings_edit:
+      action: play
+      priority: 3
+  service_volume_stop:
+    service_settings:
+      action: remove
+
   # audits:
   service_audits_menu_show:
     service_audits_menu:

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -73,6 +73,10 @@ class FastSerialCommunicator(LogMixin):
 
     async def connect(self):
         for port in self.config['port']:
+            # If this is an auto-detect that failed to detect, the port will
+            # just be 'auto' and there's no reason to try and connect to it.
+            if port == 'auto':
+                continue
             self.log.info(f"Trying to connect to {port} at {self.config['baud']}bps")
             success = False
 
@@ -88,7 +92,7 @@ class FastSerialCommunicator(LogMixin):
 
                     # if we are in production mode, retry
                     await asyncio.sleep(.1)
-                    self.log.warning("Connection to %s failed. Will retry.", port)
+                    self.log.warning("Connection to port %s failed. Will retry.", port)
                 else:
                     # we got a connection
                     self.log.info(f"Connected to {port} at {self.config['baud']}bps")

--- a/mpf/platforms/fast/fast_audio.py
+++ b/mpf/platforms/fast/fast_audio.py
@@ -193,3 +193,7 @@ class FASTAudioInterface(LogMixin):
         if not ms:
             ms = self.control_pin_pulse_times[7]
         self.communicator.pulse_control_pin(7, ms)
+
+    def save_settings_to_firmware(self, **kwargs):
+        del kwargs
+        self.communicator.save_settings_to_firmware()

--- a/mpf/platforms/fast/fast_audio.py
+++ b/mpf/platforms/fast/fast_audio.py
@@ -13,9 +13,9 @@ class FASTAudioInterface(LogMixin):
         self.machine = platform.machine
         self.communicator = communicator
         self.amps = {
-            'main': { 'label': "Speakers" },
-            'sub': { 'label': "Subwoofer" },
-            'headphones': { 'label': "Headphones" }
+            'main': { 'name': 'fast_audio_main', 'label': "Speakers" },
+            'sub': { 'name': 'fast_audio_sub', 'label': "Subwoofer" },
+            'headphones': { 'name': 'fast_audio_headphones', 'label': "Headphones" }
         }
         self.control_pin_pulse_times = list()
 
@@ -30,10 +30,12 @@ class FASTAudioInterface(LogMixin):
         self._register_event_handlers()
 
     def _configure_machine_vars(self):
-        for amp in self.amps.keys():
-            var_name = f'fast_audio_{amp}_volume'
+        for amp_name in self.amps.keys():
+            var_name = f'fast_audio_{amp_name}_volume'
 
-            if amp != 'main' and self.communicator.config[f'link_{amp}_to_main']:
+            # Is there a race condition on first boot if the linked amp
+            # comes in the iteration before 'main' is written?
+            if amp_name != 'main' and self.communicator.config[f'link_{amp_name}_to_main']:
                 self.machine.variables.set_machine_var(
                     name=var_name,
                     value=self.machine.variables.get_machine_var('fast_audio_main_volume'),
@@ -41,33 +43,35 @@ class FASTAudioInterface(LogMixin):
 
             elif not self.machine.variables.is_machine_var(var_name):
                 self.machine.variables.set_machine_var(name=var_name,
-                                                    value=self.communicator.config[f'default_{amp}_volume'],
+                                                    value=self.communicator.config[f'default_{amp_name}_volume'],
                                                     persist=self.communicator.config[f'persist_volume_settings'])
     def _init_amps(self):
-        for amp in self.amps.keys():
-            self.amps[amp]['steps'] = self.communicator.config[f'{amp}_steps']
-            self.amps[amp]['max_volume'] = self.communicator.config[f'max_hw_volume_{amp}']
-            self.amps[amp]['levels_list'] = self.communicator.config[f'{amp}_levels_list']
-            self.amps[amp]['link_to_main'] = self.communicator.config[f'link_{amp}_to_main']
-            self.amps[amp]['volume'] = self.get_volume(amp)
+        for amp_name in self.amps.keys():
+            amp = self.amps[amp_name]
+            amp['steps'] = self.communicator.config[f'{amp_name}_steps']
+            amp['max_volume'] = self.communicator.config[f'max_hw_volume_{amp_name}']
+            amp['levels_list'] = self.communicator.config[f'{amp_name}_levels_list']
+            amp['link_to_main'] = self.communicator.config[f'link_{amp_name}_to_main']
 
             # Just set everything here. The communicator will send the
             # config as part of its init process later
-            if self.communicator.config[f'{amp}_amp_enabled']:
-                self.communicator.enable_amp(amp, send_now=False)
+            if self.communicator.config[f'{amp_name}_amp_enabled']:
+                self.communicator.enable_amp(amp_name, send_now=False)
 
-            if not self.amps[amp]['levels_list']:
-                self._create_levels_list(amp)
+            if not amp['levels_list']:
+                self._create_levels_list(amp_name)
             else:
                 # if we have a levels list in the config, make sure the steps num is right
-                self.amps[amp]['steps'] = len(self.amps[amp]['levels_list']) - 1
+                amp['steps'] = len(amp['levels_list']) - 1
 
-            if self.amps[amp]['link_to_main'] and len(self.amps[amp]['levels_list']) != len(self.amps['main']['levels_list']):
-                raise AssertionError(f"Cannot link {amp} to main. The number of volume steps must be the same. "
+            if amp['link_to_main'] and len(amp['levels_list']) != len(self.amps['main']['levels_list']):
+                raise AssertionError(f"Cannot link {amp_name} to main. The number of volume steps must be the same. "
                                      f"Main has {len(self.amps['main']['levels_list'])} steps, "
-                                     f"but {amp} has {len(self.amps[amp]['levels_list'])} steps.")
+                                     f"but {amp_name} has {len(amp['levels_list'])} steps.")
 
-            self.communicator.set_volume(amp, self.get_hw_volume(amp), send_now=False)
+        # Finish all the configurations first, then iterate to set volumes (for linked amps)
+        for amp_name in self.amps.keys():
+            self._set_volume(amp_name, self.get_volume(amp_name))
 
     def _configure_control_pins(self):
         for i in range(6):
@@ -88,94 +92,80 @@ class FASTAudioInterface(LogMixin):
         self.communicator.set_phones_behavior(phones, send_now=False)
 
     def _register_event_handlers(self):
-        self.platform.machine.events.add_handler('machine_var_fast_audio_main_volume', self.set_volume, amp='main')
-        self.platform.machine.events.add_handler('machine_var_fast_audio_sub_volume', self.set_volume, amp='sub')
-        self.platform.machine.events.add_handler('machine_var_fast_audio_headphones_volume', self.set_volume, amp='headphones')
+        self.platform.machine.events.add_handler('machine_var_fast_audio_main_volume', self._set_volume, amp_name='main')
+        self.platform.machine.events.add_handler('machine_var_fast_audio_sub_volume', self._set_volume, amp_name='sub')
+        self.platform.machine.events.add_handler('machine_var_fast_audio_headphones_volume', self._set_volume, amp_name='headphones')
         self.platform.machine.events.add_handler('fast_audio_temp_volume', self.temp_volume)
         self.platform.machine.events.add_handler('fast_audio_restore', self.restore_volume)
         self.platform.machine.events.add_handler('fast_audio_pulse_lcd_pin', self.pulse_lcd_pin)
         self.platform.machine.events.add_handler('fast_audio_pulse_power_pin', self.pulse_power_pin)
         self.platform.machine.events.add_handler('fast_audio_pulse_reset_pin', self.pulse_reset_pin)
 
-    def _create_levels_list(self, amp):
-        steps = self.communicator.config[f'{amp}_steps']
-        max_volume = self.communicator.config[f'max_hw_volume_{amp}']
+    def _create_levels_list(self, amp_name):
+        steps = self.communicator.config[f'{amp_name}_steps']
+        max_volume = self.communicator.config[f'max_hw_volume_{amp_name}']
         step_percent = 1 / steps
 
         if max_volume > 63:
-            raise AssertionError(f"Invalid max_hw_volume_{amp}: {max_volume}")
+            raise AssertionError(f"Invalid max_hw_volume_{amp_name}: {max_volume}")
 
         for i in range(steps):
             volume = ceil(max_volume * (1 - (i * step_percent)))
-            self.amps[amp]['levels_list'].append(volume)
+            self.amps[amp_name]['levels_list'].append(volume)
 
         # technically our list is number of volume levels + 1, since that's more logicial
         # for humans. e.g. 20 volume steps of 5% each is 0-100% volume, which
         # has 21 items in the list.
-        self.amps[amp]['levels_list'].append(0)
-        self.amps[amp]['levels_list'].reverse()
+        self.amps[amp_name]['levels_list'].append(0)
+        self.amps[amp_name]['levels_list'].reverse()
 
-    def send_volume_to_hw(self, amp=None):
+    def send_volume_to_hw(self, amp_name=None):
         """Send the current volume to the hardware."""
-        if amp is None:
-            for amp in self.amps.keys():
-                self.send_volume_to_hw(amp)
+        if amp_name is None:
+            for amp_name in self.amps.keys():
+                self.send_volume_to_hw(amp_name)
             return
 
-        self.communicator.set_volume(amp, self.get_hw_volume(amp))
+        self.communicator.set_volume(amp_name, self.get_volume(amp_name))
 
-    def get_hw_volume(self, amp):
-        try:
-            return self.amps[amp]['levels_list'][self.get_volume(amp)]
-        except IndexError:
-            raise AssertionError(f"Invalid volume {self.get_volume(amp)} for amp: {amp}.",
-                                 f"There are only {len(self.amps[amp]['levels_list'])} entries in the volume levels list.")
-
-    def increase_volume(self, amp, change=1, **kwargs):
-        """Increase the volume by the specified number of steps."""
-        self.set_volume(amp, self.amps[amp]['volume'] + int(change))
-
-    def decrease_volume(self, amp, change=1, **kwargs):
-        """Decrease the volume by the specified number of steps."""
-        self.set_volume(amp, self.amps[amp]['volume'] - int(change))
-
-    def set_volume(self, amp, value=0, **kwargs):
-        """Set the amp volume to the specified level, using the volume map"""
+    def _set_volume(self, amp_name, value=0, **kwargs):
+        """Set the amp volume to the specified level, in absolute units.
+            This is a private method, volume changes should be instigated by
+            updating the corresponding machine variable."""
         value = int(value)
 
-        if value > self.amps[amp]['steps']:
-            value = self.amps[amp]['steps']
+        if value > self.amps[amp_name]['max_volume']:
+            value = self.amps[amp_name]['max_volume']
         elif value < 0:
             value = 0
 
-        self.send_volume_to_hw(amp)
-        self._set_machine_var_volume(amp, value)
+        self.debug_log("Writing FAST amp volume %s to %s (decimal)", amp_name, value)
+        self.send_volume_to_hw(amp_name)
 
-        if amp == self.amps['main']:
-            for other_amp in self.amps.keys():
-                if self.amps[other_amp]['link_to_main'] and other_amp != amp:
-                    self._set_machine_var_volume(other_amp, self.amps[amp]['levels_list'][value])
-                    self.send_volume_to_hw(other_amp)
+        if amp_name == 'main':
+            for other_amp_name in self.amps.keys():
+                if other_amp_name != amp_name and self.amps[other_amp_name]['link_to_main']:
+                    # Update the machine var, which will be caught and handled
+                    self._set_machine_var_volume(other_amp_name, value)
 
-    def get_volume(self, amp, **kwargs):
-        return self.machine.variables.get_machine_var(f'fast_audio_{amp}_volume')
+    def get_volume(self, amp_name, **kwargs):
+        return self.machine.variables.get_machine_var(f'fast_audio_{amp_name}_volume')
 
-    def _set_machine_var_volume(self, amp, value):
-        amp['volume'] = value
-        self.machine.variables.set_machine_var(f'fast_audio_{amp}_volume', value)
+    def _set_machine_var_volume(self, amp_name, value):
+        self.machine.variables.set_machine_var(f'fast_audio_{amp_name}_volume', value)
 
-    def temp_volume(self, amp, change=1, **kwargs):
-        """Temporarily change the volume by the specified number of steps, up or down,
+    def temp_volume(self, amp_name, change=1, **kwargs):
+        """Temporarily change the volume by the specified number of units, up or down,
         but without changing the machine var. This is used for ducking or other
         temporary volume changes where you don't want to save it to disk.
         """
         change = int(change)
-        self.communicator.set_volume(amp, self.amps['main']['levels_list'][self.get_volume(amp) + change],
+        self.communicator.set_volume(amp_name, self.get_volume(amp_name) + change,
                                      send_now=True)
 
-    def restore_volume(self, amp, **kwargs):
+    def restore_volume(self, amp_name, **kwargs):
         """Restore the volume to the value to the machine var value"""
-        self.communicator.set_volume(amp, self.amps['main']['levels_list'][self.get_volume(amp)],
+        self.communicator.set_volume(amp_name, self.get_volume(amp_name),
                                      send_now=True)
 
     def pulse_lcd_pin(self, pin, ms=None, **kwargs):

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -596,8 +596,9 @@ class MpfTestCase(unittest.TestCase):
             self.loop.run_once()
             if timeout and time.time() > start + timeout:
                 raise AssertionError("Start took more than {}s".format(timeout))
-
         # trigger exception if there was one
+        if self._exception:
+            raise(self._exception['exception'])
         init.result()
 
     def _mock_event_handler(self, event_name, **kwargs):

--- a/mpf/tests/test_Fast_Audio.py
+++ b/mpf/tests/test_Fast_Audio.py
@@ -15,18 +15,20 @@ class TestFastAudio(TestFastBase):
     def create_expected_commands(self):
 
         if self._testMethodName == 'test_machine_var_loading':
-            self.serial_connections['aud'].expected_commands = {'AM:0F':'AM:0F',  # all 3 amps enabled, hp is line level
-                                                                'AV:2D':'AV:2D',  # 45
-                                                                'AS:0F':'AS:0F',  # 15
-                                                                'AH:36':'AH:36',}  # 54
+            self.serial_connections['aud'].expected_commands = {
+                'AM:0F':'AM:0F',  # all 3 amps enabled, hp is line level
+                'AH:11':'AH:11',
+                'AV:0F':'AV:0F',
+                'AS:0F':'AS:0F',
+            }
 
             self.serial_connections['aud'].autorespond_commands['WD:3E8'] = 'WD:3E8,03'
 
         else:
             self.serial_connections['aud'].expected_commands = {'AM:0B':'AM:0B',
-                                                                'AV:11':'AV:11',
-                                                                'AS:17':'AS:17',
-                                                                'AH:28':'AH:28',}
+                                                                'AV:08':'AV:08',
+                                                                'AS:09':'AS:09',
+                                                                'AH:0A':'AH:0A',}
 
     def test_audio_basics(self):
 
@@ -55,49 +57,49 @@ class TestFastAudio(TestFastBase):
         self.assertEqual(9, fast_audio.get_volume('sub'))
         self.assertEqual(10, fast_audio.get_volume('headphones'))
 
-        self.assertEqual(17, fast_audio.get_hw_volume('main'))
-        self.assertEqual(23, fast_audio.get_hw_volume('sub'))
-        self.assertEqual(40, fast_audio.get_hw_volume('headphones'))
+        self.assertEqual('08', fast_audio.communicator._volume_to_hw(fast_audio.get_volume('main')))
+        self.assertEqual('09', fast_audio.communicator._volume_to_hw(fast_audio.get_volume('sub')))
+        self.assertEqual('0A', fast_audio.communicator._volume_to_hw(fast_audio.get_volume('headphones')))
 
-        self.assertEqual('11', self.aud_cpu.main_volume)
-        self.assertEqual('17', self.aud_cpu.sub_volume)
-        self.assertEqual('28', self.aud_cpu.headphones_volume)
+        self.assertEqual('08', self.aud_cpu.main_volume)
+        self.assertEqual('09', self.aud_cpu.sub_volume)
+        self.assertEqual('0A', self.aud_cpu.headphones_volume)
 
         self.assertTrue(fast_audio.communicator.amps['main']['enabled'])
         self.assertTrue(fast_audio.communicator.amps['sub']['enabled'])
         self.assertTrue(fast_audio.communicator.amps['headphones']['enabled'])
 
-        self.assertTrue(fast_audio.amps['main']['link_to_main'])
+        self.assertFalse(fast_audio.amps['main']['link_to_main'])
         self.assertFalse(fast_audio.amps['sub']['link_to_main'])
         self.assertFalse(fast_audio.amps['headphones']['link_to_main'])
 
         # Change the volume var and make sure it's reflected in the hardware
-        self.aud_cpu.expected_commands['AV:13'] = 'AV:13'
-        self.machine.variables.set_machine_var('fast_audio_main_volume', 9)
+        self.aud_cpu.expected_commands['AV:0D'] = 'AV:0D'
+        self.machine.variables.set_machine_var('fast_audio_main_volume', 13)
         self.advance_time_and_run(1)
-        self.assertEqual('13', self.aud_cpu.main_volume)
-        self.assertEqual(9, fast_audio.get_volume('main'))
-        self.assertEqual(19, fast_audio.get_hw_volume('main'))
+        self.assertEqual('0D', self.aud_cpu.main_volume)
+        self.assertEqual(13, fast_audio.get_volume('main'))
+        self.assertEqual('0D', fast_audio.communicator._volume_to_hw(fast_audio.get_volume('main')))
 
         # Test machine var player events work from config
-        self.aud_cpu.expected_commands['AV:16'] = 'AV:16'
+        self.aud_cpu.expected_commands['AV:0E'] = 'AV:0E'
         self.post_event('increase_main_volume', 1)
-        self.assertEqual('16', self.aud_cpu.main_volume)
-        self.assertEqual(10, fast_audio.get_volume('main'))
-        self.assertEqual(22, fast_audio.get_hw_volume('main'))
+        self.assertEqual('0E', self.aud_cpu.main_volume)
+        self.assertEqual(14, fast_audio.get_volume('main'))
+        self.assertEqual('0E', fast_audio.communicator._volume_to_hw(fast_audio.get_volume('main')))
 
         # test ducking / restore
-        self.assertEqual('16', fast_audio.communicator.amps['main']['volume'])
-        self.aud_cpu.expected_commands['AV:20'] = 'AV:20'
-        self.post_event('fast_audio_temp_volume', amp='main', change=5)
+        self.assertEqual(14, fast_audio.communicator.amps['main']['volume'])
+        self.aud_cpu.expected_commands['AV:13'] = 'AV:13'
+        self.post_event('fast_audio_temp_volume', amp_name='main', change=5)
         self.advance_time_and_run(1)
-        self.assertEqual('20', fast_audio.communicator.amps['main']['volume'])
-        self.assertEqual(10, self.machine.variables.get_machine_var('fast_audio_main_volume'))
+        self.assertEqual(19, fast_audio.communicator.amps['main']['volume'])
+        self.assertEqual(14, self.machine.variables.get_machine_var('fast_audio_main_volume'))
 
-        self.aud_cpu.expected_commands['AV:16'] = 'AV:16'
-        self.post_event('fast_audio_restore', amp='main')
+        self.aud_cpu.expected_commands['AV:0E'] = 'AV:0E'
+        self.post_event('fast_audio_restore', amp_name='main')
         self.advance_time_and_run(1)
-        self.assertEqual('16', fast_audio.communicator.amps['main']['volume'])
+        self.assertEqual(14, fast_audio.communicator.amps['main']['volume'])
 
     def test_control_pins(self):
         self.aud_cpu.expected_commands['XO:01,63'] = 'XO:P'
@@ -110,7 +112,10 @@ class TestFastAudio(TestFastBase):
 
     @test_config('audio2.yaml')
     def test_machine_var_loading(self):
+        fast_audio = self.machine.default_platform.audio_interface
         self.assertEqual(15, self.machine.variables.get_machine_var('fast_audio_main_volume'))
-        # sub is linked to main, so it will be 15 even though the machine var is 2
+        self.assertEqual(15, fast_audio.communicator.amps['main']['volume'])
+        # sub is linked to main, so it will be 15 even though the config value is 2
         self.assertEqual(15, self.machine.variables.get_machine_var('fast_audio_sub_volume'))
+        self.assertEqual(15, fast_audio.communicator.amps['sub']['volume'])
         self.assertEqual(17, self.machine.variables.get_machine_var('fast_audio_headphones_volume'))

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -141,7 +141,15 @@ class TestServiceMode(MpfFakeGameTestCase):
 
         self.hit_and_release_switch("s_service_up")
         self.advance_time_and_run()
+        self.assertEventCalledWith("service_menu_selected", label='Audio Menu')
+
+        self.hit_and_release_switch("s_service_up")
+        self.advance_time_and_run()
         self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
+
+        self.hit_and_release_switch("s_service_down")
+        self.advance_time_and_run()
+        self.assertEventCalledWith("service_menu_selected", label='Audio Menu')
 
         self.hit_and_release_switch("s_service_down")
         self.advance_time_and_run()


### PR DESCRIPTION
This PR implements a new Service Menu for Audio Controls, including both software and hardware volume controls, and refactors the FAST Audio Board code.

## Audio Service Menu -> Software Levels

The Audio Menu is added to the default service menu and populates a "Software Levels" submenu. The submenu parses the machine's `sound_system:` configuration to identify each of the `tracks` and offers volume control for each track. To support this functionality, the Tracks class is updated to use a machine variable for its volume level, similar to how the main volume control does. The Tracks also support the `label` config option for displaying a human-friendly name in the service menu.

The menu is currently hard-coded to offer volume levels from 0-100% at 5% increments. A future update could make this customizable, if desired.

The various menu and submenus use the same formatting and kwargs as the other service menu, so no new slides are needed if a user has already established (or is using the default) service slides.

## Audio Service Menu -> Hardware Levels

The Audio Menu can detect the presence of a hardware sound device (currently, only the FAST Audio Board is supported) and provide level-setting for the hardware using its serial API. Each hardware platform defines its level options (e.g. speakers, subwoofer, headphones) and exposes a method to change their level.

When the Audio Service menu is loaded, it checks whether a hardware device is attached and if so, automatically adds the _Hardware Levels_ submenu next to the _Software Levels_. If no hardware device is detected, the submenu is not added.

There is also an option in the submenu to write the current level settings to the hardware device, which is automatically added if the device supports a `write_to_firmware()` method.

## FAST Audio Board

This PR refactors much of the initial implementation of the FAST Audio Board by @toomanybrians based on my testing and usage. The main changes are:

* Rename variables to use `amp_name` for string-type refs to amp types, and reserve `amp` variables for objects containing properties about the amp.
* Pass, store, and load volume levels as decimal integers, and only convert to hexadecimal when writing over serial
* Track volume levels based on the absolute units, rather than steps. This prevents accidental blowout if the number of steps changes.
* Make the audio board connection "optional", so it can be defined in the configs but isn't required to run the game. For users with limited USB ports or looking to scrape every possible CPU resource, disconnecting the audio board during normal play can be advantageous.
* Eliminate a redundant initialization call prior to opening the hardware connection
* Don't link the main speaker volume to itself by default (saves code paths)

### Other FAST Changes

This PR also improves the port auto-detection logic to prevent hangs when a certain device is not attached. Previously, MPF would identify the ports it needs to auto-detect and wait until each one reported in. If one is not connected, the startup flow will hang. This PR changes that logic with a few tweaks:
* Any port that has a `pid` and `vid` of a FAST device but doesn't respond to an `ID:` command will give up after 5 attempts, instead of probing indefinitely.
* Any port that didn't successfully find an auto-detect port won't attempt to connect, instead of trying to open port `"auto"`.
* Any device tagged as `"optional"` in the configs won't block startup if it's not found (see optional audio board above).

### Future Improvements
The FAST Audio Board and its amps do not use a base class or interface, so this implementation currently cannot scale to other platforms. Abstracting the properties and methods would allow other devices to be controlled.

The FAST Audio currently has two classes, an Interface for exposing volume levels and a Connector for communicating over serial. Each of these classes has a collection of `amp` objects (basic Dict instances) with different properties and uses. It would simplify understanding to build an Amp class that could be shared/passed between these two consumers.

## Testing

All tests have been updated and pass. I've verified the functionality manually on my Mass Effect 2 machine, with both software and hardware volume controls, saved variables, and service menu interactions. However this is a big set of changes so any feedback and testers are appreciated!

![can you hear me](https://media.giphy.com/media/j3W89cZYpY9AOJtZBq/giphy.gif)