### PR TITLE
Service Mode Refactor for 0.80

### DIFF
--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -472,7 +472,7 @@ class BcpInterface(MpfController):
             self.machine.machine_var_monitor = False
 
     def _send_machine_settings(self, client, setting_type=None):
-        settings = [setting_type] if setting_type else ["standard", "feature", "game", "coin"]
+        settings = [setting_type] if setting_type else ["standard", "feature", "game", "coin", "hw_volume"]
         for s in settings:
             self.machine.bcp.transport.send_to_client(
                 client, bcp_command='settings',

--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -101,10 +101,10 @@ class BcpInterface(MpfController):
         if not self.machine.bcp.transport.get_transports_for_handler(event):
             self.machine.events.remove_handler_by_event(event=event, handler=self.bcp_trigger)
 
-    async def _bcp_receive_set_machine_var(self, client, name, value):
+    async def _bcp_receive_set_machine_var(self, client, name, value, persist=False):
         """Set machine var via bcp."""
         del client
-        self.machine.variables.set_machine_var(name, value)
+        self.machine.variables.set_machine_var(name, value, persist)
         # document variables injected by MC
         '''machine_var: mc_version
 

--- a/mpf/core/config_processor.py
+++ b/mpf/core/config_processor.py
@@ -152,12 +152,12 @@ class ConfigProcessor:
 
         deprecated_080 = ["sound_pools"]
         invalid_080 = ["playlists", "playlist_player", "slides", "sounds", "sound_loop_player",
-                          "sound_loop_sets", "sound_system", "track_player", "widgets"]
+                       "sound_loop_sets", "sound_system", "track_player", "widgets"]
         for k in config.keys():
             if k in config_spec:
                 if k in deprecated_080:
-                    self.log.warning("Config section '%s' is deprecated in MPF 0.80 and will be unsupported in future versions. "
-                                     "Please migrate this config to GMC.", k)
+                    self.log.warning("Config section '%s' is deprecated in MPF 0.80 and will be unsupported "
+                                     "in future versions. Please migrate this config to GMC.", k)
                 if config_type not in config_spec[k]['__valid_in__']:
                     raise ConfigFileError('Found a "{}:" section in config file {}, '
                                           'but that section is not valid in {} config '

--- a/mpf/core/config_validator.py
+++ b/mpf/core/config_validator.py
@@ -356,7 +356,7 @@ class ConfigValidator:
         # The inclusion of sound_pools causes a nested ducking subconfig that
         # fails due to missing required properties. Check for an empty dict
         # as subconfig and ignore it.
-        if item is None or (item is Dict and not len(item)):
+        if item is None or (item is Dict and len(item) == 0):
             return {}
         try:
             attribute, base_spec_str = param.split(",", 1)

--- a/mpf/core/crash_reporter.py
+++ b/mpf/core/crash_reporter.py
@@ -176,7 +176,7 @@ def analyze_traceback(tb, inspection_level=None, limit=None):
 
 
 def _send_crash_report(report, reporting_url):
-    r = requests.post(reporting_url, json=report)
+    r = requests.post(reporting_url, json=report, timeout=60)
     if r.status_code != 200:
         print("Failed to send report. Got response code {}. Error: {}", r.status_code, r.content)
     else:

--- a/mpf/core/machine_vars.py
+++ b/mpf/core/machine_vars.py
@@ -182,6 +182,9 @@ class MachineVariables(LogMixin):
         ----
             name: String name of the variable you're setting the value for.
             value: The value you're setting. This can be any Type.
+            persist: Whether to persist this machine var to disk. Only
+                applies to new/unconfigured vars; vars defined in the
+                machine_vars config will use their config setting.
         """
         if name not in self.machine_vars:
             self.configure_machine_var(name=name, persist=persist)

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -84,7 +84,9 @@ sort_devices_by_number: single|bool|True
                 ["s_flipper_right_inactive"]
             ): "PAGE_RIGHT",
             self.machine.events.wait_for_any_event(
-                ["s_credit_active"]
+                # Use the INACTIVE event to prevent attract from starting a game
+                # (which it does on inactive)
+                ["sw_start_inactive"]
             ): "START",
             self.machine.events.wait_for_any_event(
                 ["service_trigger"]

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -1,6 +1,6 @@
 """Service mode for MPF."""
-import subprocess
-import os
+# import subprocess
+# import os
 from collections import namedtuple
 
 from typing import List

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -2,7 +2,6 @@
 import subprocess
 import os
 from collections import namedtuple
-from functools import partial
 
 from typing import List
 
@@ -29,8 +28,6 @@ class Service(AsyncMode):
         self._trigger = None
         self._is_displayed = False
 
-
-
     def mode_start(self, **kwargs):
         """Create an event handler for the "reset" event triggered via keypress."""
         del kwargs
@@ -38,7 +35,6 @@ class Service(AsyncMode):
 
         # Map MC-triggered events to methods in the parent class
         self.add_mode_event_handler("service_trigger", self._on_service_trigger)
-
 
     @staticmethod
     def get_config_spec():
@@ -161,7 +157,6 @@ sort_devices_by_number: single|bool|True
             key = await self._get_key()
             if key:
                 self.machine.events.post("service_button", button=key)
-
 
     # # Utilities
     # def _load_utilities_menu_entries(self) -> List[ServiceMenuEntry]:

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -155,25 +155,6 @@ sort_devices_by_number: single|bool|True
 
         await self._service_mode_exit()
 
-    # def _update_main_menu(self, items: List[ServiceMenuEntry], position: int):
-    #     self.machine.events.post("service_menu_deselected")
-    #     self.machine.events.post("service_menu_show")
-    #     self.machine.events.post("service_menu_selected", label=items[position].label)
-
-    # def _load_menu_entries(self) -> List[ServiceMenuEntry]:
-    #     """Return the menu items with label and callback."""
-    #     # If you want to add menu entries overload the mode and this method.
-    #     entries = [
-    #         ServiceMenuEntry("Diagnostics Menu", self._diagnostics_menu),
-    #         ServiceMenuEntry("Audits Menu", self._audits_menu),
-    #         ServiceMenuEntry("Adjustments Menu", self._adjustments_menu),
-    #         ServiceMenuEntry("Utilities Menu", self._utilities_menu),
-    #         ServiceMenuEntry("Audio Menu", self._audio_menu)
-
-    #     ]
-    #     return entries
-
-
     async def _service_mode_main_menu(self):
         self._is_displayed = True
         while self._is_displayed:
@@ -181,81 +162,6 @@ sort_devices_by_number: single|bool|True
             if key:
                 self.machine.events.post("service_button", button=key)
 
-
-    # # Diagnostics
-    # def _load_diagnostic_menu_entries(self) -> List[ServiceMenuEntry]:
-    #     """Return the diagnostics menu items with label and callback."""
-    #     return [
-    #         ServiceMenuEntry("Switch Menu", self._diagnostics_switch_menu),
-    #         ServiceMenuEntry("Coil Menu", self._diagnostics_coil_menu),
-    #         ServiceMenuEntry("Light Menu", self._diagnostics_light_menu),
-    #     ]
-
-    # async def _diagnostics_menu(self):
-    #     await self._make_menu(self._load_diagnostic_menu_entries())
-
-    # def _load_diagnostic_switch_menu_entries(self) -> List[ServiceMenuEntry]:
-    #     """Return the switch menu items with label and callback."""
-    #     return [
-    #         ServiceMenuEntry("Switch Edge Test", self._switch_test_menu),
-    #     ]
-
-    # async def _diagnostics_switch_menu(self):
-    #     await self._make_menu(self._load_diagnostic_switch_menu_entries())
-
-    # def _load_diagnostic_coil_menu_entries(self) -> List[ServiceMenuEntry]:
-    #     """Return the coil menu items with label and callback."""
-    #     return [
-    #         ServiceMenuEntry("Single Coil Test", self._coil_test_menu),
-    #     ]
-
-    # async def _diagnostics_coil_menu(self):
-    #     await self._make_menu(self._load_diagnostic_coil_menu_entries())
-
-    # def _load_diagnostic_light_menu_entries(self) -> List[ServiceMenuEntry]:
-    #     """Return the light menu items with label and callback."""
-    #     return [
-    #         ServiceMenuEntry("Single Light Test", self._light_test_menu),
-    #         ServiceMenuEntry("Light Chain Test", self._light_chain_menu)
-    #     ]
-
-    # async def _diagnostics_light_menu(self):
-    #     await self._make_menu(self._load_diagnostic_light_menu_entries())
-
-    # # Adjustments
-    # def _load_adjustments_menu_entries(self) -> List[ServiceMenuEntry]:
-    #     """Return the adjustments menu items with label and callback."""
-    #     return [
-    #         ServiceMenuEntry("Standard Adjustments", partial(self._settings_menu, "standard")),
-    #         ServiceMenuEntry("Feature Adjustments", partial(self._settings_menu, "feature")),
-    #         ServiceMenuEntry("Game Adjustments", partial(self._settings_menu, "game")),
-    #         ServiceMenuEntry("Coin Adjustments", partial(self._settings_menu, "coin")),
-    #     ]
-
-    # async def _adjustments_menu(self):
-    #     await self._make_menu(self._load_adjustments_menu_entries())
-
-    # Audio
-    # def _load_audio_menu_entries(self) -> List[ServiceMenuEntry]:
-    #     """Return the audio menu items with label and callback."""
-    #     items = [
-    #         ServiceMenuEntry("Software Levels", self._volume_menu)
-    #     ]
-
-    #     self.debug_log("Looking for platform volumes: %s", self.machine.hardware_platforms)
-    #     for p, platform in self.machine.hardware_platforms.items():
-    #         # TODO: Define an AudioInterface base class
-    #         if getattr(platform, "audio_interface", None):
-    #             self.debug_log("Found '%s' platform audio for volume: %s", p, platform)
-    #             # TODO: find a good way to get a name of a platform
-    #             name = p.title()
-    #             items.append(ServiceMenuEntry(f"{name} Levels", partial(self._volume_menu, platform)))
-    #         else:
-    #             self.debug_log("Platform '%s' has no audio to configure volume: %s", p, platform)
-    #     return items
-
-    # async def _audio_menu(self):
-    #     await self._make_menu(self._load_audio_menu_entries())
 
     # # Utilities
     # def _load_utilities_menu_entries(self) -> List[ServiceMenuEntry]:
@@ -291,30 +197,6 @@ sort_devices_by_number: single|bool|True
     #         ServiceMenuEntry("Reset Credits", self._utilities_reset_credits),
     #         ServiceMenuEntry("Reset to Factory Settings", self._utilities_reset_to_factory_settings),
     #     ]
-
-    # async def _make_option_slide(self, title, question, options, warning):
-    #     """Show service_options_slide, provide options and return the selected option."""
-    #     position = 0
-
-    #     while True:
-    #         self.machine.events.post("service_options_slide_start", title=title, question=question,
-    #                                  option=options[position], warning=warning)
-    #         key = await self._get_key()
-    #         if key == 'ESC':
-    #             self.machine.events.post("service_options_slide_stop")
-    #             return None
-    #         if key == 'UP':
-    #             position += 1
-    #             if position >= len(options):
-    #                 position = 0
-    #         elif key == 'DOWN':
-    #             position -= 1
-    #             if position < 0:
-    #                 position = len(options) - 1
-    #         elif key == 'ENTER':
-    #             # select and return option
-    #             self.machine.events.post("service_options_slide_stop")
-    #             return options[position]
 
     # async def _utilities_reset_menu(self):
     #     await self._make_menu(self._load_utilities_reset_menu_entries())
@@ -371,34 +253,6 @@ sort_devices_by_number: single|bool|True
 
     # def _update_software_update_slide(self, run_update):
     #     self.machine.events.post("service_software_update_choice", run_update="Yes" if run_update else "No")
-
-    # async def _make_menu(self, items):
-    #     """Show a menu by controlling slides via events and executing callbacks."""
-    #     if not items:
-    #         # do not crash on empty menu
-    #         return
-    #     position = 0
-    #     self._update_main_menu(items, position)
-
-    #     while True:
-    #         key = await self._get_key()
-    #         if key == 'ESC':
-    #             return
-    #         if key == 'UP':
-    #             position += 1
-    #             if position >= len(items):
-    #                 position = 0
-    #             self._update_main_menu(items, position)
-    #         elif key == 'DOWN':
-    #             position -= 1
-    #             if position < 0:
-    #                 position = len(items) - 1
-    #             self._update_main_menu(items, position)
-    #         elif key == 'ENTER':
-    #             # call submenu
-    #             self.machine.events.post("service_menu_deselected")
-    #             await items[position].callback()
-    #             self._update_main_menu(items, position)
 
     def _switch_monitor(self, change: MonitoredSwitchChange):
         if change.state:

--- a/mpf/modes/service/config/service.yaml
+++ b/mpf/modes/service/config/service.yaml
@@ -25,3 +25,6 @@ event_player:
         - service_power_off
     sw_power_on_active:
         - service_power_on
+
+slide_player:
+    service_mode_entered: service

--- a/mpf/modes/service/config/service.yaml
+++ b/mpf/modes/service/config/service.yaml
@@ -28,3 +28,6 @@ event_player:
 
 slide_player:
     service_mode_entered: service
+    service_mode_exited:
+        service:
+            action: remove

--- a/mpf/platforms/fast/fast_audio.py
+++ b/mpf/platforms/fast/fast_audio.py
@@ -4,7 +4,6 @@ from math import ceil
 from mpf.core.logging import LogMixin
 from mpf.core.settings_controller import SettingEntry
 
-DEFAULT_VOLUME_VALUE = 0.3
 VARIABLE_NAME = "fast_audio_%s_volume"
 SETTING_TYPE = "hw_volume"
 
@@ -40,17 +39,31 @@ class FASTAudioInterface(LogMixin):
         self._register_event_handlers()
 
     def _configure_machine_vars(self):
-        for amp_name, settings in self.amps.items():
-            var_name = VARIABLE_NAME % amp_name
+        # See if main volume has been defined yet, otherwise use default
+        main_volume = self.machine.variables.get_machine_var('fast_audio_main_volume')
+        if main_volume is None:
+            main_volume = self.communicator.config[f'default_main_volume']
 
-            if amp_name != 'main' and self.communicator.config[f'link_{amp_name}_to_main']:
-                var_name = VARIABLE_NAME % "main"
+        for amp_name, settings in self.amps.items():
+
+            default_value = self.communicator.config[f'default_{amp_name}_volume']
+            if self.communicator.config.get(f'link_{amp_name}_to_main', False):
+                machine_var_name = VARIABLE_NAME % "main"
+            else:
+                machine_var_name = VARIABLE_NAME % amp_name
+
+                # Create a machine variable if one doesn't exist
+                if not self.machine.variables.is_machine_var(machine_var_name):
+                    self.machine.variables.set_machine_var(machine_var_name, default_value, self.communicator.config['persist_volume_settings'])
+
+            # Identify the machine var for this amp
+            settings["machine_var"] = machine_var_name
             self.machine.settings.add_setting(SettingEntry(
                 settings['name'],
                 settings['label'],
                 settings['sort'],
-                var_name,
-                DEFAULT_VOLUME_VALUE,
+                machine_var_name,
+                default_value,
                 None,
                 SETTING_TYPE
             ))
@@ -60,7 +73,6 @@ class FASTAudioInterface(LogMixin):
             amp['steps'] = self.communicator.config[f'{amp_name}_steps']
             amp['max_volume'] = self.communicator.config[f'max_hw_volume_{amp_name}']
             amp['levels_list'] = self.communicator.config[f'{amp_name}_levels_list']
-            amp['link_to_main'] = self.communicator.config[f'link_{amp_name}_to_main']
 
             # Just set everything here. The communicator will send the
             # config as part of its init process later
@@ -73,7 +85,7 @@ class FASTAudioInterface(LogMixin):
                 # if we have a levels list in the config, make sure the steps num is right
                 amp['steps'] = len(amp['levels_list']) - 1
 
-            if amp['link_to_main'] and len(amp['levels_list']) != len(self.amps['main']['levels_list']):
+            if self.communicator.config[f'link_{amp_name}_to_main'] and len(amp['levels_list']) != len(self.amps['main']['levels_list']):
                 raise AssertionError(f"Cannot link {amp_name} to main. The number of volume steps must be the same. "
                                      f"Main has {len(self.amps['main']['levels_list'])} steps, "
                                      f"but {amp_name} has {len(amp['levels_list'])} steps.")
@@ -137,7 +149,6 @@ class FASTAudioInterface(LogMixin):
             for each_amp_name in self.amps:
                 self.send_volume_to_hw(each_amp_name, send_now)
             return
-
         self.communicator.set_volume(amp_name, self.get_volume(amp_name), send_now)
 
     def _set_volume(self, amp_name, value=0, **kwargs):
@@ -157,19 +168,13 @@ class FASTAudioInterface(LogMixin):
         #self.platform.debug_log("Writing FAST amp volume %s to %s (decimal)", amp_name, value)
         self.send_volume_to_hw(amp_name)
 
-        if amp_name == 'main':
-            for other_amp_name, other_amp in self.amps.items():
-                if other_amp_name != amp_name and other_amp['link_to_main']:
-                    # Update the machine var, which will be caught and handled
-                    self._set_machine_var_volume(other_amp_name, value)
-
     def get_volume(self, amp_name, **kwargs):
         """Return the current volume of the specified amp."""
         del kwargs
-        return self.machine.variables.get_machine_var(f'fast_audio_{amp_name}_volume')
+        return self.machine.variables.get_machine_var(self.amps[amp_name]["machine_var"]) or 0
 
     def _set_machine_var_volume(self, amp_name, value):
-        self.machine.variables.set_machine_var(f'fast_audio_{amp_name}_volume', value)
+        self.machine.variables.set_machine_var(self.amps[amp_name]["machine_var"], value)
 
     def temp_volume(self, amp_name, change=1, **kwargs):
         """Temporarily change the volume by the specified number of units, up or down.

--- a/mpf/platforms/fast/fast_audio.py
+++ b/mpf/platforms/fast/fast_audio.py
@@ -42,7 +42,7 @@ class FASTAudioInterface(LogMixin):
         # See if main volume has been defined yet, otherwise use default
         main_volume = self.machine.variables.get_machine_var('fast_audio_main_volume')
         if main_volume is None:
-            main_volume = self.communicator.config[f'default_main_volume']
+            main_volume = self.communicator.config['default_main_volume']
 
         for amp_name, settings in self.amps.items():
 
@@ -54,7 +54,8 @@ class FASTAudioInterface(LogMixin):
 
                 # Create a machine variable if one doesn't exist
                 if not self.machine.variables.is_machine_var(machine_var_name):
-                    self.machine.variables.set_machine_var(machine_var_name, default_value, self.communicator.config['persist_volume_settings'])
+                    self.machine.variables.set_machine_var(machine_var_name, default_value,
+                                                           self.communicator.config['persist_volume_settings'])
 
             # Identify the machine var for this amp
             settings["machine_var"] = machine_var_name
@@ -85,7 +86,8 @@ class FASTAudioInterface(LogMixin):
                 # if we have a levels list in the config, make sure the steps num is right
                 amp['steps'] = len(amp['levels_list']) - 1
 
-            if self.communicator.config[f'link_{amp_name}_to_main'] and len(amp['levels_list']) != len(self.amps['main']['levels_list']):
+            if self.communicator.config[f'link_{amp_name}_to_main'] and \
+                    len(amp['levels_list']) != len(self.amps['main']['levels_list']):
                 raise AssertionError(f"Cannot link {amp_name} to main. The number of volume steps must be the same. "
                                      f"Main has {len(self.amps['main']['levels_list'])} steps, "
                                      f"but {amp_name} has {len(amp['levels_list'])} steps.")

--- a/mpf/tests/machine_files/fast/config/audio.yaml
+++ b/mpf/tests/machine_files/fast/config/audio.yaml
@@ -22,6 +22,14 @@ fast:
     power_pulse_time: 98
     reset_pulse_time: 97
 
+machine_vars:
+  fast_audio_sub_volume:
+    initial_value: 9
+  fast_audio_main_volume:
+    initial_value: 8
+  fast_audio_headphones_volume:
+    initial_value: 10
+
 variable_player:
   increase_main_volume:
     fast_audio_main_volume:

--- a/mpf/tests/machine_files/fast/config/audio2.yaml
+++ b/mpf/tests/machine_files/fast/config/audio2.yaml
@@ -27,6 +27,7 @@ fast:
       - 14
       - 15
     headphones_level: line
+    link_sub_to_main: true
 
 machine_vars:
   fast_audio_main_volume:

--- a/mpf/tests/test_Fast_Audio.py
+++ b/mpf/tests/test_Fast_Audio.py
@@ -25,10 +25,15 @@ class TestFastAudio(TestFastBase):
             self.serial_connections['aud'].autorespond_commands['WD:3E8'] = 'WD:3E8,03'
 
         else:
-            self.serial_connections['aud'].expected_commands = {'AM:0B':'AM:0B',
-                                                                'AV:08':'AV:08',
-                                                                'AS:09':'AS:09',
-                                                                'AH:0A':'AH:0A',}
+            self.serial_connections['aud'].expected_commands = {
+                # 'AV:00':'AV:00',
+                # 'AS:00':'AS:00',
+                # 'AH:00':'AH:00',
+                'AM:0B':'AM:0B',
+                'AV:08':'AV:08',
+                'AS:09':'AS:09',
+                'AH:0A':'AH:0A',
+            }
 
     def test_audio_basics(self):
 
@@ -68,10 +73,6 @@ class TestFastAudio(TestFastBase):
         self.assertTrue(fast_audio.communicator.amps['main']['enabled'])
         self.assertTrue(fast_audio.communicator.amps['sub']['enabled'])
         self.assertTrue(fast_audio.communicator.amps['headphones']['enabled'])
-
-        self.assertFalse(fast_audio.amps['main']['link_to_main'])
-        self.assertFalse(fast_audio.amps['sub']['link_to_main'])
-        self.assertFalse(fast_audio.amps['headphones']['link_to_main'])
 
         # Change the volume var and make sure it's reflected in the hardware
         self.aud_cpu.expected_commands['AV:0D'] = 'AV:0D'
@@ -113,9 +114,13 @@ class TestFastAudio(TestFastBase):
     @test_config('audio2.yaml')
     def test_machine_var_loading(self):
         fast_audio = self.machine.default_platform.audio_interface
+        self.advance_time_and_run()
         self.assertEqual(15, self.machine.variables.get_machine_var('fast_audio_main_volume'))
+        self.assertEqual(15, fast_audio.get_volume('main'))
         self.assertEqual(15, fast_audio.communicator.amps['main']['volume'])
+        # sub has a machine value set in the configs, which is persisted
+        self.assertEqual(2, self.machine.variables.get_machine_var('fast_audio_sub_volume'))
         # sub is linked to main, so it will be 15 even though the config value is 2
-        self.assertEqual(15, self.machine.variables.get_machine_var('fast_audio_sub_volume'))
+        self.assertEqual(15, fast_audio.get_volume('main'))
         self.assertEqual(15, fast_audio.communicator.amps['sub']['volume'])
         self.assertEqual(17, self.machine.variables.get_machine_var('fast_audio_headphones_volume'))

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -295,27 +295,15 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.assertMachineVarEqual(0, "credit_units")
 
     def test_switch_test(self):
-        self.mock_event("service_menu_selected")
+        self.mock_event("service_main_menu")
         # enter menu
         self.hit_and_release_switch("s_service_enter")
         self.advance_time_and_run()
 
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
-
-        # enter diagnostics menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Switch Menu')
-
-        # enter switch menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Switch Edge Test')
+        self.assertEventCalled("service_main_menu")
 
         # start edge test
-        self.hit_and_release_switch("s_service_enter")
+        self.machine.events.post("service_trigger", action="switch_test")
         self.advance_time_and_run()
 
         self.mock_event("service_switch_test_start")
@@ -331,42 +319,18 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.assertEventCalled("service_switch_test_stop")
 
     def test_light_test(self):
-        self.mock_event("service_menu_selected")
+        self.mock_event("service_main_menu")
         # enter menu
         self.hit_and_release_switch("s_service_enter")
         self.advance_time_and_run()
 
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
+        self.assertEventCalled("service_main_menu")
 
-        # enter diagnostics menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Switch Menu')
-
-        # select coil menu
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Coil Menu')
-
-        # select light menu
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Light Menu')
-
-        # enter light menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Single Light Test')
-
+        # enter light_test
         self.mock_event("service_light_test_start")
         self.mock_event("service_light_test_stop")
 
-        # enter single light test
-        self.hit_and_release_switch("s_service_enter")
+        self.machine.events.post("service_trigger", action="light_test")
         self.advance_time_and_run()
 
         for color in ["white", "red", "green", "blue", "yellow", "white"]:
@@ -414,45 +378,28 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.assertEventCalled("service_light_test_stop")
 
     def test_coil_test(self):
-        self.mock_event("service_menu_selected")
+        self.mock_event("service_main_menu")
         self.mock_event("service_coil_test_start")
         self.mock_event("service_coil_test_stop")
         # enter menu
         self.hit_and_release_switch("s_service_enter")
         self.advance_time_and_run()
 
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
+        self.assertEventCalled("service_main_menu")
 
-        # enter diagnostics menu
-        self.hit_and_release_switch("s_service_enter")
+        # enter coil test
+        self.machine.events.post("service_trigger", action="coil_test")
         self.advance_time_and_run()
 
-        self.assertEventCalledWith("service_menu_selected", label='Switch Menu')
-
-        # select coil menu
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Coil Menu')
-
-        # enter coil menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Single Coil Test')
-
-        # start edge test
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        # selects the first coil
-        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='First coil',
-                                   coil_name='c_test', coil_num='1')
+        self.assertEventCalledWith("service_coil_test_start",
+                                   board_name='Virtual', coil_label='First coil',
+                                   coil_name="c_test", coil_num='1')
 
         # select test2
         self.hit_and_release_switch("s_service_up")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_coil_test_start", board_name='Virtual', coil_label='Second coil',
+        self.assertEventCalledWith("service_coil_test_start",
+                                   board_name='Virtual', coil_label='Second coil',
                                    coil_name='c_test2', coil_num='2')
 
         self.machine.coils["c_test2"].pulse = MagicMock()

--- a/mpf/tests/test_ServiceMode.py
+++ b/mpf/tests/test_ServiceMode.py
@@ -42,7 +42,7 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.assertModeNotRunning("attract")
 
         # exit
-        self.hit_and_release_switch("s_service_esc")
+        self.machine.events.post("service_trigger", action="service_exit")
         self.advance_time_and_run()
         self.assertEventCalled('service_mode_entered', 1)
         self.assertEventCalled('service_mode_exited', 1)
@@ -64,7 +64,7 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.assertModeRunning("service")
 
         # exit service
-        self.hit_and_release_switch("s_service_esc")
+        self.machine.events.post("service_trigger", action="service_exit")
         self.advance_time_and_run()
         self.assertEventCalled('service_mode_exited', 2)
         self.assertEventCalled('service_door_closed', 1)
@@ -114,48 +114,13 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.assertModeNotRunning("attract")
 
         # exit service mode
-        self.hit_and_release_switch("s_service_esc")
+        self.machine.events.post("service_trigger", action="service_exit")
         self.advance_time_and_run()
         self.assertModeRunning("attract")
         self.assertEventCalled('service_mode_exited')
 
-    def test_start_menu(self):
-        self.mock_event("service_menu_selected")
-        # enter menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Audits Menu')
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Adjustments Menu')
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Utilities Menu')
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Audio Menu')
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
-
-        self.hit_and_release_switch("s_service_down")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Audio Menu')
-
-        self.hit_and_release_switch("s_service_down")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Utilities Menu')
-
     def test_utilities_reset(self):
+        self.skipTest("Audits and Resets not yet implemented in MPF 0.80")
         self.hit_and_release_switch("s_service_esc")
         self.advance_time_and_run(.1)
         self.hit_and_release_switch("s_service_esc")
@@ -178,36 +143,17 @@ class TestServiceMode(MpfFakeGameTestCase):
 
         self.assertMachineVarEqual(1, "credit_units")
 
-        self.mock_event("service_menu_selected")
+        self.mock_event("service_main_menu")
         self.mock_event("service_options_slide_start")
         # enter menu
         self.hit_and_release_switch("s_service_enter")
         self.advance_time_and_run()
 
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
+        self.assertEventCalled("service_main_menu")
 
         self.hit_and_release_switch("s_service_up")
         self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Audits Menu')
 
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Adjustments Menu')
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Utilities Menu')
-
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Reset Menu')
-
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_menu_selected", label='Reset Coin Audits')
-        self.assertEventNotCalled("service_options_slide_start")
-        self.mock_event("service_menu_selected")
-        self.mock_event("service_options_slide_start")
 
         # RESET earning audits
         self.hit_and_release_switch("s_service_enter")
@@ -462,85 +408,3 @@ class TestServiceMode(MpfFakeGameTestCase):
         self.advance_time_and_run()
         self.assertEventCalled("master_volume_increase", 1)
         self.assertEventCalled("master_volume_decrease", 1)
-
-    def test_settings(self):
-        self.machine.settings._settings = {}
-        self.machine.settings.add_setting(SettingEntry("test1", "Test1", 1, "test1", "b",
-                                                       {"a": "A", "b": "B (default)", "c": "C"}, "standard"))
-        self.machine.settings.add_setting(SettingEntry("test2", "Test2", 2, "test2", False,
-                                                       {True: "Yes", False: "No (default)"}, "standard"))
-        self.mock_event("service_settings_start")
-        self.mock_event("service_settings_edit")
-        self.mock_event("service_settings_stop")
-
-        self.mock_event("service_menu_selected")
-        # enter menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Diagnostics Menu')
-
-        # select audits menu
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Audits Menu')
-
-        # select adjustments menu
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Adjustments Menu')
-
-        # enter adjustments menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_menu_selected", label='Standard Adjustments')
-
-        # enter standard adjustments menu
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-
-        self.assertEventCalledWith("service_settings_start", settings_label='Test1', value_label="B (default)")
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_start", settings_label='Test2', value_label="No (default)")
-
-        # change setting
-        self.hit_and_release_switch("s_service_enter")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="No (default)")
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="Yes")
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="No (default)")
-
-        self.hit_and_release_switch("s_service_down")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_edit", settings_label='Test2', value_label="Yes")
-
-        # exit setting change
-        self.hit_and_release_switch("s_service_esc")
-        self.advance_time_and_run()
-
-        self.hit_and_release_switch("s_service_up")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_start", settings_label='Test1', value_label="B (default)")
-
-        self.hit_and_release_switch("s_service_down")
-        self.advance_time_and_run()
-        self.assertEventCalledWith("service_settings_start", settings_label='Test2', value_label="Yes")
-
-        self.assertEventNotCalled("service_settings_stop")
-
-        # exit settings change
-        self.hit_and_release_switch("s_service_esc")
-        self.advance_time_and_run()
-
-        self.assertEventCalled("service_settings_stop")


### PR DESCRIPTION
This PR refactors the built-in Service mode for a paradigm shift in service management.

## Summary

MPF 0.5x was heavily involved in the rendering of the service menu, dynamically generating menu items and posting slides for the MC to render. All of the menu management and navigation structure was managed by MPF, and the results were passed to MC. Regardless of the MC being used, the service menu was brittle and strongly hard-coded.

MPF 0.8x changes this approach by offloading all menu and UI responsibilities to the MC. MPF will provide lists of settings options, lists of switches, coils and lights, audit data, and other information necessary for the MC to render, but the layout and navigation of the service menu is the MC's responsibility. When the user invokes an actionable task, a `service_trigger` event is sent from the MC back to MPF to handle the behavior (e.g. turn on a light, fire a coil, save a setting machine var).

## Overview of Changes

* BCP events to set_machine_var can now include a `persist` flag to persist values not defined in the machine's `machine_vars:` config
* A new setting type `"hw_volume"` is defined for hardware platform volume controls
* The built in Service mode's _service.yaml_ now includes a `slide_player:` call to play the service slide
* Service navigation can be done with a four-button input (up/down/enter/esc) or a three-button input (up/down/toggle)
* Flippers can be used to skip pages of the service menu
* The FAST Audio board is refactored to better align with how machine variables and settings are tracked

This PR works in tandem with https://github.com/missionpinball/mpf-gmc/pull/6, the GMC implementation of the Service menu UI.