### PR TITLE
Version bump: dev 0.57.0.dev34

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.0.dev33'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.0.dev34'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'


### PR DESCRIPTION
This PR increments the prerelease MPF version to dev34 to validate all the fixes that have gone in since!

