### PR TITLE
Ensure LED fade brightness is never negative

### DIFF
--- a/mpf/platforms/fast/fast_led.py
+++ b/mpf/platforms/fast/fast_led.py
@@ -4,9 +4,8 @@ import logging
 from typing import Optional
 from typing import List
 
-from mpf.core.utility_functions import Util
 from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface
-from mpf.platforms.fast.fast_defines import EXPANSION_BOARD_FEATURES
+
 
 class FASTRGBLED:
 
@@ -49,6 +48,7 @@ class FASTRGBLED:
 
         return result
 
+
 class FASTExpLED(FASTRGBLED):
 
     """FAST RGB LED on an expansion board."""
@@ -60,12 +60,13 @@ class FASTExpLED(FASTRGBLED):
         """Return representation of this LED."""
         return f'<FASTExpLED: {self.number}>'
 
+    # pylint: disable-msg=super-init-not-called
     def __init__(self, number: str, hardware_fade_ms: int, platform) -> None:
         """Initialize FAST LED."""
         self.number = number  # 5 char hex string, board address, breakout
         self.number_int = int(number, 16)
         self.platform = platform
-        self.address = f'{number[0:3]}' # '880'
+        self.address = f'{number[0:3]}'  # '880'
         self.exp_board = platform.exp_boards_by_address[self.address[0:2]]
         self.breakout_board = platform.exp_breakout_boards[self.address]
 
@@ -124,8 +125,12 @@ class FASTLEDChannel(LightPlatformInterface):
             self._last_brightness = brightness
             done = True
 
+        # There is a bug that can sometimes cause the start_time to be ahead of the current_time,
+        # resulting in a negative brightness value. This may be a floating-point rounding error,
+        # or maybe something else. I can't figure it out, so just floor the value to be non-negative.
         if brightness < 0:
-            self.led.log.warning("Calculated a negative brightness (%s) for led %s channel %s. current_time: %s"+\
+            brightness = 0
+            self.led.log.warning("Calculated a negative brightness (%s) for led %s channel %s. current_time: %s "
                                  "start_brightness: %s, start_time: %s, target_brightness: %s, target_time: %s",
                                  brightness, self.led, self.channel, current_time, start_brightness, start_time,
                                  target_brightness, target_time)


### PR DESCRIPTION
This PR fixes a bug where a FAST LED fade can sometimes calculate a negative brightness. The issue is caused by the fade's `start_time` being after the `current_time`.

I've done much investigation into the issue and cannot figure out the root cause, aside from a possible floating-point rounding error that causes the two calls to `self.machine.clock.get_time()` to yield slightly offset values. I found no systemic or regularly reproducible cause for the issue, so I cannot "fix" it at this time. Instead, just do a safety check to ensure the value is never negative.

Also, did some linting cleanup while the file is changed.

![don't be negative](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDk3NmoxODMwOTNicWZzMzFxNmQ1c3d0NjkwNzhzZG5vbGVjczR5cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ArK0QrSGeztvkp41Wy/giphy.gif)