### PR TITLE
File manager thread safety

### DIFF
--- a/mpf/core/data_manager.py
+++ b/mpf/core/data_manager.py
@@ -116,6 +116,7 @@ class DataManager(MpfController):
 
     def _writing_thread(self):  # pragma: no cover
         # prevent early writes at start-up
+        data = None
         time.sleep(self.min_wait_secs)
         while not self.machine.thread_stopper.is_set():
             if not self._dirty.wait(1):
@@ -132,11 +133,12 @@ class DataManager(MpfController):
                 # If the file writer has an exception handle it here. Otherwise
                 # this thread will die and all subsequent write attempts will no-op.
                 self.info_log("ERROR writing file %s: %s", self.filename, e)
+            data = None
             # prevent too many writes
             time.sleep(self.min_wait_secs)
 
         # if dirty write data one last time during shutdown
-        if self._dirty.is_set():
+        if data and self._dirty.is_set():
             while FileManager.is_busy:
                 time.sleep(0.2)
             FileManager.save(self.filename, data)

--- a/mpf/core/data_manager.py
+++ b/mpf/core/data_manager.py
@@ -120,15 +120,23 @@ class DataManager(MpfController):
         while not self.machine.thread_stopper.is_set():
             if not self._dirty.wait(1):
                 continue
+            while FileManager.is_busy:
+                time.sleep(0.2)
             self._dirty.clear()
 
             data = copy.deepcopy(self.data)
-            self.debug_log("Writing %s to: %s", self.name, self.filename)
             # save data
-            FileManager.save(self.filename, data)
+            try:
+                FileManager.save(self.filename, data)
+            except Exception as e:
+                # If the file writer has an exception handle it here. Otherwise
+                # this thread will die and all subsequent write attempts will no-op.
+                self.info_log("ERROR writing file %s: %s", self.filename, e)
             # prevent too many writes
             time.sleep(self.min_wait_secs)
 
         # if dirty write data one last time during shutdown
         if self._dirty.is_set():
+            while FileManager.is_busy:
+                time.sleep(0.2)
             FileManager.save(self.filename, data)

--- a/mpf/core/file_manager.py
+++ b/mpf/core/file_manager.py
@@ -20,6 +20,7 @@ class FileManager:
     log = logging.getLogger('FileManager')
     file_interfaces = dict()    # type: Dict[str, YamlInterface]
     initialized = False
+    is_busy = False
 
     @classmethod
     def init(cls):
@@ -109,6 +110,12 @@ class FileManager:
         if not FileManager.initialized:
             FileManager.init()
 
+        # FileManager is a singleton and many threads may attempt to write
+        # concurrently. Ruamel has a known issue where concurrent writes
+        # on a YamlInterface will throw. Set a flag to prevent multiple
+        # data writes concurrently.
+        # TODO: Create FileManager instances for each DataManager instance.
+        FileManager.is_busy = True
         ext = os.path.splitext(filename)[1]
 
         # save to temp file and move afterwards. prevents broken files
@@ -121,3 +128,4 @@ class FileManager:
 
         # move temp file
         os.replace(temp_file, filename)
+        FileManager.is_busy = False

--- a/mpf/core/mode.py
+++ b/mpf/core/mode.py
@@ -105,6 +105,11 @@ class Mode(LogMixin):
         """Return *True* if this mode is active."""
         return self._active
 
+    @property
+    def starting(self) -> bool:
+        """Return *True* if this mode is starting."""
+        return self._starting
+
     @active.setter
     def active(self, new_active: bool):
         """Setter for _active."""


### PR DESCRIPTION
This PR fixes an issue where file writing in MPF could shut off without warning and with no indication to the user, leading to data loss and data inconsistency.

### The Problem
For performance reasons, every DataManager's file writing processing is handled in a separate thread, so that I/O operations don't block the main MPF thread operation. These threads all call on the FileManager singleton for the actual write operation, which is not threaded but also not blocking. FileManger as a singleton maintains one instance of YamlInstance for writing Yaml files.

There is a known issue in Ruamel where attempting to write concurrently to a YamlInstance causes a crash, and in MPF this can occur (for example) when the auditor is auditing a value that's also an earnings or machine_var value. Both of the DataManager threads will write to the FileManager, and the simultaneous write events cause Ruamel to throw an exception.

This bug is especially pernicious because the exception rolls up to the DataManager threads, which don't handle the exception and they themselves crash. However MPF is not expecting this and therefore doesn't check whether the I/O thread is still available, and just blindly sends future file updates into the void without any indication that the updates are not being written.

### The Solution
This PR does not attempt to address the MPF <-> DataManager I/O Thread relationship, which would be future work to generate unique instances of YamlInstance per DataManager and have thread validation prior to write operations. Instead, this PR addresses the FileManager singleton attempting simultaneous writes through the YamlInstance.

This PR adds an `is_busy` property to the FileManager that indicates whether the FileManager is currently writing. This flag itself does not block subsequent write attempts because the FileManager has no cache to track a stack of writes. Instead, the DataManager is updated to verify that the FileManager is not busy, and will wait (checking every 200ms) until it is safe to write. With this agreement, all DataManagers will wait their turn during concurrent write situations, avoiding the Ruamel crash and keeping the threads alive.

**Another bug**
This PR also addresses a small bug where during shutdown, if a DataManager has not yet instantiated its data (for example, a shutdown crash during startup), it attempts to write a null value to file. This PR adds a check to see if there is data to write before attempting the shutdown write operation.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExejV3Nzd6bWtlcmFlOGRhMXJneXEwNDg5MnNudGRycnNsc3pnajUyMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/bwLowbhUWm2lO/giphy.gif)