### PR TITLE
Bonus score rounding option

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -286,6 +286,8 @@ bonus_mode_settings:
     end_bonus_event: single|event_handler|None
     keep_multiplier: single|template_bool|False
     bonus_entries: list|subconfig(bonus_entries)|
+    rounding_value: single|int|
+    rounding_direction: single|str|up
 bonus_entries:
     event: single|event_posted|
     score: single|template_int|

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -286,7 +286,7 @@ bonus_mode_settings:
     end_bonus_event: single|event_handler|None
     keep_multiplier: single|template_bool|False
     bonus_entries: list|subconfig(bonus_entries)|
-    rounding_value: single|int|
+    rounding_value: single|int|None
     rounding_direction: single|str|up
 bonus_entries:
     event: single|event_posted|

--- a/mpf/modes/bonus/code/bonus.py
+++ b/mpf/modes/bonus/code/bonus.py
@@ -100,6 +100,13 @@ class Bonus(Mode):
             self._bonus_next_item()
             return
 
+        if self.settings["rounding_value"] and (r := (score % self.settings["rounding_value"])):
+            self.debug_log("rounding bonus score %s remainder of %s", score, r)
+            if self.settings["rounding_direction"] == "down":
+                score -= r
+            else:
+                score += self.settings["rounding_value"] - r
+
         self.debug_log("Bonus Entry '{}': score: {} player_score_entry: {}={}".
                        format(entry['event'], score,
                               entry['player_score_entry'], hits))


### PR DESCRIPTION
This PR creates a new option for Bonus mode scoring to allow rounding to a certain increment.

By using the `rounding_value:` config option, you can specify a rounding amount for the bonus calculations (e.g. `10`, `100`, `1000`) and all bonus scores will be rounded to an even amount at that increment. This is helpful for games that like to keep nice round scoring values, but have bonus calculations that may produce other numbers.

The `rounding_direction:` config option controls whether the calculated bonus score is rounded up or down to reach the nearest rounding value. By default the score will be rounded up.

![bonus!](https://media.giphy.com/media/6IH1M53L5Dj5kcgTVl/giphy.gif)