### PR TITLE
Kivy Window: fullscreen 'fake'

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.0.dev40'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.0.dev41'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -2369,7 +2369,7 @@ window:
     source_display: single|str|window
     borderless: single|bool_int|false
     resizable: single|bool_int|true
-    fullscreen: single|bool_int|false
+    fullscreen: single|str|false
     show_cursor: single|bool_int|true
     exit_on_escape: single|bool|true
     height: single|int|600


### PR DESCRIPTION
This PR adjusts the config spec for `window:` to support strings as the `fullscreen:` configuration value. Per the Kivy 2.3 documentation:

>  fullscreen: int or string, one of 0, 1, ‘fake’ or ‘auto’

> Activate fullscreen. If set to 1, a resolution of width times height pixels will be used. If set to auto, your current display’s resolution will be used instead. This is most likely what you want. If you want to place the window in another display, use fake, or set the borderless option from the graphics section, then adjust width, height, top and left.


Doing some internal testing, using `fake` for the fullscreen value yields better results in terms of borderless, frameless, multi-display-spanning windows.

![bigger is better](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHc1aWd3ajVva2JzeXZ4NXByczEydDRlbXZsNjg4b2hwbmZqdXA4aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6nUXfbNf4D9U54Fa/giphy.gif)