### PR TITLE
Misc fixes: no match, timed_enable_events, FAST Nano RGB

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -319,6 +319,7 @@ coils:
     disable_events: event_handler|event_handler:ms|None
     enable_events: event_handler|event_handler:ms|None
     pulse_events: event_handler|event_handler:ms|None
+    timed_enable_events: event_handler|event_handler:ms|None
     platform_settings: single|dict|None
     psu: single|machine(psus)|default
     platform: single|str|None
@@ -1793,6 +1794,7 @@ sound_player:
     delay: single|secs|None
     track: single|str|None
     volume: single|gain|None
+    ducking: single|subconfig(sound_ducking)|None
     pan: single|float_or_token|None
     loops: single|int_or_token|None
     priority: single|int_or_token|None

--- a/mpf/modes/bonus/code/bonus.py
+++ b/mpf/modes/bonus/code/bonus.py
@@ -91,6 +91,10 @@ class Bonus(Mode):
             self._subtotal()
             return
 
+        # Calling player.vars.get() instead of player.get() bypasses the
+        # auto-fill zero and will throw if there is no player variable.
+        # The fallback value of 1 is used for bonus entries that don't use
+        # a player score, which are multiplied by one to get the bonus.
         hits = self.player.vars.get(entry['player_score_entry'], 1)
         score = entry['score'].evaluate([]) * hits
 

--- a/mpf/modes/match/code/match.py
+++ b/mpf/modes/match/code/match.py
@@ -18,9 +18,9 @@ class Match(AsyncMode):
         """initialize match mode."""
         super().__init__(*args, **kwargs)
         # add setting
-        self.machine.settings.add_setting(SettingEntry("match_percentage", "Match percentage", 500,
+        self.machine.settings.add_setting(SettingEntry("match_percentage", "Match Percentage", 500,
                                                        "match_percentage", 10,
-                                                       {0: "off", 2: "2%", 5: "5%", 10: "10%", 15: "15%", 30: "30%",
+                                                       {0: "Never", 2: "2%", 5: "5%", 10: "10%", 15: "15%", 30: "30%",
                                                         50: "50%"}, "standard"))
 
     def _get_match_numbers(self):

--- a/mpf/platforms/fast/communicators/rgb.py
+++ b/mpf/platforms/fast/communicators/rgb.py
@@ -59,7 +59,8 @@ class FastRgbCommunicator(FastSerialCommunicator):
     async def soft_reset(self, **kwargs):
         """Reset the NET processor."""
         del kwargs
-        await self.send_and_wait_for_response('RA:000000', 'RX:P')
+        #await self.send_and_wait_for_response('RA:000000', 'RX:P')
+        self.send_and_forget("RA:000000")
 
     def reset(self):
         """Reset the RGB processor."""


### PR DESCRIPTION
This PR contains a few miscellaneous fixes I've collected recently.

### No Match Option
This PR changes the label of a 0% match possibility from "off" to "Never", which more accurately clarifies the no-chance-of-match and avoids ambiguity of Match mode being disabled versus enabled but never going to match.

### Timed Enable Events
This PR adds a config option for `timed_enable_events` for coils that support timed enable pulses. The coil code itself already supports timed_enable events, but without them in the config spec they could never be triggered. This change adds this option to the spec.

### Fast NANO RGB
The recent refactor of FAST interface code by @toomanybrians includes improvements to the startup and reset flows. Unfortunately the legacy Nano RGB controller can have trouble with the reset command when processing other shows, leading to hangs. This PR changes the reset command for the Nano RGB controller to be fire-and-forget instead of wait-for-confirmation, to avoid hangs for the few users (probably just me) using the latest MPF with a legacy board.

### Bonus Calculation Comment
I misread the logic of the bonus score calculation and regressed the behavior, until I more carefully parsed the code and realized my mistake. This PR adds a detailed comment on how that calculation works, to avoid this mishap in the future.

![hello](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGRid3lqNmlpNTA5aTU3Mnd4MzhodXk3c2RxOTA1d3ljbjFhZWs0YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FArgGzk7KO14k/giphy.gif)