### PR TITLE
Bugfix: Pololu Stepper status parsing

### DIFF
--- a/mpf/platforms/pololu/pololu_ticcmd_wrapper.py
+++ b/mpf/platforms/pololu/pololu_ticcmd_wrapper.py
@@ -97,11 +97,10 @@ class PololuTiccmdWrapper:
     async def get_status(self):
         """Return the current status of the TIC device."""
         cmd_return = await self._ticcmd_future('-s', '--full')
-        self.log.info("get_status() received cmd_return: %s", cmd_return)
+        self.log.debug("get_status() received cmd_return: %s", cmd_return)
         value = cmd_return.decode('utf-8')
         yaml = ruamel.yaml.YAML(typ='safe')
         status = yaml.load(value)
-        self.log.info("yaml.load() generated status: %s", status)
         return status
 
     def halt_and_hold(self):

--- a/mpf/platforms/pololu/pololu_ticcmd_wrapper.py
+++ b/mpf/platforms/pololu/pololu_ticcmd_wrapper.py
@@ -3,7 +3,6 @@ import subprocess
 import logging
 import asyncio
 
-from io import StringIO, TextIOWrapper
 from threading import Thread
 import ruamel.yaml
 
@@ -99,27 +98,10 @@ class PololuTiccmdWrapper:
         """Return the current status of the TIC device."""
         cmd_return = await self._ticcmd_future('-s', '--full')
         self.log.info("get_status() received cmd_return: %s", cmd_return)
-        errors = []
-        try:
-            tio = TextIOWrapper(cmd_return)
-            value = tio.read()
-            self.log.info("TextIOWrapper.read() returned value: %s", value)
-        except Exception as e:
-            self.log.error("Unable to read from TextIOWrapper")
-            self.log.error(e)
-            errors.append(e)
-        try:
-            sio = StringIO(cmd_return)
-            value = sio.getvalue()
-            self.log.info("StringIO.getvalue() returned value: %s", value)
-        except Exception as e:
-            self.log.error("Unable to get value from StringIO")
-            self.log.error(e)
-            errors.append(e)
-        if errors and not value:
-            raise errors[0]
+        value = cmd_return.decode('utf-8')
         yaml = ruamel.yaml.YAML(typ='safe')
         status = yaml.load(value)
+        self.log.info("yaml.load() generated status: %s", status)
         return status
 
     def halt_and_hold(self):

--- a/mpf/tests/test_PololuTic.py
+++ b/mpf/tests/test_PololuTic.py
@@ -32,7 +32,7 @@ class TestPololuTic(MpfTestCase):
                 yaml = ruamel.yaml.YAML()
                 yaml.Dumper = RoundTripDumper
                 yaml.dump(new_status, output)
-                return output.getvalue()
+                return output.getvalue().encode()
 
         elif args == ('--reset-command-timeout',):
             return ""


### PR DESCRIPTION
This PR fixes a bug from https://github.com/avanwinkle/mpf/commit/ac59cd653fc1a8b23b8169db1755814d41466ce2#diff-39051c21ea0b1eab69d23ca87cab1d8152eae7ee6e2c38b40fd3caacbb8a5f58 which was introduced during the great 0.57 YAML upgrade.

Based on tests with a physical pololu stepper, the received status byte format needs to be decoded into a UTF string, rather than converted to an IO buffer. This PR replaces the IO buffer with a decode call, and updates the test accordingly.

Verified on a physical device.

![happy day](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDR1MmVoMHlqY3dqMnBocGVuNnp0MmxpZWo3a28xeWIxYWxkbGNsYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2uluGTvB7DAQvZyHp/giphy-downsized.gif)