### PR TITLE
More logging updates and trough jam adjustment

### DIFF
--- a/mpf/devices/ball_device/ball_count_handler.py
+++ b/mpf/devices/ball_device/ball_count_handler.py
@@ -93,7 +93,7 @@ class BallCountHandler(BallDeviceStateHandler):
 
         self._ball_count = await self.counter.count_balls()
         # on start try to reorder balls if count is unstable
-        if self.counter.is_count_unreliable():
+        if self.counter.is_count_unreliable() or self.counter.is_jammed():
             self.info_log("BCH: Count is unstable. Trying to reorder balls.")
             await self.ball_device.ejector.reorder_balls()
             self.info_log("BCH: Repulse done. Waiting for balls to settle.")

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -60,7 +60,7 @@ class DropTarget(SystemWideDevice):
             self.config['playfield'].ball_search.register(
                 self.config['ball_search_order'], self._ball_search, self.name)
 
-        if '{}_active'.format(self.config['playfield'].name) in self.config['switch'].tags:
+        if f'{self.config['playfield'].name}_active' in self.config['switch'].tags:
             self.raise_config_error(
                 "Drop target device '{}' uses switch '{}' which has a "
                 "'{}_active' tag. This is handled internally by the device. Remove the "
@@ -211,13 +211,13 @@ class DropTarget(SystemWideDevice):
     def _update_state_from_switch(self, reconcile=False, **kwargs):
         del kwargs
 
-        self.debug_log("Updating Drop Target '{}' State From Switches".format(self.name))
         is_complete = self.machine.switch_controller.is_active(
             self.config['switch'])
 
-        self.debug_log("Switch '{}' is active value '{}'.  Self.Complete value '{}'".format(self.config['switch'].name, is_complete, self.complete))
+        self.debug_log("Drop target %s switch %s has active value %s compared to drop complete %s",
+                       self.name, self.config['switch'].name, is_complete, self.complete)
         if self._in_ball_search or self._ignore_switch_hits:
-            self.debug_log("Exiting Drop Target '{}' state update due to being in ball search or ignoring switch hits".format(self.name))
+            self.debug_log("Ignoring state change in drop target %s due to being in ball search or ignoring switch hits", self.name)
             return
 
         if not reconcile:
@@ -226,10 +226,8 @@ class DropTarget(SystemWideDevice):
         if is_complete != self.complete:
 
             if is_complete:
-                self.debug_log("Updating Drop Target '{}' To Down".format(self.name))
                 self._down()
             else:
-                self.debug_log("Updating Drop Target '{}' To Up".format(self.name))
                 self._up()
 
             self._update_banks()

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -60,7 +60,7 @@ class DropTarget(SystemWideDevice):
             self.config['playfield'].ball_search.register(
                 self.config['ball_search_order'], self._ball_search, self.name)
 
-        if f'{self.config['playfield'].name}_active' in self.config['switch'].tags:
+        if f"{self.config['playfield'].name}_active" in self.config['switch'].tags:
             self.raise_config_error(
                 "Drop target device '{}' uses switch '{}' which has a "
                 "'{}_active' tag. This is handled internally by the device. Remove the "

--- a/mpf/devices/state_machine.py
+++ b/mpf/devices/state_machine.py
@@ -100,7 +100,7 @@ class StateMachine(SystemWideDevice, ModeDevice):
             self._show = None
 
     def _stop_current_state(self):
-        self.log.debug("Stopping state %s", self.state)
+        self.debug_log("Stopping state %s", self.state)
         self._remove_handlers()
         state_config = self.config['states'][self.state]
         if state_config['events_when_stopped']:
@@ -108,14 +108,14 @@ class StateMachine(SystemWideDevice, ModeDevice):
                 self.machine.events.post(event_name)
 
         if self._show:
-            self.log.debug("Stopping show %s", self._show)
+            self.debug_log("Stopping show %s", self._show)
             self._show.stop()
             self._show = None
 
         self.state = None
 
     def _start_state(self, state):
-        self.log.debug("Starting state %s", state)
+        self.debug_log("Starting state %s", state)
         if state not in self.config['states']:
             raise AssertionError("Invalid state {}".format(state))
 
@@ -132,7 +132,7 @@ class StateMachine(SystemWideDevice, ModeDevice):
         assert not self._show
         state_config = self.config['states'][self.state]
         if state_config['show_when_active']:
-            self.log.debug("Starting show %s", state_config['show_when_active'])
+            self.debug_log("Starting show %s", state_config['show_when_active'])
             self._show = self.machine.show_controller.play_show_with_config(state_config['show_when_active'],
                                                                             self.mode)
 
@@ -145,7 +145,7 @@ class StateMachine(SystemWideDevice, ModeDevice):
 
     def _transition(self, transition_config, **kwargs):
         del kwargs
-        self.log.info("Transitioning from %s to %s", self.state, transition_config["target"])
+        self.info_log("Transitioning from %s to %s", self.state, transition_config["target"])
         self._stop_current_state()
         if transition_config['events_when_transitioning']:
             for event_name in transition_config['events_when_transitioning']:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "ruamel.yaml == 0.17.32",  # Oct 4, 2023, main config file interface
     "sortedcontainers == 2.4.0",  # Oct 4 2023, used by platform batch light system
     "terminaltables == 3.1.10",  # Oct 4 2023, used for the service CLI
-    "uvloop == 0.17.0; platform_system!='Windows'", # Oct 4 2023, msin asyncio loop
+    # uvloop should be optional, non-Cython derivatives don't support it.
+    # "uvloop == 0.17.0; platform_system!='Windows'", # Oct 4 2023, msin asyncio loop
     "Pillow == 9.5.0"  # Nov 4 2023. Asciimatics needs Pillow > 2.7, but latest 10.x breaks kivy for now (fix due in 2.3), so we pin to latest working Pillow for now.
     ]
 dynamic = ["version"]


### PR DESCRIPTION
This PR mostly continues with logging updates, including:
* String substitutions on new DropTarget logs
* Use LogMixin for state_machines and achievements to respect logLevel and production flag

This PR also adds a trough jam check on the trough initialization, to attempt a reorder pulse. There is future work necessary to handle a full jammed trough because MPF counts the full balls and thinks all is okay.... but that's work for another day.

This PR also removes the requirement of the `uvloop` package as part of the base MPF install. UVLoop has always been optional and is accounted for in the code, and non-Cython interpreters (e.g. pypy) don't support uvloop. For users who wish to take advantage of uvloop, simply doing `pip install uvloop` will install it and MPF will then detect and leverage it.

![pop it!](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeno1ZGttNTZnYzZnOTZhbXhnMzlzbjNpN3dobzNqcGJod2ZkOGhzZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l3q2P2l54336ew5iM/giphy-downsized.gif)