### PR TITLE
FAST Exp LED b16 debug

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.0.dev35'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.0.dev36'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -158,7 +158,12 @@ class FastExpansionBoard:
 
                 log_msg = f'RD@{breakout_address}:{msg}'  # pretty version of the message for the log
 
-                self.communicator.send_bytes(b16decode(f'{msg_header}{msg}'), log_msg)
+                try:
+                    self.communicator.send_bytes(b16decode(f'{msg_header}{msg}'), log_msg)
+                except Exception as e:
+                    self.log.error(f"Error decoding the following message for board {breakout_address} : {msg_header}{msg}")
+                    self.log.debug("Attempted update that caused this error: %s", dirty_leds)
+                    raise e
 
     def set_led_fade(self, rate: int) -> None:
         """Set LED fade rate in ms."""


### PR DESCRIPTION
This PR adds additional logging when a FAST Expansion Board LED update fails to process a base16 message. The `log_msg` is not logged until after the message is decoded, so a crash on the decoding prevents the offending message from being seen.

Also bump up the version so this can be released to the user who is experiencing the crash.

![crashing](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2VpczJidHd0dnZxZ2pueTUzNjdvanltZ2g1cm5nbGJnbGxudHI5dSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MVgLEacpr9KVK172Ne/giphy.gif)