### PR TITLE
Multiple eject device handling

### DIFF
--- a/mpf/devices/ball_device/ball_device.py
+++ b/mpf/devices/ball_device/ball_device.py
@@ -141,7 +141,8 @@ class BallDevice(SystemWideDevice):
     async def lost_idle_ball(self):
         """Lost an ball while the device was idle."""
         # handle lost balls
-        self.warning_log("Ball disappeared while idle. This should not normally happen.")
+        if self.state == "idle":
+            self.warning_log("Ball disappeared while idle. This should not normally happen.")
         self.available_balls -= 1
         self.config['ball_missing_target'].add_missing_balls(1)
         await self._balls_missing(1)

--- a/mpf/devices/ball_device/outgoing_balls_handler.py
+++ b/mpf/devices/ball_device/outgoing_balls_handler.py
@@ -433,12 +433,11 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
                 # Post that the ball is lost
                 await self.ball_device.lost_idle_ball()
                 # Cancel the eject queue for the lost ball
-                self.info_log("How many ejects are requested? %s", self.ball_device.requested_balls)
-                self.info_log("Playfield ejects requested? %s", self.machine.playfields.playfield.num_balls_requested)
                 for _ in range(0, old_balls - new_balls):
-                    self.info_log("Cancelling one queued request")
-                    self._eject_queue.get_nowait()
-                    self._eject_queue.task_done()
+                    self.info_log("Cancelling a queued eject request")
+                    if not self._eject_queue.empty():
+                        self._eject_queue.get_nowait()
+                        self._eject_queue.task_done()
                 self.info_log("Necessary queue requests are completed. Updating ball count to %s." % new_balls)
                 self.ball_device.ball_count_handler._set_ball_count(new_balls)
 

--- a/mpf/devices/ball_device/outgoing_balls_handler.py
+++ b/mpf/devices/ball_device/outgoing_balls_handler.py
@@ -424,6 +424,25 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
             result = await self._handle_confirm(eject_request, ball_eject_process, incoming_ball_at_target,
                                                 eject_try)
             await self.ball_device.ball_count_handler.end_eject(ball_eject_process, result)
+
+            self.info_log("Eject successful, looking for missing balls")
+            new_balls = await self.ball_device.ball_count_handler.counter.count_balls()
+            old_balls = self.ball_device.counted_balls
+            self.info_log("Found %s physical balls and %s expected balls", new_balls, old_balls)
+            if new_balls < old_balls:
+                # Post that the ball is lost
+                await self.ball_device.lost_idle_ball()
+                # Cancel the eject queue for the lost ball
+                self.info_log("How many ejects are requested? %s", self.ball_device.requested_balls)
+                self.info_log("Playfield ejects requested? %s", self.machine.playfields.playfield.num_balls_requested)
+                for _ in range(0, old_balls - new_balls):
+                    self.info_log("Cancelling one queued request")
+                    self._eject_queue.get_nowait()
+                    self._eject_queue.task_done()
+                self.info_log("Necessary queue requests are completed. Updating ball count to %s." % new_balls)
+                self.ball_device.ball_count_handler._set_ball_count(new_balls)
+
+
             return result
         except asyncio.CancelledError:
             ball_eject_process.cancel()

--- a/mpf/devices/ball_device/outgoing_balls_handler.py
+++ b/mpf/devices/ball_device/outgoing_balls_handler.py
@@ -425,19 +425,24 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
                                                 eject_try)
             await self.ball_device.ball_count_handler.end_eject(ball_eject_process, result)
 
-            new_balls = await self.ball_device.ball_count_handler.counter.count_balls()
-            old_balls = self.ball_device.counted_balls
-            if new_balls < old_balls:
-                self.info_log("Found %s physical balls and %s expected balls", new_balls, old_balls)
-                # Post that the ball is lost
-                await self.ball_device.lost_idle_ball()
-                # Cancel the eject queue for the lost ball
-                for _ in range(0, old_balls - new_balls):
-                    if not self._eject_queue.empty():
-                        self._eject_queue.get_nowait()
-                        self._eject_queue.task_done()
-                self.info_log("Necessary queue requests are cancelled. Updating ball count to %s." % new_balls)
-                self.ball_device.ball_count_handler._set_ball_count(new_balls)
+            # Check if more balls left than expected, meaning the ejector kicked out multiple
+            # balls. If so, tag those missing balls as lost (except for mechanical ejects, which
+            # may be expected, and troughs, which may jam)
+            if "trough" not in self.ball_device.tags and not self.ball_device.config['mechanical_eject']:
+                new_balls = await self.ball_device.ball_count_handler.counter.count_balls()
+                old_balls = self.ball_device.counted_balls
+
+                if new_balls < old_balls:
+                    self.info_log("Found %s physical balls and %s expected balls", new_balls, old_balls)
+                    # Post that the ball is lost
+                    await self.ball_device.lost_idle_ball()
+                    # Cancel the eject queue for the lost ball
+                    for _ in range(0, old_balls - new_balls):
+                        if not self._eject_queue.empty():
+                            self._eject_queue.get_nowait()
+                            self._eject_queue.task_done()
+                    self.info_log("Necessary queue requests are cancelled. Updating ball count to %s." % new_balls)
+                    self.ball_device.ball_count_handler._set_ball_count(new_balls)
 
             return result
         except asyncio.CancelledError:

--- a/mpf/devices/ball_device/outgoing_balls_handler.py
+++ b/mpf/devices/ball_device/outgoing_balls_handler.py
@@ -425,22 +425,19 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
                                                 eject_try)
             await self.ball_device.ball_count_handler.end_eject(ball_eject_process, result)
 
-            self.info_log("Eject successful, looking for missing balls")
             new_balls = await self.ball_device.ball_count_handler.counter.count_balls()
             old_balls = self.ball_device.counted_balls
-            self.info_log("Found %s physical balls and %s expected balls", new_balls, old_balls)
             if new_balls < old_balls:
+                self.info_log("Found %s physical balls and %s expected balls", new_balls, old_balls)
                 # Post that the ball is lost
                 await self.ball_device.lost_idle_ball()
                 # Cancel the eject queue for the lost ball
                 for _ in range(0, old_balls - new_balls):
-                    self.info_log("Cancelling a queued eject request")
                     if not self._eject_queue.empty():
                         self._eject_queue.get_nowait()
                         self._eject_queue.task_done()
-                self.info_log("Necessary queue requests are completed. Updating ball count to %s." % new_balls)
+                self.info_log("Necessary queue requests are cancelled. Updating ball count to %s." % new_balls)
                 self.ball_device.ball_count_handler._set_ball_count(new_balls)
-
 
             return result
         except asyncio.CancelledError:

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -319,15 +319,15 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
         '''
 
         # schedule eject of new balls for all physically locked balls
-        if self.config['balls_to_replace'] == -1 or self.locked_balls <= self.config['balls_to_replace']:
-            self.debug_log("{} locked balls and {} to replace, requesting {} new balls"
-                           .format(self.locked_balls, self.config['balls_to_replace'], balls_to_lock_physically))
+        if self.config['balls_to_replace'] == -1 or new_locked_balls <= self.config['balls_to_replace']:
+            self.info_log("{} locked balls and {} to replace, requesting {} new balls"
+                           .format(new_locked_balls, self.config['balls_to_replace'], balls_to_lock_physically))
             self._request_new_balls(balls_to_lock_physically)
         else:
-            self.debug_log("{} locked balls exceeds {} to replace, not requesting any balls"
-                           .format(self.locked_balls, self.config['balls_to_replace']))
+            self.info_log("{} locked balls exceeds {} to replace, not requesting any balls"
+                           .format(new_locked_balls, self.config['balls_to_replace']))
 
-        self.debug_log("Locked %s balls virtually and %s balls physically", balls_to_lock, balls_to_lock_physically)
+        self.info_log("Locked %s balls virtually and %s balls physically", balls_to_lock, balls_to_lock_physically)
 
         return {'unclaimed_balls': unclaimed_balls - balls_to_lock_physically}
 

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -320,12 +320,12 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
 
         # schedule eject of new balls for all physically locked balls
         if self.config['balls_to_replace'] == -1 or new_locked_balls <= self.config['balls_to_replace']:
-            self.info_log("{} locked balls and {} to replace, requesting {} new balls"
-                           .format(new_locked_balls, self.config['balls_to_replace'], balls_to_lock_physically))
+            self.info_log("%s locked balls and %s to replace, requesting %s new balls",
+                          new_locked_balls, self.config['balls_to_replace'], balls_to_lock_physically)
             self._request_new_balls(balls_to_lock_physically)
         else:
-            self.info_log("{} locked balls exceeds {} to replace, not requesting any balls"
-                           .format(new_locked_balls, self.config['balls_to_replace']))
+            self.info_log("%s locked balls exceeds %s to replace, not requesting any balls",
+                          new_locked_balls, self.config['balls_to_replace'])
 
         self.info_log("Locked %s balls virtually and %s balls physically", balls_to_lock, balls_to_lock_physically)
 

--- a/mpf/tests/machine_files/multiball_locks/config/config.yaml
+++ b/mpf/tests/machine_files/multiball_locks/config/config.yaml
@@ -12,6 +12,8 @@ coils:
         number:
     eject_coil4:
         number:
+    eject_coil5:
+        number:
 
 switches:
     s_ball_switch1:
@@ -40,7 +42,10 @@ switches:
         number:
     s_lockb2:
         number:
-
+    s_lockp1:
+        number:
+    s_lockp2:
+        number:
 playfields:
     playfield:
         default_source_device: bd_trough
@@ -64,6 +69,11 @@ ball_devices:
         eject_coil: eject_coil4
         ball_switches: s_lockb1, s_lockb2
         eject_timeouts: 2s
+    bd_lock_physical:
+        eject_coil: eject_coil5
+        ball_switches: s_lockp1, s_lockp2
+        eject_timeouts: 2s
+        eject_events: eject_lock
 
 multiballs:
     mb:
@@ -71,3 +81,7 @@ multiballs:
         shoot_again: 0
         start_events: mb_start
         ball_locks: bd_lock
+    physical:
+        ball_count: 3
+        start_events: physical_mb_start
+        ball_locks: bd_lock_physical

--- a/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
+++ b/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
@@ -30,3 +30,4 @@ multiball_locks:
     locked_ball_counting_strategy: virtual_only
     ball_lost_action: add_to_play
     disable_events: disable_lock_physical
+    reset_count_for_current_player_events: physical_mb_start

--- a/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
+++ b/mpf/tests/machine_files/multiball_locks/modes/default/config/default.yaml
@@ -24,3 +24,9 @@ multiball_locks:
     balls_to_lock: 2
     locked_ball_counting_strategy: virtual_only
     blocking_facility: foo
+  lock_physical:
+    lock_devices: bd_lock_physical
+    balls_to_lock: 2
+    locked_ball_counting_strategy: virtual_only
+    ball_lost_action: add_to_play
+    disable_events: disable_lock_physical


### PR DESCRIPTION
This PR adds some stability improvements to physical ball locks and multi balls.

### Graceful Lost Ball Handling
This PR extends the ball count handler for ejecting physical balls to double-check the ball counts after an eject attempt, in case more balls were ejected than expected. If this occurs, the changes in this PR will post that the device has lost balls, and will update the device count to reflect the new physical count. 

For situations where multiple balls were intended to be ejected and some eject together, this PR also gracefully cancels the eject queue for the lost balls.

This change does not apply to ball devices tagged as `trough`, because troughs can jam and "lose" many balls simultaneously and those balls should not be removed from the trough count yet. This change also does not apply to manual eject devices (which really shouldn't have multiple balls anyway) because there is no way to objectively measure how many eject attempts were made relative to how many balls were ejected.

### Improved Ball Count Handling
This PR changes the logic for counting physical balls in a ball device, tracking the expected new number of balls instead of the known physical ball count. This change allows the ball device to identify when the ball counts mismatch (e.g. a ball slipped out or multiple balls entered simultaneously) and avoids race conditions. There is no change in the happy path behavior, just a reduced chance of error.

![eject it](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmMyZXUwdXZtZWdteWwxamVlY3BzcTZ6aXVidHV0cmRzbGZmdmJnZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ceRlrrXwjgXBNj34WS/giphy.gif)