### PR TITLE
Fast led b16 debug: negative brightness

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.0.dev36'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.0.dev37'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/platforms/fast/fast_led.py
+++ b/mpf/platforms/fast/fast_led.py
@@ -123,6 +123,12 @@ class FASTLEDChannel(LightPlatformInterface):
             self._last_brightness = brightness
             done = True
 
+        if brightness < 0:
+            self.led.log.warning("Calculated a negative brightness (%s) for led %s channel %s. current_time: %s"+\
+                                 "start_brightness: %s, start_time: %s, target_brightness: %s, target_time: %s",
+                                 brightness, self.led, self.channel, current_time, start_brightness, start_time,
+                                 target_brightness, target_time)
+
         return brightness, fade_ms, done
 
     def get_board_name(self):


### PR DESCRIPTION
This PR adds additional logging to debug a scenario in which a FAST RGB LED returns a brightness less than zero, resulting in a base16 decoding error and crash.

![log](https://media.giphy.com/media/3otPoxy3BE4iPS0RYA/giphy.gif)