### PR TITLE
Shot priority for switch handlers

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1561,6 +1561,7 @@ shots:
     delay_switch: dict|machine(switches):ms|None
     persist_enable: single|bool|true
     playfield: single|machine(playfields)|playfield
+    priority: single|int|0
     mark_playfield_active: single|bool|true
     enable_events: event_handler|event_handler:ms|None
     disable_events: event_handler|event_handler:ms|None
@@ -2194,6 +2195,7 @@ widgets:
         timing: single|enum(after_previous,with_previous)|after_previous
         repeat: single|bool_or_token|false
         easing: single|str|linear
+        step: single|float|0.0
     bezier:
         points: list|num_or_token|
         thickness: single|float_or_token|1.0

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -80,14 +80,15 @@ class Shot(EnableDisableMixin, ModeDevice):
         self._handlers = []
         for switch in self.config['switches']:
             self._handlers.append(self.machine.events.add_handler("{}_active".format(switch.name),
-                                                                  self.event_hit, priority=self.mode.priority,
+                                                                  self.event_hit,
+                                                                  priority=self.mode.priority + self.config['priority'],
                                                                   blocking_facility="shot"))
 
         for switch in list(self.config['delay_switch'].keys()):
             self._handlers.append(self.machine.events.add_handler("{}_active".format(switch.name),
                                                                   self._delay_switch_hit,
                                                                   switch_name=switch.name,
-                                                                  priority=self.mode.priority,
+                                                                  priority=self.mode.priority + self.config['priority'],
                                                                   blocking_facility="shot"))
 
     def _remove_switch_handlers(self):

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -282,7 +282,8 @@ class Shot(EnableDisableMixin, ModeDevice):
         if self.profile.config['block']:
             min_priority = kwargs.get("_min_priority", {"all": 0})
             min_shots = min_priority.get("shot", 0)
-            min_priority["shot"] = self.mode.priority if self.mode.priority > min_shots else min_shots
+            shot_priority = self.mode.priority + self.config["priority"]
+            min_priority["shot"] = shot_priority if shot_priority > min_shots else min_shots
             return {"_min_priority": min_priority}
 
         return None

--- a/mpf/tests/machine_files/shots/config/test_shots.yaml
+++ b/mpf/tests/machine_files/shots/config/test_shots.yaml
@@ -5,6 +5,7 @@ modes:
   - base3
   - mode1
   - mode2
+  - mode3
 
 switches:
   switch_1:

--- a/mpf/tests/machine_files/shots/modes/mode3/config/mode3.yaml
+++ b/mpf/tests/machine_files/shots/modes/mode3/config/mode3.yaml
@@ -1,0 +1,21 @@
+#config_version=6
+
+mode:
+  priority: 100
+
+shots:
+  mode3_shot_3_1:
+    switch: switch_3
+  mode3_shot_3_2:
+    switch: switch_3
+    priority: 10
+
+variable_player:
+  mode3_shot_3_1_hit:
+    foo:
+      action: set
+      int: 100
+  mode3_shot_3_2_hit:
+    foo:
+      action: set
+      int: 50

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -119,6 +119,16 @@ class TestShots(MpfTestCase):
         # check if color returns to mode1_shot_2 color
         self.assertLightColor("light_2", "antiquewhite")
 
+    def test_switch_priorities(self):
+        self.start_game()
+        self.start_mode("mode3")
+
+        self.assertEqual(self.machine.game.player['foo'], 0)
+        self.hit_and_release_switch('switch_3')
+        self.advance_time_and_run()
+
+        self.assertEqual(self.machine.game.player['foo'], 100)
+
     def test_hits(self):
         self.assertFalse(self.machine.shots["mode1_shot_1"].enabled)
 


### PR DESCRIPTION
This PR adds support for a `priority:` config setting in `shots:`, which is additive to the mode priority when setting up switch handlers for shots.

Without this change, multiple shots in the same mode or shots in modes with the same priority will have (relatively) unordered handlers and may be evaluated in arbitrary order.

With this change, specifying a `priority:` on a shot adds that relative priority to the switch handler, so the order in which shots are hit is deterministic.

The priority is also applied to `blocking:` calculations, so a shot can be defined with a higher relative blocking priority of another shot in the same mode or a different higher-priority mode.

![me first!](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmZ3Z3pwNmttbzkzYTFhZWJqcWVzZ2poMWNpMnk2YW1lNnQ5ejU1biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3orifdWDdLJsXAv7XO/giphy.gif)