### PR TITLE
OPP platform: add support for WING_SOL_8 wing type.

### DIFF
--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -462,6 +462,8 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform, ServoP
             if msg[2 + wing_index] == ord(OppRs232Intf.WING_SOL):
                 sol_mask |= (0x0f << (4 * wing_index))
                 inp_mask |= (0x0f << (8 * wing_index))
+            if msg[2 + wing_index] == ord(OppRs232Intf.WING_SOL_8):
+                sol_mask |= (0xff << (8 * wing_index))
             elif msg[2 + wing_index] == ord(OppRs232Intf.WING_INP):
                 inp_mask |= (0xff << (8 * wing_index))
             elif msg[2 + wing_index] == ord(OppRs232Intf.WING_INCAND):

--- a/mpf/platforms/opp/opp_rs232_intf.py
+++ b/mpf/platforms/opp/opp_rs232_intf.py
@@ -54,6 +54,7 @@ class OppRs232Intf:
     WING_SW_MATRIX_OUT_LOW_WING = b'\x0a'
     WING_LAMP_MATRIX_COL_WING = b'\x0b'
     WING_LAMP_MATRIX_ROW_WING = b'\x0c'
+    WING_SOL_8 = b'\x0d'
 
     NUM_G2_INP_PER_BRD = 32
     CFG_INP_STATE = b'\x00'


### PR DESCRIPTION
This is to support a fork of OPP being able to drive up to 32 solenoids.

https://gitlab.com/mrechte/open-pinball-project

This PR has been discussed with OPP owner: openpinballproject@gmail.com.