### PR TITLE
Segment Displays: Stack vs Replace Option

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1479,6 +1479,7 @@ segment_displays:
     default_transition_update_hz: single|float_or_token|30
     platform_settings: single|dict|None
     platform: single|str|None
+    update_method: single|str|None
 light_segment_displays_device:
     lights: list|dict(str:machine(lights))|None
     light_groups: list|machine(neoseg_displays)|None

--- a/mpf/platforms/fast/communicators/seg.py
+++ b/mpf/platforms/fast/communicators/seg.py
@@ -39,6 +39,7 @@ class FastSegCommunicator(FastSerialCommunicator):
 
             if s.next_color:
                 self.send_and_forget(('PC:{},{}').format(s.hex_id, s.next_color))
+                s.current_color = s.next_color
                 s.next_color = None
 
     async def soft_reset(self):
@@ -49,3 +50,4 @@ class FastSegCommunicator(FastSerialCommunicator):
             self.send_and_forget(f'PA:{s.hex_id},')
             s.next_text = None
             s.next_color = None
+            s.current_color = None

--- a/mpf/platforms/fast/fast_segment_display.py
+++ b/mpf/platforms/fast/fast_segment_display.py
@@ -14,7 +14,7 @@ class FASTSegmentDisplay(SegmentDisplayPlatformInterface):
 
     """FAST segment display."""
 
-    __slots__ = ["serial", "hex_id", "next_color", "next_text"]
+    __slots__ = ["serial", "hex_id", "next_color", "next_text", "current_color"]
 
     def __init__(self, index, communicator):
         """Initialize alpha numeric display."""
@@ -23,6 +23,7 @@ class FASTSegmentDisplay(SegmentDisplayPlatformInterface):
         self.hex_id = Util.int_to_hex_string(index * 7)
         self.next_color = None
         self.next_text = None
+        self.current_color = None
 
     def set_text(self, text: ColoredSegmentDisplayText, flashing: FlashingType, flash_mask: str) -> None:
         """Set digits to display."""
@@ -36,6 +37,12 @@ class FASTSegmentDisplay(SegmentDisplayPlatformInterface):
     def _set_color(self, colors: List[RGBColor]) -> None:
         """Set display color."""
         if len(colors) == 1:
-            self.next_color = (RGBColor(colors[0]).hex + ',') * 7
+            next_color = (RGBColor(colors[0]).hex + ',') * 7
         else:
-            self.next_color = ','.join([RGBColor(color).hex for color in colors]) + ','
+            next_color = ','.join([RGBColor(color).hex for color in colors]) + ','
+
+        # Current color is set by the FastSegCommunicator after the serial
+        # command is written to set the color (which happens automatically
+        # on the next loop whenever self.next_color is set).
+        if next_color != self.current_color:
+            self.next_color = next_color

--- a/mpf/plugins/platform_integration_test_runner.py
+++ b/mpf/plugins/platform_integration_test_runner.py
@@ -7,7 +7,6 @@ from mpf.core.delays import DelayManager
 from mpf.core.plugin import MpfPlugin
 from mpf.core.utility_functions import Util
 
-
 class MpfPlatformIntegrationTestRunner(MpfPlugin):
 
     """Runs a Platform Integration test provided by the command line.
@@ -17,18 +16,14 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
     mpf -pit path.to.ModuleFile.ModuleClassName
     """
 
-    __slots__ = ("delay", "_task", "_keep_alive", "_start_time", "_test_obj",
-                 "trough_switches")
+    __slots__ = ( "delay", "_task", "_keep_alive", "_start_time", "_test_obj")
 
     def __init__(self, *args, **kwargs):
         """Initialize the test runner."""
         super().__init__(*args, **kwargs)
         self._keep_alive = None
-        self._task = None
-        self._test_obj = None
         self._start_time = None
         self.delay = None
-        self.trough_switches = None
 
     @property
     def is_plugin_enabled(self):
@@ -38,8 +33,7 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
     def initialize(self):
         """Initialize test runner and load test module."""
         self.configure_logging('MpfPlatformIntegration', 'basic', 'full')
-        self.info_log("Initializing Platform Integration Test: Arg value is %s",
-                      self.machine.options["platform_integration_test"])
+        self.info_log("Platform Integration Test is here! Arg value is %s", self.machine.options["platform_integration_test"])
         self.delay = DelayManager(self.machine)
 
         # Find the file with the test
@@ -71,28 +65,18 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
         # Create an event handler to begin the test run
         self.machine.events.add_handler(self._test_obj.test_start_event, self._run_test)
 
-        self.trough_switches = []
-        for ball_device in self.machine.ball_devices.items_tagged('trough'):
-            jam_switch = ball_device.config.get('jam_switch')
-            for s in Util.string_to_list(ball_device.config["ball_switches"]):
-                if s != jam_switch:
-                    self.trough_switches.append(s)
-
         # Pre-set initial switches defined in the test
         if self._test_obj.initial_switches is not None:
             for s in self._test_obj.initial_switches:
-                s_state = 0 if self.machine.switches[s].invert else 1
-                self.machine.switch_controller.process_switch(s, s_state)
+                self.machine.switch_controller.process_switch(s, 1)
         # Pre-fill the trough with balls if no initial switches are defined
         else:
-            for s in self.trough_switches:
-                s_state = 0 if self.machine.switches[s].invert else 1
-                self.info_log("Initializing trough switch %s", s)
-                self.machine.switch_controller.process_switch(s, s_state)
-            self.info_log("Re-initializing trough ball counts")
             for ball_device in self.machine.ball_devices.items_tagged('trough'):
+                for s in Util.string_to_list(ball_device.config["ball_switches"]):
+                    self.info_log("Initializing trough switch %s", s)
+                    self.machine.switch_controller.process_switch(s, 1)
+                self.info_log("Re-initializing trough ball count")
                 ball_device.ball_count_handler.counter.trigger_recount()
-            self.machine.ball_controller.num_balls_known = len(self.trough_switches)
 
     def _run_test(self, **kwargs):
         del kwargs
@@ -112,7 +96,7 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
             self._task = None
         duration = datetime.now() - self._start_time
         msg = f"All tests completed successfully in {duration.seconds}.{duration.microseconds // 1000} seconds."
-        if not self._keep_alive:
+        if not self.keep_alive:
             self.machine.stop(msg)
         else:
             self.info_log("%s Keep Alive is enabled, runner will not exit game." % msg)
@@ -136,8 +120,6 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
         """Set a switch to a given state, synchronously."""
         if state is None:
             state = int(not self.machine.switches[switch_name].state)
-        if self.machine.switches[switch_name].invert:
-            state ^= 1
         self.delay.remove(switch_name)
         self.info_log("Setting switch %s to state %s", switch_name, state)
         self.machine.switch_controller.process_switch(switch_name, state)
@@ -155,7 +137,6 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
                 "exception": AssertionError(f"Awaited event '{event}' failed to trigger within {timeout}s.")
             })
 
-    # pylint: disable-msg=too-many-arguments
     async def set_switch(self, switch_name, state=None, duration_secs=None, wait_after=None, blocking=True):
         """Set a switch to a given state.
 
@@ -174,41 +155,38 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
                 self.set_switch_sync(switch_name, int(not state))
             else:
                 # Remove any existing reversion, add a new one if necessary
-                self.delay.add(name=switch_name, ms=duration_secs * 1000,
-                               callback=self.set_switch_sync,
-                               switch_name=switch_name, state=int(not state))
+                self.delay.add(name=switch_name, ms=duration_secs*1000, callback=self.set_switch_sync,
+                            switch_name=switch_name, state=int(not state))
 
         if wait_after:
             await asyncio.sleep(wait_after)
 
-    async def start_game(self, num_players=1):
+    async def start_game(self, player_count=1):
         """Start a game with the requested number of players."""
         self.info_log("Starting game.")
         await asyncio.sleep(1)
         start_button = self.machine.switches.items_tagged('start')[0]
-        for _ in range(0, num_players):
+        for _ in range(0, player_count+1):
             await self.set_switch(start_button.name, 1, 0.2)
             await asyncio.sleep(0.5)
-        assert self.machine.game, "Game failed to start"
 
-    async def eject_and_plunge_ball(self, plunger_switch_name, plunger_lane_settle_time=2, **kwargs):
-        """Shuffle the trough switches and plunger to simulate an eject."""
+    async def eject_and_plunge_ball(self, plunger_lane_settle_time=2, **kwargs):
+        # TODO: Use dynamic switch names to find the plunger and trough
         del kwargs
         self.info_log("Ejecting and plunging ball...")
-        self.set_switch_sync(self.trough_switches[0], 0)
+        self.set_switch_sync("s_trough_1", 0)
         await asyncio.sleep(0.03)
-        self.set_switch_sync(self.trough_switches[-1], 0)
+        self.set_switch_sync("s_trough_3", 0)
         await asyncio.sleep(0.1)
-        self.set_switch_sync(self.trough_switches[0], 1)
+        self.set_switch_sync("s_trough_1", 1)
         await asyncio.sleep(0.25)
-        await self.set_switch(plunger_switch_name, 1, duration_secs=plunger_lane_settle_time)
+        await self.set_switch("s_plunger_lane", 1, plunger_lane_settle_time)
         await asyncio.sleep(1)
 
     async def move_ball_from_drain_to_trough(self, **kwargs):
-        """Move a ball from the drain device to the trough device."""
+        # TODO: Use dynamic switch names to find drain and trough
         del kwargs
-        drain_switches = self.machine.ball_devices.items_tagged('drain')[0].config.get('ball_switches')
-        self.set_switch_sync(drain_switches[-1], 0)
+        self.set_switch_sync("s_drain", 0)
         await asyncio.sleep(0.25)
-        self.set_switch_sync(self.trough_switches[-1], 1)
+        self.set_switch_sync("s_trough_3", 1)
         await asyncio.sleep(0.25)

--- a/mpf/tests/machine_files/segment_display/config/config.yaml
+++ b/mpf/tests/machine_files/segment_display/config/config.yaml
@@ -19,6 +19,12 @@ segment_displays:
     number: 1
     size: 10
     integrated_dots: true
+  display_stack:
+    number: 4
+    update_method: stack
+  display_replace:
+    number: 5
+    update_method: replace
 
 segment_display_player:
   test_event1:

--- a/mpf/tests/test_SegmentDisplay.py
+++ b/mpf/tests/test_SegmentDisplay.py
@@ -197,6 +197,21 @@ class TestSegmentDisplay(MpfFakeGameTestCase):
         self.assertEqual("       ", display5.hw_display.text)
         self.assertEqual(FlashingType.NO_FLASH, display5.hw_display.flashing)
 
+    def test_update_method(self):
+        display_stack = self.machine.segment_displays["display_stack"]
+        display_replace = self.machine.segment_displays["display_replace"]
+
+        for i in range(0, 10):
+            display_stack.add_text(f"STACK {i}", key=i, priority=i)
+            display_replace.add_text(f"REPLC {i}", key=i, priority=i)
+            self.advance_time_and_run(0.5)
+
+        self.assertEqual("STACK 9", display_stack.hw_display.text)
+        self.assertEqual("REPLC 9", display_replace.hw_display.text)
+
+        self.assertEqual(len(display_stack._text_stack), 10)
+        self.assertEqual(len(display_replace._text_stack), 0)
+
     def test_player(self):
         display1 = self.machine.segment_displays["display1"]
         display2 = self.machine.segment_displays["display2"]


### PR DESCRIPTION
This PR adds a new `update_method:` config option for segment displays with accepted values of `"stack"` and `"replace"`.

## How Segment Displays Work

At an architectural level, segment displays in MPF (currently) are structured similar to Slides in MC. Consider the physical segment display like an MC display, and each set of text like a Slide. Text can include dynamic values (e.g. player variables) that will automatically update when those variables change, like a Widget. 

Most importantly, a segment display retains in memory a "stack" of text entries—like an MC display has a stack of slides—with the highest-priority text on top and the lowest-priority text on the bottom. At any given time, the highest-priority text is rendered on the display and when it's removed, the next-highest-priority text is shown in its place.

To ensure the text is always accurate, text entries that have dynamic values will continue to update even when they're not on top. This way, whenever the stack changes the new text will always be correct.

## A Different Mental Model

After it's explained, and when considered in parallel to Slides and Widgets, the above architecture for segment displays makes sense—but it's not necessarily intuitive, or how a user would necessarily _expect_ segment displays to work.

The alternative mental model is to consider segment displays like lights or static widgets: send specific text to the display, and it renders that text until told otherwise. In this scenario the game code is responsible for tracking and sending every single text update to the display, which requires more diligence but eliminates the mental overhead of tracking the stacks and priorities.

The new `update_method:` config option in this PR allows a user to choose which approach to segment display text they want to use, and MPF will correspondingly build and manage a text stack when the config option is `"stack"`, or skip stacking and simply render text directly to the display when the config option is `"replace"`.

## Why Does it Matter?

There is a sneaky pitfall if a game is coded with the "replace" model in mind but MPF is running the "stack" model under the hood. 

Specifically, the part about _"Text can include dynamic values that will automatically update when those variables change"._ To maintain the current value of a variable, a text entry with a dynamic value creates an event listener to subscribe to that value and update on changes. However in a game coded to explicitly send text updates to the displays, each time new text is sent to the display that references a variable (e.g. a player's score), that new text creates a new event handler and is added to the stack.

On a modern performant computer and a single player game, this extra stack of text entries and event handlers isn't enough to be noticable. But think of a spinner: each spin of the spinner, a new text entry is sent to the segment display with the player score. This text entry creates an event listener for changes to the score, which doesn't matter because on the next score, a new text entry will be stacked on top of that one. Now think of a high-scoring four-player game that uses the spinner a lot. By the end of the game, the segment display may have a stack of 5,000+ text entries, each one with its own event listener.

This stack consumes memory and can slow down a game, but even worse is at the end of the game. All of the event handlers subscribe to the end of the game to cleanly dispose of themselves, and when MPF encounters a stack of _thosands_ of handlers for a single event, that can quickly bring the CPU to its breaking point.

## Compatibility and Expected Behavior

I posit that the "replace" mental model is more intuitive and more likely to be implemented by an MPF user, and therefore would make sense to be the default behavior for segment displays. However the "stack" approach has been the default (and only) MPF implementation to date. If anybody is using segment displays and successfully leveraging the stack approach, their game will break if the default is switched to the replacement approach.

Therefore the changes in this PR default the `update_method:` to be `"stack"`, with a warning that in a future version of MPF (major release only, i.e. 0.58) the default will change to `"replace"`. This allows us to flag it as a breaking change for users upgrading to that version while eventually settling in on the (presumably) more intuitive behavior as default.

## Also colors
This PR also adds a minor tweak to the FAST segment display code to track the current segment colors and only send color updates if they change. The color update payload is over 7x that of a normal text payload, and explicitly defined colors on a text update in rapid succession (once again, spinners) can cause buffer overloads. Eliminating the unnecessary color payload reduces the bandwidth requirements and alleviates the risk of malformed text on the display.

![STACKS](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWxyMXJkYnlxZmx6dndtbndhZDBpcnV4c2U4MzhkbDE3b282N3h0MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zm787Nt3WSBcQ/giphy.gif)