### PR TITLE
Fix fast exp hex decode

### DIFF
--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -512,6 +512,7 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
 
         return switch
 
+    # pylint: disable-msg=too-many-locals
     def configure_light(self, number, subtype, config, platform_settings) -> LightPlatformInterface:
         """Configure light in platform."""
         del platform_settings
@@ -567,7 +568,10 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
 
             elif int(parts[0]) > 255:
                 # EXP LED in int form, which is how "previous:" values are calculated
-                this_led_number = hex(int(parts[0]))[2:]
+
+                raw_hex_string = hex(int(parts[0]))[2:]  # lowercase with 0x prefix stripped"
+                this_led_number = Util.normalize_hex_string(raw_hex_string, len(raw_hex_string))
+
                 exp_board = self.exp_boards_by_address[this_led_number[:2]]
 
                 if this_led_number not in self.fast_exp_leds:

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -120,7 +120,7 @@ lights:
     start_channel: brian-b2-2-3-0  #88222-0, 88222-1, 88222-2, 88223-0
     type: rgbw
   led29:
-    channels:  # testing out of order, non-contiquous channels
+    channels:  # testing out of order, non-contiguous channels
       red:
         number: neuron-1-10-0  # 48009-0
       green:
@@ -129,6 +129,13 @@ lights:
         number: neuron-1-10-1  # 48009-1
       white:
         number: neuron-1-11-2  # 4800A-2
+
+  led30:
+    number: dave-4-12
+    type: rgb
+  led31:
+    previous: led30
+    type: rgb
 
 servos:
     servo1:

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -122,6 +122,13 @@ class TestFastExp(TestFastBase):
         self.assertEqual(self.led29.hw_drivers['green'][0].number, '48009-2')
         self.assertEqual(self.led29.hw_drivers['blue'][0].number, '48009-1')
         self.assertEqual(self.led29.hw_drivers['white'][0].number, '4800A-2')
+        self.assertEqual(self.led30.hw_drivers['red'][0].number, 'B406B-0')
+        self.assertEqual(self.led30.hw_drivers['green'][0].number, 'B406B-1')
+        self.assertEqual(self.led30.hw_drivers['blue'][0].number, 'B406B-2')
+        self.assertEqual(self.led31.hw_drivers['red'][0].number, 'B406C-0')
+        self.assertEqual(self.led31.hw_drivers['green'][0].number, 'B406C-1')
+        self.assertEqual(self.led31.hw_drivers['blue'][0].number, 'B406C-2')
+
 
     def _test_led_colors(self):
 


### PR DESCRIPTION
I branched this off the last green 0.80.x, so it should be all green still

-first commit adds a failing test (not even any assertions -- just defining a FAST EXP LED using "previous" is enough to trigger lower-case-hex behavior if it's on a board with id such as "B4".
-second commit adds hex normalization and passes tests again. Not sure if I picked the best hex massaging function from Util, but it was better than just .upcase() in the callsite :)