### PR TITLE
Optimize log formatting

### DIFF
--- a/mpf/core/ball_search.py
+++ b/mpf/core/ball_search.py
@@ -104,8 +104,7 @@ class BallSearch(MpfController):
             restore_callback: optional callback to restore state of the device
                 after ball search ended
         """
-        self.debug_log("Registering callback: {} (priority: {})".format(
-            name, priority))
+        self.debug_log("Registering callback: %s (priority: %s)", name, priority)
         self.callbacks.append(BallSearchCallback(priority, callback, name, restore_callback))
         # sort by priority
         self.callbacks = sorted(self.callbacks, key=lambda entry: entry.priority)
@@ -279,8 +278,8 @@ class BallSearch(MpfController):
                     'ball_search_wait_after_iteration']
 
             # if a callback returns True we wait for the next one
-            self.debug_log("Ball search: {} (phase: {}  iteration: {})".format(
-                element.name, self.phase, self.iteration))
+            self.debug_log("Ball search: %s (phase: %s  iteration: %s)",
+                element.name, self.phase, self.iteration)
             if element.callback(self.phase, self.iteration):
                 self.delay.add(name='run', callback=self._run, ms=timeout)
                 return

--- a/mpf/core/config_player.py
+++ b/mpf/core/config_player.py
@@ -161,7 +161,7 @@ class ConfigPlayer(LogMixin, metaclass=abc.ABCMeta):
         try:
             return self.instances[context][self.config_file_section]
         except KeyError:
-            self.warning_log("Config player {} is missing context {}".format(self.config_file_section, context))
+            self.warning_log("Config player %s is missing context %s", self.config_file_section, context)
             return {}
 
     def _reset_instance_dict(self, context):

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -656,7 +656,7 @@ class MachineController(LogMixin):
                                                           timeout=timeout))
         except asyncio.TimeoutError:
             self._crash_shutdown()
-            self.error_log("MPF needed more than {}s for initialization. Aborting!".format(timeout))
+            self.error_log("MPF needed more than %ss for initialization. Aborting!", timeout)
             return False
         except RuntimeError as e:
             self._crash_shutdown()

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -499,7 +499,7 @@ class MachineController(LogMixin):
 
             for custom_code in Util.string_to_event_list(self.config['custom_code']):
 
-                self.debug_log(f"Loading {custom_code} custom code")
+                self.debug_log("Loading %s custom code", custom_code)
 
                 custom_code_obj = Util.string_to_class(custom_code)(
                     machine=self,

--- a/mpf/core/mpf_controller.py
+++ b/mpf/core/mpf_controller.py
@@ -34,4 +34,4 @@ class MpfController(LogMixin, metaclass=abc.ABCMeta):
             self.machine.config['logging']['console'][self.config_name],
             self.machine.config['logging']['file'][self.config_name])
 
-        self.debug_log("Loading the {}".format(self.module_name))
+        self.debug_log("Loading the %s", self.module_name)

--- a/mpf/core/placeholder_manager.py
+++ b/mpf/core/placeholder_manager.py
@@ -907,8 +907,8 @@ class BasePlaceholderManager(MpfController):
                     match_dict['number'] = type(default_number)(match_dict['number'])
                 # Gracefully fall back if the number can't be parsed
                 except ValueError:
-                    self.warning_log("Condition '{}' has invalid number value '{}'".format(
-                                     template, match_dict['number']))
+                    self.warning_log("Condition '%s' has invalid number value '%s'",
+                                     template, match_dict['number'])
                     match_dict['number'] = default_number
         return ConditionalEvent(match_dict["name"], match_dict["condition"], match_dict["number"])
 

--- a/mpf/core/settings_controller.py
+++ b/mpf/core/settings_controller.py
@@ -85,18 +85,17 @@ class SettingsController(MpfController):
             value = self.machine.variables.get_machine_var(self._settings[setting_name].machine_var)
 
         if value not in self._settings[setting_name].values:
-            self.warning_log("Setting {} contained an invalid value {}. Falling back to default: {}".format(
-                setting_name, value, self._settings[setting_name].default
-            ))
+            self.warning_log("Setting %s contained an invalid value %s. Falling back to default: %s",
+                             setting_name, value, self._settings[setting_name].default)
             value = self._settings[setting_name].default
 
-        self.debug_log("Retrieving value: {}={}".format(setting_name, value))
+        self.debug_log("Retrieving value: %s=%s", setting_name, value)
 
         return value
 
     def set_setting_value(self, setting_name, value):
         """Set the value of a setting."""
-        self.debug_log("New value: {}={}".format(setting_name, value))
+        self.debug_log("New value: %s=%s", setting_name, value)
 
         if setting_name not in self._settings:
             raise AssertionError("Invalid setting {}".format(setting_name))

--- a/mpf/core/show_controller.py
+++ b/mpf/core/show_controller.py
@@ -48,7 +48,7 @@ class ShowController(MpfController):
         del kwargs
         show_names = self.machine.mpf_config.get_shows()
         for show_name in show_names:
-            self.log.debug(f"Loading show: {show_name}")
+            self.log.debug("Loading show: %s", show_name)
             show_config = self.machine.mpf_config.get_show_config(show_name)
             self.machine.shows[show_name].load(show_config)
 

--- a/mpf/core/show_controller.py
+++ b/mpf/core/show_controller.py
@@ -68,7 +68,7 @@ class ShowController(MpfController):
                              "there's already a show with that name. Shows are"
                              " shared machine-wide".format(name))
 
-        self.debug_log("Registering show: {}".format(name))
+        self.debug_log("Registering show: %s", name)
         self.machine.shows[name] = Show(self.machine,
                                         name=name)
 

--- a/mpf/core/text_ui.py
+++ b/mpf/core/text_ui.py
@@ -80,7 +80,7 @@ class TextUi(MpfController):
         self.screen = None
 
         if not machine.options['text_ui'] or not Scene:
-            self.log.debug(f"Text UI is disabled. TUI option setting: {machine.options['text_ui']}, Asciimatics loaded: {Scene}")
+            self.log.debug("Text UI is disabled. TUI option setting: %s, Asciimatics loaded: %s", machine.options['text_ui'], Scene)
             return
 
         # hack to add themes until https://github.com/peterbrittain/asciimatics/issues/207 is implemented

--- a/mpf/devices/ball_save.py
+++ b/mpf/devices/ball_save.py
@@ -78,10 +78,10 @@ class BallSave(SystemWideDevice, ModeDevice):
         self.enabled = True
         self.state = 'enabled'
         self.active_time = self.config['active_time'].evaluate([])
-        self.debug_log("Enabling. Auto launch: {}, Balls to save: {}, Active time: {}s".format(
+        self.debug_log("Enabling. Auto launch: %s, Balls to save: %s, Active time: %ss",
                        self.config['auto_launch'],
                        self.config['balls_to_save'],
-                       self.active_time))
+                       self.active_time)
 
         # Enable shoot again
         self.machine.events.add_handler('ball_drain',

--- a/mpf/devices/blinkenlight.py
+++ b/mpf/devices/blinkenlight.py
@@ -56,7 +56,7 @@ class Blinkenlight(SystemWideDevice):
         # check if this key already exists. If it does, replace it with the incoming color/priority
         self._colors = [x for x in self._colors if x[1] != key]
         self._colors.append((color, key, priority))
-        self.info_log('Color {} with key {} added'.format(color, key))
+        self.info_log('Color %s with key %s added', color, key)
         self._update_light()
 
     def remove_all_colors(self):
@@ -70,7 +70,7 @@ class Blinkenlight(SystemWideDevice):
         old_len = len(self._colors)
         self._colors = [x for x in self._colors if x[1] != key]
         if len(self._colors) != old_len:
-            self.info_log('Color removed with key {}'.format(key))
+            self.info_log('Color removed with key %s', key)
             self._update_light()
 
     def _update_light(self):

--- a/mpf/devices/flipper.py
+++ b/mpf/devices/flipper.py
@@ -125,7 +125,7 @@ class Flipper(SystemWideDevice):
 
         To prevent multiple rules at the same time we prioritize disable > enable.
         """
-        self.debug_log(f"Disabling via event callback. kwargs: {kwargs}")
+        self.debug_log("Disabling via event callback. kwargs: %s", kwargs)
         self.disable()
 
     def disable(self):

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -78,7 +78,7 @@ class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
     def _handle_balls_in_play_and_balls_live(self):
         ball_count = self.config['ball_count'].evaluate([])
         balls_to_replace = self.machine.game.balls_in_play if self.config['replace_balls_in_play'] else 0
-        self.debug_log("Going to add an additional {} balls for replace_balls_in_play".format(balls_to_replace))
+        self.debug_log("Going to add an additional %s balls for replace_balls_in_play", balls_to_replace)
 
         if self.config['ball_count_type'] == "total":
             # policy: total balls

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -320,12 +320,12 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
 
         # schedule eject of new balls for all physically locked balls
         if self.config['balls_to_replace'] == -1 or self.locked_balls <= self.config['balls_to_replace']:
-            self.debug_log("{} locked balls and {} to replace, requesting {} new balls"
-                           .format(self.locked_balls, self.config['balls_to_replace'], balls_to_lock_physically))
+            self.debug_log("%s locked balls and %s to replace, requesting %s new balls",
+                           self.locked_balls, self.config['balls_to_replace'], balls_to_lock_physically)
             self._request_new_balls(balls_to_lock_physically)
         else:
-            self.debug_log("{} locked balls exceeds {} to replace, not requesting any balls"
-                           .format(self.locked_balls, self.config['balls_to_replace']))
+            self.debug_log("%s locked balls exceeds %s to replace, not requesting any balls"
+                           self.locked_balls, self.config['balls_to_replace'])
 
         self.debug_log("Locked %s balls virtually and %s balls physically", balls_to_lock, balls_to_lock_physically)
 

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -324,7 +324,7 @@ class MultiballLock(EnableDisableMixin, ModeDevice):
                            self.locked_balls, self.config['balls_to_replace'], balls_to_lock_physically)
             self._request_new_balls(balls_to_lock_physically)
         else:
-            self.debug_log("%s locked balls exceeds %s to replace, not requesting any balls"
+            self.debug_log("%s locked balls exceeds %s to replace, not requesting any balls",
                            self.locked_balls, self.config['balls_to_replace'])
 
         self.debug_log("Locked %s balls virtually and %s balls physically", balls_to_lock, balls_to_lock_physically)

--- a/mpf/modes/bonus/code/bonus.py
+++ b/mpf/modes/bonus/code/bonus.py
@@ -99,8 +99,8 @@ class Bonus(Mode):
         score = entry['score'].evaluate([]) * hits
 
         if (not score and entry['skip_if_zero']) or (score < 0 and entry['skip_if_negative']):
-            self.debug_log("Skipping bonus entry '{}' because its value is 0".
-                           format(entry['event']))
+            self.debug_log("Skipping bonus entry '%s' because its value is 0",
+                           entry['event'])
             self._bonus_next_item()
             return
 
@@ -111,9 +111,8 @@ class Bonus(Mode):
             else:
                 score += self.settings["rounding_value"] - r
 
-        self.debug_log("Bonus Entry '{}': score: {} player_score_entry: {}={}".
-                       format(entry['event'], score,
-                              entry['player_score_entry'], hits))
+        self.debug_log("Bonus Entry '%s': score: %s player_score_entry: %s=%s",
+                       entry['event'], score, entry['player_score_entry'], hits)
 
         self.bonus_score += score
         self.machine.events.post(entry['event'], score=score,
@@ -131,7 +130,7 @@ class Bonus(Mode):
             self._total_bonus()
 
         else:
-            self.debug_log("Bonus subtotal: {}", self.bonus_score)
+            self.debug_log("Bonus subtotal: %s", self.bonus_score)
             self.machine.events.post('bonus_subtotal', score=self.bonus_score)
             '''event: bonus_subtotal
 
@@ -152,7 +151,7 @@ class Bonus(Mode):
 
     def _do_multiplier(self):
         multiplier = self.player.vars.get("bonus_multiplier", 1)
-        self.debug_log("Bonus multiplier: {}".format(multiplier))
+        self.debug_log("Bonus multiplier: %s", multiplier)
         self.machine.events.post('bonus_multiplier', multiplier=multiplier)
         '''event: bonus_multiplier
 
@@ -172,7 +171,7 @@ class Bonus(Mode):
     def _total_bonus(self):
         self.player.add_with_kwargs("score", self.bonus_score,
                                     source=self.name)
-        self.debug_log("Bonus Total: {}", self.bonus_score)
+        self.debug_log("Bonus Total: %s", self.bonus_score)
         self.machine.events.post('bonus_total', score=self.bonus_score)
 
         if not self.settings['end_bonus_event']:

--- a/mpf/platforms/fast/communicators/exp.py
+++ b/mpf/platforms/fast/communicators/exp.py
@@ -96,5 +96,5 @@ class FastExpCommunicator(FastSerialCommunicator):
         if not 0 <= rate <= 8191:
             raise ValueError(f"FAST LED fade rate of {rate}ms is out of bounds. Must be between 0 and 8191ms")
 
-        self.platform.debug_log(f"{self} - Setting LED fade rate to {rate}ms")
+        self.platform.debug_log("%s - Setting LED fade rate to %sms", self, rate)
         self.send_and_forget(f'RF@{board_address}:{Util.int_to_hex_string(rate, True)}')

--- a/mpf/platforms/fast/communicators/rgb.py
+++ b/mpf/platforms/fast/communicators/rgb.py
@@ -24,7 +24,7 @@ class FastRgbCommunicator(FastSerialCommunicator):
 
     def _process_boot_msg(self, msg):
         """Process bootloader message."""
-        self.log.debug(f"Got Bootloader message: !B:{msg}")
+        self.log.debug("Got Bootloader message: !B:%s", msg)
         if msg in ('00', '02'):
             if self.config['ignore_reboot']:
                 self.machine.events.post("fast_rgb_rebooted", msg=msg)

--- a/mpf/platforms/fast/fast_driver.py
+++ b/mpf/platforms/fast/fast_driver.py
@@ -144,7 +144,8 @@ class FASTDriver:
         return Util.int_to_hex_string(num)
 
     def send_config_to_driver(self, one_shot: bool = False, wait_to_confirm: bool = False):
-        self.log.debug(f"Sending config to driver {self.number}. one_shot: {one_shot}. wait_to_confirm: {wait_to_confirm}")
+        self.log.debug("Sending config to driver %s. one_shot: %s. wait_to_confirm: %s",
+                       self.number, one_shot, wait_to_confirm)
 
         if one_shot:
             trigger = self.set_bit(self.current_driver_config.trigger, 3)
@@ -167,7 +168,7 @@ class FASTDriver:
                   f'{self.current_driver_config.param2},{self.current_driver_config.param3},{self.current_driver_config.param4},'
                   f'{self.current_driver_config.param5}')
 
-        self.log.debug(f"Current config for driver {self.number}: {config}")
+        self.log.debug("Current config for driver %s: %s", self.number, config)
         return config
 
     def get_board_name(self):
@@ -194,12 +195,12 @@ class FASTDriver:
             return "FF"
 
         rms = Util.int_to_hex_string(pulse_ms * 2)
-        self.log.debug(f"Using recycle_ms of {rms} for driver {self.number}")
+        self.log.debug("Using recycle_ms of %s for driver %s", rms, self.number)
         return rms
 
     async def reset(self):
         """Reset the driver to fresh (disabled/unconfigured) state."""
-        self.log.debug(f"Resetting driver {self.number}")
+        self.log.debug("Resetting driver %s", self.number)
         self.current_driver_config.trigger =   '00'
         self.current_driver_config.switch_id = '00'
         self.current_driver_config.mode =      '00'
@@ -214,15 +215,15 @@ class FASTDriver:
     def disable(self):
         """Disable (turn off) this driver."""
         if not self._reenable_autofire_if_configured():
-            self.log.debug(f"Disabling driver {self.number}")
+            self.log.debug("Disabling driver %s", self.number)
             self.communicator.send_and_forget(f'{self.communicator.TRIGGER_CMD}:{self.hw_number},02')
         else:
-            self.log.debug(f"Received disable command for driver {self.number} but reenabled autofire instead")
+            self.log.debug("Received disable command for driver %s but reenabled autofire instead", self.number)
 
     def set_hardware_rule(self, mode, switch, coil_settings, **kwargs):
 
-        self.log.debug(f"Setting hardware rule for driver {self.number}. Mode: {mode}. Switch: {switch.hw_switch.hw_number}. "
-                       f"coil_settings: {coil_settings}. kwargs: {kwargs}.")
+        self.log.debug("Setting hardware rule for driver %s. Mode: %s. Switch: %s. coil_settings: %s. kwargs: %s.",
+                       self.number, mode, switch.hw_switch.hw_number, coil_settings, kwargs)
 
         self._check_switch_coil_combination(switch, coil_settings.hw_driver)
 
@@ -341,7 +342,7 @@ class FASTDriver:
 
     def clear_autofire(self):
         """Clear autofire."""
-        self.log.debug(f"Clearing autofire mode for driver {self.number}")
+        self.log.debug("Clearing autofire mode for driver %s", self.number)
         self._check_and_clear_delay()
         if not self.autofire_config:
             return
@@ -356,7 +357,8 @@ class FASTDriver:
     def enable(self, pulse_settings: PulseSettings, hold_settings: HoldSettings):
         """Enable (turn on) this driver."""
 
-        self.log.debug(f"Enabling (turning on) driver {self.number} with pulse_settings: {pulse_settings} and hold_settings: {hold_settings}.")
+        self.log.debug("Enabling (turning on) driver %s with pulse_settings: %s and hold_settings: %s.",
+                       self.number, pulse_settings, hold_settings)
 
         self._check_and_clear_delay()
 
@@ -402,7 +404,8 @@ class FASTDriver:
     def timed_enable(self, pulse_settings: PulseSettings, hold_settings: HoldSettings):
         """Pulse and hold this driver for a specified duration."""
 
-        self.log.debug(f"Timed enabling (pulsing and holding) driver {self.number} with pulse_settings: {pulse_settings} and hold_settings: {hold_settings}.")
+        self.log.debug("Timed enabling (pulsing and holding) driver %s with pulse_settings: %s and hold_settings: %s.",
+                       self.number, pulse_settings, hold_settings)
 
         if not hold_settings.duration and self.current_driver_config.mode == '70':
             # If we are in mode 70, timed enable defaults are already set
@@ -412,7 +415,8 @@ class FASTDriver:
 
     def pulse(self, pulse_settings: PulseSettings):
         """Pulse this driver."""
-        self.log.debug(f"Pulsing driver {self.number} with pulse_settings: {pulse_settings}.")
+        self.log.debug("Pulsing driver %s with pulse_settings: %s.",
+                       self.number, pulse_settings)
         self._pulse(pulse_settings)
 
     def _pulse(self, pulse_settings: PulseSettings, hold_settings: HoldSettings = None):

--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -41,7 +41,8 @@ class FastExpansionBoard:
         self.firmware_version = None
         self.hw_verified = False  # have we made contact with the board and verified it's the right hardware?
 
-        self.log.debug(f'Creating FAST Expansion Board "{self.name}" ({self.model} Address: {self.address})')
+        self.log.debug('Creating FAST Expansion Board "%s" (%s Address: %s)',
+                       self.name, self.model, self.address)
 
         self.features = EXPANSION_BOARD_FEATURES[self.model]  # ([local model numbers,], num of remotes) tuple
         self.breakouts = dict()
@@ -87,7 +88,8 @@ class FastExpansionBoard:
             active_board (str): 2 or 3 hex character address of the EXP or BRK board
         """
 
-        self.log.info(f'Verifying hardware for {self} with ID string "{id_string}", board address {active_board}')
+        self.log.info('Verifying hardware for %s with ID string "%s", board address %s',
+                      self, id_string, active_board)
 
         exp_board = active_board[:2]
         brk_board = active_board[2:]  # will be empty if we got a 2-digit address for an EXP board
@@ -96,7 +98,7 @@ class FastExpansionBoard:
             _, product_id, firmware_version = id_string.split()
         except ValueError:
             if id_string == 'F':  # got an ID:F response which means this breakout is not actually there
-                self.log.error(f'Breakout {brk_board} on {self} is not responding')
+                self.log.error('Breakout %s on %s is not responding', brk_board, self)
                 raise AssertionError(f'Breakout {brk_board} on {self} is not responding')
             else:
                 raise AssertionError(f'Invalid ID string {id_string} from {self}')
@@ -106,7 +108,8 @@ class FastExpansionBoard:
 
         if brk_board:
             if version.parse(firmware_version) < version.parse(self.breakouts[brk_board].features['min_fw']):
-                self.log.error(f'Firmware on breakout board {product_id} is too old. Required: {self.breakouts[brk_board].features["min_fw"]}, Actual: {firmware_version}. Update at fastpinball.com/firmware')
+                self.log.error('Firmware on breakout board %s is too old. Required: %s, Actual: %s. Update at fastpinball.com/firmware',
+                               product_id, self.breakouts[brk_board].features["min_fw"], firmware_version)
                 self.platform.machine.stop(f'Firmware on breakout board {product_id} is too old. Required: {self.breakouts[brk_board].features["min_fw"]}, Actual: {firmware_version}. Update at fastpinball.com/firmware')
 
             brk = self.breakouts[brk_board]
@@ -118,7 +121,8 @@ class FastExpansionBoard:
 
         else:
             if version.parse(firmware_version) < version.parse(self.features['min_fw']):
-                self.log.error(f'Firmware on {self} is too old. Required: {self.features["min_fw"]}, Actual: {firmware_version}. Update at fastpinball.com/firmware')
+                self.log.error('Firmware on %s is too old. Required: %s, Actual: %s. Update at fastpinball.com/firmware',
+                               self, self.features["min_fw"], firmware_version)
                 self.platform.machine.stop(f'Firmware on {self} is too old. Required: {self.features["min_fw"]}, Actual: {firmware_version}. Update at fastpinball.com/firmware')
 
             if product_id != self.model:
@@ -176,7 +180,7 @@ class FastBreakoutBoard:
         self.expansion_board = expansion_board  # object
         self.log = expansion_board.log
         self.index = config['port']  # int, zero-based, 0-5
-        self.log.debug(f"Creating FAST Breakout Board {self.index} on {self.expansion_board}")
+        self.log.debug("Creating FAST Breakout Board %s on %s", self.index, self.expansion_board)
         self.platform = expansion_board.platform
         self.communicator = expansion_board.communicator
         self.address = f'{self.expansion_board.address}{self.index}'  # string hex byte + nibble

--- a/mpf/platforms/fast/fast_port_detector.py
+++ b/mpf/platforms/fast/fast_port_detector.py
@@ -19,7 +19,7 @@ class FastPortDetector:
         self.task_writers = dict()
         self.results = dict()  # dict of processor: port
 
-        self.platform.log.info(f"Auto-detecting ports for the following connections: {self.autodetect_processors}")
+        self.platform.log.info("Auto-detecting ports for the following connections: %s", self.autodetect_processors)
 
         self._find_fast_devices()
 
@@ -33,9 +33,10 @@ class FastPortDetector:
                     baud = self.machine.config['fast'][proc]['baud']
                     if port.device not in self.hardcoded_ports:
                         self.detected_fast_ports.append((port.device, baud))
-                        self.platform.log.debug(f"Port {port.device} is connected to a {desc}.")
+                        self.platform.log.debug("Port %s is connected to a %s.", port.device, desc)
                     else:
-                        self.platform.log.debug(f"Skipping auto-detect of {proc} on {port.device} since it's in the config file elsewhere.")
+                        self.platform.log.debug("Skipping auto-detect of %s on %s since it's in the config file elsewhere.",
+                                                proc, port.device)
 
     async def detect_ports(self):
         self.tasks = [asyncio.create_task(self._connect_task(port, baud)) for port, baud in self.detected_fast_ports]
@@ -62,7 +63,7 @@ class FastPortDetector:
                     bytesize=EIGHTBITS, parity=PARITY_NONE, stopbits=STOPBITS_ONE)
                 reader, writer = await connector
             except SerialException:
-                self.log.error(f"Could not connect to port {port}. Are you connected via CoolTerm? :)")
+                self.log.error("Could not connect to port %s. Are you connected via CoolTerm? :)", port)
 
             self.platform.debug_log(" - success connecting to port %s", port)
             self.task_writers[asyncio.current_task()] = writer
@@ -93,7 +94,7 @@ class FastPortDetector:
 
     def _report_success(self, processor, port):
         self.results[processor] = port
-        self.platform.log.info(f'Detected {processor.upper()} on port {port}')
+        self.platform.log.info('Detected %s on port %s', processor.upper(), port)
         self.platform.config[processor]['port'] = [port]
 
         if len(self.results) >= len(self.autodetect_processors):

--- a/mpf/platforms/fast/fast_segment_display.py
+++ b/mpf/platforms/fast/fast_segment_display.py
@@ -35,7 +35,6 @@ class FASTSegmentDisplay(SegmentDisplayPlatformInterface):
 
     def _set_color(self, colors: List[RGBColor]) -> None:
         """Set display color."""
-        #self.serial.platform.info_log("Color: {}".format(colors))
         if len(colors) == 1:
             self.next_color = (RGBColor(colors[0]).hex + ',') * 7
         else:

--- a/mpf/platforms/pkone/pkone_serial_communicator.py
+++ b/mpf/platforms/pkone/pkone_serial_communicator.py
@@ -125,7 +125,7 @@ class PKONESerialCommunicator(BaseSerialCommunicator):
         msg = ''
         while msg != 'PRSE' and not msg.startswith('PXX'):
             msg = (await self.readuntil(b'E')).decode()
-            self.platform.debug_log("Got: {}".format(msg))
+            self.platform.debug_log("Got: %s", msg)
 
         if msg.startswith('PXX'):
             raise AssertionError('Received an error while resetting the controller: {}'.format(msg))


### PR DESCRIPTION
This PR replaces numerous log statements that use f-string formatting (`f"The value is {value}"`) and string.format (`"The value is {}".format(value)`) with standard substitution (`"The value is %s", value`).

### Why Does This Matter?
In Python each of the above three methods is equivalent for populating a variable into a string, but during logging there is an additional consideration. It takes CPU time to generate a string (which is immutable, and therefore requires a unique instance) and many log statements are suppressed. Formatting a string with **f-string** or **string.format** _before_ submitting it to the logger still requires Python to generate the string. But when a **substitution string** and values are passed into the logger, the logger is smart enough to not generate the string if the log is going to be suppressed anyway.

As a result, using substitution strings reduces the CPU overhead of log calls and consumes less resources as the log level rises.

### How Much Better?
Using the **`timeit`** module, I benchmarked log statements using both f-string and substitution methods. When the log level was sufficient to log the output, the substitution method ran in 94.5% of the time (a savings of 5.5%). When the log level suppressed the output, the substitution method ran in 90% of the time (a savings of 10%).

This may not seem like much, but many info and (especially) debug logs can run dozens of times a second, especially when monitoring serial communications. When maintaining multiple serial connections, e.g. to each of FAST Nano, Expansion, Audio, and RGB boards, that creates a substantial amount of debug logging. Saving 10% of that energy is worth doing, I think.

![faster!](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2phcjl6dGZucGc2MzVsM2NnbHNtaWt6bTltZXA1M2p5emJ0enhicyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7XsFGzfP6WmC4/giphy.gif)