### PR TITLE
Lost Balls for Holds and Locks

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1142,6 +1142,7 @@ multiball_locks:
     __type__: device
     balls_to_lock: single|int|
     balls_to_replace: single|int|-1
+    ball_lost_action: single|str|None
     blocking_facility: single|str|None
     lock_devices: list|machine(ball_devices)|
     source_devices: list|machine(ball_devices)|None

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -246,9 +246,9 @@ class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
         """Handle the ball hold devices losing a ball."""
         if self.balls_held:
             self.balls_held -= balls
-            self.debug_log("Ball device %s lost %s balls, hold now has %s balls held", device, balls, self.balls_held)
+            self.info_log("Ball device %s lost %s balls, hold now has %s balls held", device, balls, self.balls_held)
         else:
-            self.debug_log("Ball device %s lost %s balls but hold is not holding. Doing nothing.", device, balls)
+            self.info_log("Ball device %s lost %s balls but hold is not holding. Doing nothing.", device, balls)
         # Do not claim this ball
         return { 'balls': balls }
 

--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -220,12 +220,16 @@ class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
         # register on ball_enter of hold_devices
         for device in self.hold_devices:
             self.machine.events.add_handler(
-                'balldevice_' + device.name + '_ball_enter',
+                f'balldevice_{device.name}_ball_enter',
                 self._hold_ball, device=device, priority=priority)
+            self.machine.events.add_handler(
+                f'balldevice_{device.name}_ball_missing',
+                self._lost_ball, device=device, priority=priority)
 
     def _unregister_handlers(self):
         # unregister ball_enter handlers
         self.machine.events.remove_handler(self._hold_ball)
+        self.machine.events.remove_handler(self._lost_ball)
 
     def is_full(self):
         """Return true if hold is full."""
@@ -237,6 +241,16 @@ class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
         if balls < 0:
             balls = 0
         return balls
+
+    def _lost_ball(self, device, balls, **kwargs):
+        """Handle the ball hold devices losing a ball."""
+        if self.balls_held:
+            self.balls_held -= balls
+            self.debug_log("Ball device %s lost %s balls, hold now has %s balls held", device, balls, self.balls_held)
+        else:
+            self.debug_log("Ball device %s lost %s balls but hold is not holding. Doing nothing.", device, balls)
+        # Do not claim this ball
+        return { 'balls': balls }
 
     def _hold_ball(self, device, new_balls, unclaimed_balls, **kwargs):
         """Handle result of _ball_enter event of hold_devices."""

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -55,7 +55,6 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
         self.machine.events.add_handler("ball_ending", self._ball_ending)
 
         for device in self.lock_devices:
-            self.info_log("Registering handler for %s", f'balldevice_{device.name}_ball_missing')
             self.machine.events.add_handler(f'balldevice_{device.name}_ball_missing',
                                             self._lost_ball, device=device)
 
@@ -338,10 +337,8 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
                       device.name, balls, self.name, self.locked_balls,
                       self.config['ball_lost_action'] )
         if self.locked_balls and self.config['ball_lost_action'] == "add_to_play":
-            self.debug_log("Ball device %s lost %s balls, adding to balls_in_play", device.name, balls)
+            self.info_log("Ball device %s lost %s balls, adding to balls_in_play", device.name, balls)
             self.machine.game.balls_in_play += balls
-        else:
-            self.info_log(" - not adding to play, config is %s", self.config)
         # Do not claim the ball
         return {'balls': balls}
 

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -315,6 +315,7 @@ class Playfield(SystemWideDevice):
             self.machine.ball_controller.add_captured_ball(self)
 
     def _source_device_ball_lost(self, target, **kwargs):
+        self.debug_log("Ball lost from source device %s with target %s", target.name, self.name)
         del kwargs
         if target == self:
             self.available_balls -= 1


### PR DESCRIPTION
This PR adds improvements for when a ball devices "loses" a ball, which can happen when a physical hold/lock device stacks multiple balls and may intermittently release more balls than expected.

### Ball Holds: Fix the Count
When a `ball_hold` device loses a ball, this PR identifies the loss of ball and adjusts the ball count of the hold. This keeps the MPF ball count accurate and prevents scenarios where the game may get stuck thinking there is a ball in play when there isn't.

### Multiball Locks: Handle the Loss
When a `multiball_lock` device loses a ball, this PR adds an optional configuration option to add that ball to current play. The current behavior is to not add the ball to play, so despite having multiple balls on the playfield the turn will end whenever the first one drains. With the new `ball_lost_action: add_to_play` config option, the lost ball can be added to play so the MPF ball count will match the physical situation and a drain of the lost ball will not end the player's turn.

![lost balls](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3VsN2k2amVlbGZnd2xoZThsbGVmd3Y1ZndrYmQ2ODg3dnpidzl5MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2SqiysZLPPTt0yGs/giphy.gif)