### PR TITLE
Eval placeholder args in show update method (from #1702)

### DIFF
--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -604,7 +604,7 @@ class RunningShow:
         Updates the values of a show while it runs. Currently supports only speed
         and manual_advance properties.
         """
-        updated_values = {k: v for k, v in kwargs.items() if v is not None and v != getattr(self.show_config, k)}
+        updated_values = {k: v for k, v in kwargs.items() if v is not None}
         if updated_values:
             self.show_config = self.show_config._replace(**updated_values)
 

--- a/mpf/config_players/show_player.py
+++ b/mpf/config_players/show_player.py
@@ -197,10 +197,9 @@ class ShowPlayer(DeviceConfigPlayer):
         del show
         del queue
         del start_time
-        del placeholder_args
         if key in instance_dict:
             instance_dict[key].update(
-                speed=show_settings.get('speed'),
+                speed=show_settings['speed'].evaluate(placeholder_args),
                 manual_advance=show_settings.get('manual_advance')
             )
 


### PR DESCRIPTION
This PR reconciles a gap caused by #1557  which added support for updating a running show, and #1702 which added support for dynamic `speed` values in shows.

The change by @cobra18t in #1702 changed the expected type of the `speed` parameter from a float to a PlaceholderTemplate, which caused a crash in the update method from #1557 that was not expecting a placeholder object.

The resolution here is tricky because in a show, once the template is evaluated it's the resulting value that's saved to the show, not the placeholder template—otherwise the template would be re-evaluated every step of the show, costing overhead. This complicates the update call, however, which that compares the two values prior to generating the updated config to avoid rewriting a show that hasn't changed. Since the incoming value is a placeholder template and the current value is a float, the comparison is not supported. 

The fix in this PR is to evaluate the new speed prior to the update call, and to remove the value comparison. The downside is that a call to update speed will always generate a new show config even if the speed is unchanged, but the upside is that update calls work with placeholder templates instead of crashing.

![go faster faster](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYW90Zzg1dTYxb3EyaXI5NWlpY3dsZmxrd3NreDFkZHExZjczeXVmbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7XsFGzfP6WmC4/giphy.gif)