### PR TITLE
FAST light config has a bug when using channels

### DIFF
--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -676,13 +676,14 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                 if 0 <= channel <= 2:
                     result = []
                     for i in range(3):
+                        working_parts = parts.copy()
                         if i + channel > 2:
                             # Channel rolls over, increment the LED number
-                            parts[3] = str(int(parts[3]) + 1)
-                            parts[4] = '0'
+                            working_parts[3] = str(int(working_parts[3]) + 1)
+                            working_parts[4] = str((channel + i) % 3)
                         else:
-                            parts[4] = str(channel + i)
-                        result.append({'number': '-'.join(parts)})
+                            working_parts[4] = str(channel + i)
+                        result.append({'number': '-'.join(working_parts)})
                     return result
                 raise AssertionError(f"Invalid LED channel: {channel}")
             raise AssertionError(f"Invalid LED number: {number}")

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -63,11 +63,11 @@ lights:
   led3:
     number: brian-1-3
   led4:
-    number: brian-b1-2-1
+    number: brian-b1-2-1-0
   led5:
-    number: brian-b1-2-2
+    number: brian-b1-2-2-1
   led6:
-    number: aaron-b2-1-1
+    number: aaron-b2-1-1-2
   led7:
     number: aaron-1-1
   led8:

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -89,6 +89,12 @@ class TestFastExp(TestFastBase):
         self.assertEqual(self.led5.hw_drivers['green'][0].number, '88121-2')
         self.assertEqual(self.led5.hw_drivers['blue'][0].number, '88122-0')
 
+        # Intentionally-failing test to prove that third channel rollover has an issue
+        self.assertEqual(self.led6.hw_drivers['red'][0].number, '89200-2')
+        self.assertEqual(self.led6.hw_drivers['green'][0].number, '89201-0')
+        # Bug is generating as 202-0 instead of 201-1
+        self.assertEqual(self.led6.hw_drivers['blue'][0].number, '89201-1')
+
 
         # Make sure all the RGBW, channels, previous, and start_channels are working
         self.assertEqual(self.led22.hw_drivers['red'][0].number, '48002-0')

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -80,6 +80,16 @@ class TestFastExp(TestFastBase):
         self.assertIn("88121", self.fast_exp_leds)
         self.assertIn("89200", self.fast_exp_leds)
 
+        # Make sure explicit offset declarations work
+        self.assertEqual(self.led4.hw_drivers['red'][0].number, '88120-0')
+        self.assertEqual(self.led4.hw_drivers['green'][0].number, '88120-1')
+        self.assertEqual(self.led4.hw_drivers['blue'][0].number, '88120-2')
+
+        self.assertEqual(self.led5.hw_drivers['red'][0].number, '88121-1')
+        self.assertEqual(self.led5.hw_drivers['green'][0].number, '88121-2')
+        self.assertEqual(self.led5.hw_drivers['blue'][0].number, '88122-0')
+
+
         # Make sure all the RGBW, channels, previous, and start_channels are working
         self.assertEqual(self.led22.hw_drivers['red'][0].number, '48002-0')
         self.assertEqual(self.led22.hw_drivers['green'][0].number, '48002-1')

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -84,15 +84,11 @@ class TestFastExp(TestFastBase):
         self.assertEqual(self.led4.hw_drivers['red'][0].number, '88120-0')
         self.assertEqual(self.led4.hw_drivers['green'][0].number, '88120-1')
         self.assertEqual(self.led4.hw_drivers['blue'][0].number, '88120-2')
-
         self.assertEqual(self.led5.hw_drivers['red'][0].number, '88121-1')
         self.assertEqual(self.led5.hw_drivers['green'][0].number, '88121-2')
         self.assertEqual(self.led5.hw_drivers['blue'][0].number, '88122-0')
-
-        # Intentionally-failing test to prove that third channel rollover has an issue
         self.assertEqual(self.led6.hw_drivers['red'][0].number, '89200-2')
         self.assertEqual(self.led6.hw_drivers['green'][0].number, '89201-0')
-        # Bug is generating as 202-0 instead of 201-1
         self.assertEqual(self.led6.hw_drivers['blue'][0].number, '89201-1')
 
 


### PR DESCRIPTION
In FAST.py:679 there is an issue if you use channel offset declaration on your light number property, such as exp_playfield-2-6-2.

Normally you'd just declare 2-6 which is implicitly 2-6-0, and consumes 2-6-1 and 2-6-2 as well. When you declare 2-6-1, you would get 261, 262, and 270 -- only one of the three channels rolled over to the next full light number.

But if you use 2-6-2 you currently get 262, 270, and 280. This is because the loop is reusing the same parts array on every iteration instead of a copy, and the rollover code modifies that initial array. It also explicitly codes 0 as the final part instead of channel+i-3.

This should generate the correct sequence, but probably still needs touching up and could use an automated test as well.
