### PR TITLE
Delay ball jam reordering to init phase 5

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.1.dev2'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.1.dev3'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'


### PR DESCRIPTION
This PR fixes an issue with the ball device reordering logic when a machine boots with a jam or disordered trough balls.

The previous fix had the correct logic, but happened during the ball device initialization in phase 2. Unfortunately hardware platform initializations happen in phases 3 and 4, including the enabling of watchdog timers that allow coil pulses. As a result, the logic was attempting to initiate a driver pulse to clear the jam but the hardware platform was ignoring it.

This PR moves the trough reorder logic to init phase 5, after the watchdog is enabled and the platform is ready to fire coils. Validated on a physical machine.

![wake it up](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWZ4YmphcmF2bGJmMHBhbm1xaW9xcnZpNmNjNjdzamJ5M3RwN2dzcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/pprWSYuAz5Vxm/giphy.gif)