### PR TITLE
Bugfix: Multiplayer conditional asset pools crash

### DIFF
--- a/mpf/commands/game.py
+++ b/mpf/commands/game.py
@@ -168,7 +168,10 @@ class Command:
             console_log.setLevel(logging.ERROR)
         else:
             console_log = logging.StreamHandler()
-            console_log.setLevel(self.args.consoleloglevel)
+            if self.args.production:
+                console_log.setLevel(logging.ERROR)
+            else:
+                console_log.setLevel(self.args.consoleloglevel)
 
         console_log.setFormatter(logging.Formatter(
             '%(asctime)s.%(msecs)03d : %(levelname)s [%(name)s] %(message)s', "%H:%M:%S"))

--- a/mpf/core/assets.py
+++ b/mpf/core/assets.py
@@ -792,7 +792,7 @@ class AssetPool:
                   if not asset[2] or asset[2].evaluate([])]  # type: List[TNullableAssetEntry]
         # Avoid crashes, return None as the asset if no conditions evaluate true
         if not result:
-            self.warning_log("AssetPool {}: {}".format(
+            self.machine.log.warning("AssetPool {}: {}".format(
                 self.name, "All conditional assets evaluated False and no other assets defined."))
             result.append((None, 0))
         return result
@@ -814,7 +814,7 @@ class AssetPool:
                 if self._asset_sequence[0].name in truthy_asset_names:
                     break
                 if x == len(self._asset_sequence) - 1:
-                    self.warning_log("AssetPool {}: All assets in sequence evaluated False.".format(self.name))
+                    self.machine.log.warning("AssetPool {}: All assets in sequence evaluated False.".format(self.name))
                     return None
 
                 self._asset_sequence.rotate(-1)
@@ -833,6 +833,9 @@ class AssetPool:
 
     def _get_random_force_all_asset(self) -> Optional[AssetClass]:
         conditional_assets = self._get_conditional_assets()  # Store to variable to avoid calling twice
+        # Different players may have different conditions, so remove any unapplicable ones
+        # Otherwise a previous player may "use up" all the assets of the next player
+        self._assets_sent = set(a for a in self._assets_sent if a in conditional_assets)
         if len(self._assets_sent) == len(conditional_assets):
             self._assets_sent = set()
 

--- a/mpf/core/assets.py
+++ b/mpf/core/assets.py
@@ -575,7 +575,7 @@ class BaseAssetManager(MpfController, LogMixin):
 
         if not remaining:
             if self._start_time:
-                self.log.info("Asset loading took: %s", time.time() - self._start_time)
+                self.info_log("Asset loading took: %s", time.time() - self._start_time)
             self._last_asset_event_time = None
             self.machine.events.post('asset_loading_complete')
             '''event: asset_loading_complete
@@ -792,7 +792,7 @@ class AssetPool:
                   if not asset[2] or asset[2].evaluate([])]  # type: List[TNullableAssetEntry]
         # Avoid crashes, return None as the asset if no conditions evaluate true
         if not result:
-            self.machine.log.warning("AssetPool {}: {}".format(
+            self.warning_log("AssetPool {}: {}".format(
                 self.name, "All conditional assets evaluated False and no other assets defined."))
             result.append((None, 0))
         return result
@@ -814,7 +814,7 @@ class AssetPool:
                 if self._asset_sequence[0].name in truthy_asset_names:
                     break
                 if x == len(self._asset_sequence) - 1:
-                    self.machine.log.warning("AssetPool {}: All assets in sequence evaluated False.".format(self.name))
+                    self.warning_log("AssetPool {}: All assets in sequence evaluated False.".format(self.name))
                     return None
 
                 self._asset_sequence.rotate(-1)

--- a/mpf/tests/machine_files/asset_manager/config/test_asset_loading.yaml
+++ b/mpf/tests/machine_files/asset_manager/config/test_asset_loading.yaml
@@ -86,3 +86,9 @@ show_pools:
       - show2
       - show3{mode.mode1.stopping}
     type: sequence
+  group9:
+    shows:
+      - show1{mode.mode1.priority>1}
+      - show2{mode.mode1.priority>1}
+      - show3
+    type: random_force_all

--- a/mpf/tests/test_AssetManager.py
+++ b/mpf/tests/test_AssetManager.py
@@ -222,6 +222,31 @@ class TestAssets(MpfTestCase):
         # play a group
         self.machine.shows['group7'].play()
 
+    def _test_conditional_random_with_multiplayer_conditions(self):
+        # When the number of valid conditional assets goes *down* on
+        # a random_force_all, a situation could occur that all the remaining
+        # conditional assets are used up. This test validates that the
+        # pool will reset the availability in that case.
+        self.machine.modes["mode1"].start()
+        self.advance_time_and_run()
+        self.assertIn('group8', self.machine.shows)
+
+        # Set a condition so all three events are valid
+        self.machine.modes["mode1"].priority = 2
+        # Pull two assets, including the future only-valid one
+        res = list()
+        while self.machine.shows['show3'] not in res:
+            res = [
+                self.machine.shows['group9'].asset,
+                self.machine.shows['group9'].asset
+            ]
+        # Change the condition so only one show is valid, but already used
+        self.machine.modes["mode1"].priority = 0
+        self.assertIs(self.machine.shows['group9'].asset, self.machine.shows['show3'])
+        self.assertIs(self.machine.shows['group9'].asset, self.machine.shows['show3'])
+        self.assertIs(self.machine.shows['group9'].asset, self.machine.shows['show3'])
+        self.assertIs(self.machine.shows['group9'].asset, self.machine.shows['show3'])
+
     def _test_conditional_sequence_asset_group(self):
         # These tests are not independent, and mode1 is still running/stopping from the above test :(
         self.advance_time_and_run()
@@ -262,4 +287,3 @@ class TestAssets(MpfTestCase):
         self.assertIs(self.machine.shows['group8'].asset, self.machine.shows['show1'])
         self.assertIs(self.machine.shows['group8'].asset, self.machine.shows['show2'])
         self.assertIs(self.machine.shows['group8'].asset, self.machine.shows['show3'])
-


### PR DESCRIPTION
This PR fixes an issue in multiplayer games where `random_force_all` conditional asset pools which are derived from player-based conditions can lead to crashing.

### The Problem
The `random_force_all` conditional asset pool keeps a list of all the assets its played, and compares that list to the available assets. If the two are the same length, the played list is reset and the random selection begins anew.

The bug occurs when a multiplayer game yields one player with more available assets than another. If the more-assets player hits the pool enough times that all of the common assets have been played, but there are assets conditional to that player which have not played, the pool will not reset itself because there are still assets to play. On the next player's turn though, all of their available assets are in the already-played list and therefore no playable asset is returned—leading to a crash.

### The Fix
One quick fix would be to change the reset logic such that if the length of played assets was equal to _or greater than_ the available assets, to reset the list. The downside here is that there may still be eligible assets unplayed across all players, and resetting the list will prevent them from being played prior to the reset. It's a functional setup, but not ideal.

Instead, this PR creates an earlier step where, prior to checking the played list against the available list, the AssetPool strips out anything from the played list that's not also in the available list. This ensures that any commonly-available assets are still played before the reset, and also that the played list is never longer than the available list.

This PR also includes tests to validate this functionality.

![play something](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2x3a2M3eHl0eHRxcjR3b3hvN2dtNTlscThidmFycmRuNDkwcHB6ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26ybwCBGgXMa8Lyhi/giphy.gif)