### PR TITLE
Clamp light brightness between 0.0 and 1.0

### DIFF
--- a/mpf/platforms/interfaces/light_platform_interface.py
+++ b/mpf/platforms/interfaces/light_platform_interface.py
@@ -111,7 +111,7 @@ class LightPlatformDirectFade(LightPlatformInterface, metaclass=abc.ABCMeta):
             else:
                 fade_ms = target_fade_ms
                 brightness = target_brightness
-            self.set_brightness_and_fade(brightness, max(fade_ms, 0))
+            self.set_brightness_and_fade(min(1.0, max(brightness, 0.0)), max(fade_ms, 0))
             if target_fade_ms <= max_fade_ms:
                 return
             await asyncio.sleep(interval)


### PR DESCRIPTION
This PR clamps the `brightness` value of a light during a fade to be between 0.0 and 1.0. 

The brightness should always be between 0 and 1, but during fades sometimes a floating-point rounding error will cause a value to be slightly above or below, which can lead to crashes and downstream errors.

I've tried to put this at the most efficient place for minimizing calculation cost while maximing the number of avenues that will benefit from the clamp.

![](https://i.imgur.com/vQXWNz6.gif)