### PR TITLE
Fast channel offset fix

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.2.dev1'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev2'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.1'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev1'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1992,6 +1992,7 @@ switches:
     type: single|enum(NC,NO)|NO
     debounce: single|enum(auto,quick,normal)|auto
     ignore_window_ms: single|ms|0
+    ignore_during_ball_search: single|bool|false
     events_when_activated: list|event_posted|None
     events_when_deactivated: list|event_posted|None
     platform: single|str|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1300,7 +1300,7 @@ player_vars:
 playfields:
     __valid_in__: machine
     __type__: device
-    enable_ball_search: single|bool|None
+    enable_ball_search: single|template_bool|None
     ball_search_timeout: single|ms|15s
     ball_search_interval: single|ms|150ms
     ball_search_phase_1_searches: single|int|3

--- a/mpf/core/ball_search.py
+++ b/mpf/core/ball_search.py
@@ -121,13 +121,16 @@ class BallSearch(MpfController):
             return
 
         del kwargs
-        if self.playfield.config['enable_ball_search'] is False or (
-            not self.playfield.config['enable_ball_search'] and
+        is_ball_search_enabled = self.playfield.config['enable_ball_search'].evaluate({}) if \
+            self.playfield.config['enable_ball_search'] else None
+        if is_ball_search_enabled is False or (
+            is_ball_search_enabled is None and
                 not self.machine.config['mpf']['default_ball_search']):
             return
 
         if not self.callbacks:
-            raise AssertionError("No callbacks registered")
+            raise AssertionError(f"Cannot run ball search on playfield '{self.playfield.name}', no callbacks "
+                                 "registered. Do you have any shots/devices defined in this playfield?")
 
         self.debug_log("Enabling Ball Search")
 

--- a/mpf/core/ball_search.py
+++ b/mpf/core/ball_search.py
@@ -255,14 +255,6 @@ class BallSearch(MpfController):
                 element = next(self.iterator)
             except StopIteration:
                 self.iteration += 1
-                self.machine.events.post('ball_search_phase_{}'.format(self.phase),
-                                         iteration=self.iteration)
-                '''event: ball_search_phase_(num)
-
-                desc: The ball search phase (num) has started.
-                args:
-                    iteration: Current iteration of phase (num)
-                '''
                 # give up at some point
                 if self.iteration > self.playfield.config[
                         'ball_search_phase_{}_searches'.format(self.phase)]:
@@ -271,6 +263,15 @@ class BallSearch(MpfController):
                     if self.phase > 3:
                         self.give_up()
                         return
+
+                self.machine.events.post('ball_search_phase_{}'.format(self.phase),
+                                         iteration=self.iteration)
+                '''event: ball_search_phase_(num)
+
+                desc: The ball search phase (num) has started.
+                args:
+                    iteration: Current iteration of phase (num)
+                '''
 
                 self.iterator = iter(self.callbacks)
                 element = next(self.iterator)

--- a/mpf/core/switch_controller.py
+++ b/mpf/core/switch_controller.py
@@ -374,7 +374,8 @@ class SwitchController(MpfController):
 
         self._cancel_timed_handlers(obj)
 
-        self._call_handlers(obj, state)
+        if not obj.is_muted:
+            self._call_handlers(obj, state)
 
         for monitor in self.monitors:
             monitor(MonitoredSwitchChange(name=obj.name, label=obj.label, platform=obj.platform,

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -169,7 +169,7 @@ class AutofireCoil(SystemWideDevice):
         if not self._enabled:
             return
         if not self._ball_search_in_progress:
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
         if self._timeout_watch_time:
             current_time = self.machine.clock.get_time()
             self._timeout_hits = [t for t in self._timeout_hits if t > current_time - self._timeout_watch_time / 1000.0]

--- a/mpf/devices/diverter.py
+++ b/mpf/devices/diverter.py
@@ -379,15 +379,15 @@ class Diverter(SystemWideDevice):
         del phase
         del iteration
         if self.active:
-            self.info_log("Temporarily deactivating diverter to search ball for %sms",
-                          self.config['ball_search_hold_time'])
+            self.debug_log("Temporarily deactivating diverter to search ball for %sms",
+                           self.config['ball_search_hold_time'])
             self._coil_deactivate()
             self.machine.delay.add(self.config['ball_search_hold_time'],
                                    self._coil_activate,
                                    'diverter_{}_ball_search'.format(self.name))
         else:
-            self.info_log("Temporarily activating diverter to search ball for %sms",
-                          self.config['ball_search_hold_time'])
+            self.debug_log("Temporarily activating diverter to search ball for %sms",
+                           self.config['ball_search_hold_time'])
             self._coil_activate()
             self.machine.delay.add(self.config['ball_search_hold_time'],
                                    self._coil_deactivate,

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -70,13 +70,13 @@ class DropTarget(SystemWideDevice):
 
     def _ignore_switch_hits_for(self, ms, reset_attempt=None):
         """Ignore switch hits for ms."""
-        self.info_log("Ignoring switch hits for %sms", ms)
+        self.debug_log("Ignoring switch hits for %sms", ms)
         self.config['switch'].mute()
         self._ignore_switch_hits = True
         self.delay.reset(name="ignore_switch", callback=self._restore_switch_hits, ms=ms, reset_attempt=reset_attempt)
 
     def _restore_switch_hits(self, reset_attempt=None):
-        self.info_log("Restoring switch hits")
+        self.debug_log("Restoring switch hits")
         self.config['switch'].unmute()
         self._ignore_switch_hits = False
         self._update_state_from_switch(reconcile=True)
@@ -92,15 +92,12 @@ class DropTarget(SystemWideDevice):
             self.debug_log("Reset confirmed!")
 
     def _ball_search_phase1(self):
-        self.info_log("Ball search phase 1: complete is %s", self.complete)
         if not self.complete and self.reset_coil:
-            self.info_log(" - not complete, firing reset coil")
             self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
             self.reset_coil.pulse()
             return True
         # if down. knock down again
         if self.complete and self.knockdown_coil:
-            self.info_log(" - complete, firing knockdown coil")
             self.knockdown_coil.pulse()
             return True
         return False
@@ -222,14 +219,13 @@ class DropTarget(SystemWideDevice):
             self.config['switch'])
 
         self.debug_log("Drop target %s switch %s has active value %s compared to drop complete %s",
-                      self.name, self.config['switch'].name, is_complete, self.complete)
+                       self.name, self.config['switch'].name, is_complete, self.complete)
         if self._in_ball_search or self._ignore_switch_hits:
             self.debug_log("Ignoring state change in drop target %s due to being in ball search "
                            "or ignoring switch hits", self.name)
             return
 
         if not reconcile:
-            self.debug_log("Hit without reconciling, marking playfield as active")
             self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
         if is_complete != self.complete:

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -99,7 +99,7 @@ class DropTarget(SystemWideDevice):
             self.reset_coil.pulse()
             return True
         # if down. knock down again
-        elif self.complete and self.knockdown_coil:
+        if self.complete and self.knockdown_coil:
             self.info_log(" - complete, firing knockdown coil")
             self.knockdown_coil.pulse()
             return True
@@ -221,16 +221,16 @@ class DropTarget(SystemWideDevice):
         is_complete = self.machine.switch_controller.is_active(
             self.config['switch'])
 
-        self.info_log("Drop target %s switch %s has active value %s compared to drop complete %s",
-                       self.name, self.config['switch'].name, is_complete, self.complete)
+        self.debug_log("Drop target %s switch %s has active value %s compared to drop complete %s",
+                      self.name, self.config['switch'].name, is_complete, self.complete)
         if self._in_ball_search or self._ignore_switch_hits:
             self.debug_log("Ignoring state change in drop target %s due to being in ball search "
                            "or ignoring switch hits", self.name)
             return
 
         if not reconcile:
-            self.info_log("Hit without reconciling, marking playfield as active")
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.debug_log("Hit without reconciling, marking playfield as active")
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
         if is_complete != self.complete:
 

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -277,8 +277,7 @@ class DropTarget(SystemWideDevice):
         device.
         Make sure we do not mark the playfield as active.
         """
-        if self.machine.switch_controller.is_active(self.config['switch']):
-            self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
+        self._update_state_from_switch(reconcile=True)
 
     def remove_from_bank(self, bank):
         """Remove the DropTarget from a bank.
@@ -440,6 +439,7 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
     def _restore_switch_hits(self, reset_attempt=None):
         for target in self.drop_targets:
             target.config['switch'].unmute()
+            target.external_reset_from_bank()
         self._ignore_switch_hits = False
         self.member_target_change()
 

--- a/mpf/devices/magnet.py
+++ b/mpf/devices/magnet.py
@@ -62,7 +62,7 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
     def grab_ball(self):
         """Grab a ball."""
         # mark the playfield active no matter what
-        self.config['playfield'].mark_playfield_active_from_device_action()
+        self.config['playfield'].mark_playfield_active_from_device_action(self.name)
         # check if magnet is enabled or already active
         if not self.enabled or self._active or self._release_in_progress:
             return

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -261,19 +261,19 @@ class Playfield(SystemWideDevice):
             incoming_ball.ball_arrived()
             break
 
-    def _mark_playfield_active(self):
+    def _mark_playfield_active(self, source=None):
         self.ball_arrived()
-        self.machine.events.post_boolean(self.name + "_active")
+        self.machine.events.post_boolean(self.name + "_active", source=source)
         '''event: (name)_active
         desc: The playfield called (name) is now active, meaning there's
         at least one loose ball on it.
         '''
 
-    def mark_playfield_active_from_device_action(self):
+    def mark_playfield_active_from_device_action(self, device_name=None):
         """Mark playfield active because a device on the playfield detected activity."""
-        self._playfield_switch_hit()
+        self._playfield_switch_hit(source=device_name)
 
-    def _playfield_switch_hit(self, **kwargs):
+    def _playfield_switch_hit(self, source=None, **kwargs):
         """Playfield switch was hit.
 
         A switch tagged with '<this playfield name>_active' was just hit,
@@ -281,7 +281,7 @@ class Playfield(SystemWideDevice):
 
         """
         if self.balls <= 0 or (kwargs.get('balls') and self.balls - kwargs['balls'] < 0):
-            self._mark_playfield_active()
+            self._mark_playfield_active(source)
 
             if not self.num_balls_requested:
                 self.debug_log("Playfield was activated with no balls expected.")

--- a/mpf/devices/sequence_shot.py
+++ b/mpf/devices/sequence_shot.py
@@ -102,7 +102,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
 
         # mark playfield active
         if self.config['playfield']:
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
         self.debug_log("Sequence advance: %s", event_name)
 

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -55,7 +55,7 @@ class Shot(EnableDisableMixin, ModeDevice):
         """Mark playfield active."""
         del kwargs
         if self.config['mark_playfield_active']:
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
     def device_loaded_in_mode(self, mode: Mode, player: Player):
         """Add device to a mode that was already started.

--- a/mpf/devices/switch.py
+++ b/mpf/devices/switch.py
@@ -264,4 +264,5 @@ class Switch(SystemWideDevice, DevicePositionMixin):
 
     @property
     def is_muted(self):
+        """True if this switch is currently muted."""
         return self._mutes > 0

--- a/mpf/devices/switch.py
+++ b/mpf/devices/switch.py
@@ -27,7 +27,7 @@ class Switch(SystemWideDevice, DevicePositionMixin):
     class_label = 'switch'
 
     __slots__ = ["hw_switch", "state", "hw_state", "invert", "recycle_secs", "recycle_clear_time",
-                 "recycle_jitter_count", "_events_to_post", "last_change", "is_muted"]
+                 "recycle_jitter_count",  "last_change", "_events_to_post", "_mutes"]
 
     def __init__(self, machine: MachineController, name: str) -> None:
         """Initialize switch."""
@@ -44,7 +44,7 @@ class Switch(SystemWideDevice, DevicePositionMixin):
         not consider whether a switch is NC or NO."""
 
         self.invert = 0
-        self.is_muted = False
+        self._mutes = 0
 
         self.recycle_secs = 0
         self.recycle_clear_time = None
@@ -254,9 +254,14 @@ class Switch(SystemWideDevice, DevicePositionMixin):
     def mute(self, **kwargs):
         """Mute this switch so that switch hits do not trigger handlers."""
         del kwargs
-        self.is_muted = True
+        self._mutes += 1
 
     def unmute(self, **kwargs):
         """Unmute this switch so that hits again trigger handlers."""
         del kwargs
-        self.is_muted = False
+        self._mutes -= 1
+        assert self._mutes >= 0, "Switch %s has unmuted more times than muted." % self.name
+
+    @property
+    def is_muted(self):
+        return self._mutes > 0

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -676,13 +676,14 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                 if 0 <= channel <= 2:
                     result = []
                     for i in range(3):
+                        working_parts = parts.copy()
                         if i + channel > 2:
                             # Channel rolls over, increment the LED number
-                            parts[3] = str(int(parts[3]) + 1)
-                            parts[4] = '0'
+                            working_parts[3] = str(int(parts[3]) + 1)
+                            working_parts[4] = str(channel + i - 3)
                         else:
-                            parts[4] = str(channel + i)
-                        result.append({'number': '-'.join(parts)})
+                            working_parts[4] = str(channel + i)
+                        result.append({'number': '-'.join(working_parts)})
                     return result
                 raise AssertionError(f"Invalid LED channel: {channel}")
             raise AssertionError(f"Invalid LED number: {number}")


### PR DESCRIPTION
In FAST.py:679 there is an issue if you use channel offset declaration on your light number property, such as exp_playfield-2-6-2.

Normally you'd just declare 2-6 which is implicitly 2-6-0, and consumes 2-6-1 and 2-6-2 as well. When you declare 2-6-1, you would get 261, 262, and 270 -- only one of the three channels rolled over to the next full light number.

But if you use 2-6-2 you currently get 262, 270, and 280. This is because the loop is reusing the same parts array on every iteration instead of a copy, and the rollover code modifies that initial array. It also explicitly codes 0 as the final part instead of channel+i-3.

This should generate the correct sequence, but probably still needs touching up and could use an automated test as well.