### PR TITLE
Timer kwargs evaluation

### DIFF
--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -513,9 +513,18 @@ class Timer(ModeDevice):
 
     @staticmethod
     def _get_timer_value(timer_value, in_ms=False, **kwargs):
+        """Return an int value for the number of ticks on the timer."""
         if hasattr(timer_value, "evaluate"):
             # Convert to int for ticks; config_spec must be float for change_tick_interval
             return int(timer_value.evaluate(kwargs) * (1000 if in_ms else 1))
+        return timer_value
+
+    @staticmethod
+    def _get_timer_tick_secs(timer_value, **kwargs):
+        """Return a float value for the number of seconds between each tick."""
+        if hasattr(timer_value, "evaluate"):
+            # Convert to int for ticks; config_spec must be float for change_tick_interval
+            return timer_value.evaluate(kwargs)
         return timer_value
 
     def change_tick_interval(self, change=0.0, **kwargs):
@@ -546,7 +555,7 @@ class Timer(ModeDevice):
             **kwargs: Optional kwargs that may affect the evaluation of the
                 timer value placeholder template.
         """
-        self.tick_secs = abs(self._get_timer_value(timer_value, **kwargs))
+        self.tick_secs = abs(self._get_timer_tick_secs(timer_value, **kwargs))
         self._create_system_timer()
 
     def jump(self, timer_value, **kwargs):


### PR DESCRIPTION
This PR refactors the Timer device to support event kwargs in placeholder evaluations for all timer control events.

Previously, most control events would drop the kwargs and evaluate placeholders on fixed values (e.g. player or machine vars). This PR passes the kwargs into the placeholder evaluation, so that events can be used to dynamically change timer ticks, tick intervals, and pause durations.

![tick tock](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcnE5aG5kdWtvMzhzYmZpNW12MnhqNGpjYjNodjRzZ3V3eDB1aGw3cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4FASGprVjhv6VTry/giphy.gif)