### PR TITLE
Misc fixes: Serial Error, Bonus Source, and more

### DIFF
--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -458,7 +458,8 @@ class BcpInterface(MpfController):
             self.machine.register_monitor('machine_vars', self._machine_var_change)
 
         # Send initial machine variable values
-        self._send_machine_vars(client)
+        for s in ("standard", "feature", "game", "coin"):
+            self._send_machine_vars(client, setting_type=s)
 
         # Establish handler for machine variable changes
         self.machine.bcp.transport.add_handler_to_transport("_machine_vars", client)
@@ -470,9 +471,10 @@ class BcpInterface(MpfController):
         if not self.machine.bcp.transport.get_transports_for_handler("_machine_vars"):
             self.machine.machine_var_monitor = False
 
-    def _send_machine_vars(self, client):
+    def _send_machine_vars(self, client, setting_type=None):
         self.machine.bcp.transport.send_to_client(
-            client, bcp_command='settings', settings=Util.convert_to_simply_type(self.machine.settings.get_settings()))
+            client, bcp_command='settings',
+            settings=Util.convert_to_simply_type(self.machine.settings.get_settings(setting_type)))
         for var_name, settings in self.machine.variables.machine_vars.items():
             self.machine.bcp.transport.send_to_client(client, bcp_command='machine_variable',
                                                       name=var_name,

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -242,9 +242,9 @@ class Shot(EnableDisableMixin, ModeDevice):
 
         priority = settings['priority'] + self.mode.priority
         if not start_step:
-            start_step = settings['start_step']
+            start_step = show_tokens.get('start_step') or settings['start_step']
 
-        self.debug_log("Playing show: %s. %s", show_name, settings)
+        self.debug_log("Playing show: %s (starting at step %s). %s", show_name, start_step, settings)
 
         show_config = self.machine.show_controller.create_show_config(
             show_name, priority=priority, speed=settings.get("speed"),

--- a/mpf/modes/bonus/code/bonus.py
+++ b/mpf/modes/bonus/code/bonus.py
@@ -170,7 +170,8 @@ class Bonus(Mode):
                        callback=self._total_bonus)
 
     def _total_bonus(self):
-        self.player.score += self.bonus_score
+        self.player.add_with_kwargs("score", self.bonus_score,
+                                    source=self.name)
         self.debug_log("Bonus Total: {}", self.bonus_score)
         self.machine.events.post('bonus_total', score=self.bonus_score)
 

--- a/mpf/platforms/base_serial_communicator.py
+++ b/mpf/platforms/base_serial_communicator.py
@@ -119,6 +119,7 @@ class BaseSerialCommunicator:
             raise
         except Exception as e:  # pylint: disable-msg=broad-except
             self.log.warning("Serial error: {}".format(e))
+            self.machine.events.post("serial_error")
             return None
 
         # we either got empty response (-> socket closed) or and error


### PR DESCRIPTION
This PR folds in a few more miscellaneous fixes I've made.

### Post *serial_error* event on serial error
This PR adds a new event *serial_error* that will be posted whenever a serial devices encounters an unrecoverable error. This event allows a BCP connection to gracefully handle a disconnect/restart when MPF loses its platform connection, instead of hanging or crashing.

### Include `source` kwarg in bonus score
This PR adds the `source` argument to the bonus score when added to the player score, for better tracking of bonus awards and balancing bonus amounts.

### Allow `start_step` in shot profile show tokens
This PR adds support for `start_step` in the `show_tokens` for a shot profile, so a single profile+show can be used with dynamic start steps based on game conditions.

### BCP Interface for sub-settings menu
This PR separates the BCP client request for machine settings values based on the sub-setting type (e.g. standard, feature, game, coin). Previously all settings were sent in a single batch, with this change they are sent in batches by sub-setting. The default behavior is still to send all of them, though they will arrive in four messages instead of one.

The advantage of this behavior is that BCP clients can also request specific sub-settings at a time, reducing bandwidth and avoiding updates on unrelated data.

![dunno](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcnBvaGQwbWh0MzRhcGh5eDhuaGhscGJsdzBrdjQ3MDBya2lwM2NreSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l3V0x6kdXUW9M4ONq/giphy.gif)