### PR TITLE
Spinner event buffer and max_events_per_second

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1928,6 +1928,7 @@ spinners:
     labels: list|str|None
     active_ms: single|ms|1000ms
     idle_ms: single|ms|None
+    max_events_per_second: single|int|-1
     playfield: single|machine(playfields)|playfield
     reset_when_inactive: single|bool|true
     enable_events: event_handler|event_handler:ms|None

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -88,7 +88,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         self.hits += 1
 
         if not self._event_buffer_ms or not self.delay.check("event_buffer"):
-            self._post_hit_event(label=label)
+            self._post_hit_event(label=label, last_hits=self.hits - 1)
 
     def _post_hit_event(self, **kwargs):
         last_hits = kwargs.get("last_hits", 0)

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -43,7 +43,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         # Cache this value because it's used a lot in rapid succession
         self._active_ms = self.config['active_ms']
         if self.config['max_events_per_second'] > 0:
-            self._event_buffer_ms =  (1 / self.config['max_events_per_second']) * 1000
+            self._event_buffer_ms = (1 / self.config['max_events_per_second']) * 1000
             self.log.debug("Configured event buffer for %s", self._event_buffer_ms)
         # Can't read the switch until the switch controller is set up
         self.machine.events.add_handler('init_phase_4',

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -91,7 +91,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
             self._post_hit_event(label=label)
 
     def _post_hit_event(self, **kwargs):
-        last_hits = kwargs.get("last_hits")
+        last_hits = kwargs.get("last_hits", 0)
         self.log.debug("Buffer check has %s previous hits, current is %s", last_hits, self.hits)
         if last_hits and last_hits == self.hits:
             self.delay.remove("event_buffer")
@@ -99,7 +99,8 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
         label = kwargs.get("label")
 
-        self.machine.events.post("spinner_{}_hit".format(self.name), hits=self.hits, label=label)
+        self.machine.events.post("spinner_{}_hit".format(self.name), hits=self.hits,
+                                 change=self.hits - last_hits, label=label)
         '''event: spinner_(name)_hit
         desc: The spinner (name) was just hit.
 
@@ -110,7 +111,8 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         label: The label of the switch that was hit
         '''
         if label:
-            self.machine.events.post("spinner_{}_{}_hit".format(self.name, label))
+            self.machine.events.post("spinner_{}_{}_hit".format(self.name, label),
+                                     hits=self.hits, change=self.hits - last_hits)
             '''event: spinner_(name)_(label)_hit
             desc: The spinner (name) was just hit on the switch labelled (label).
 

--- a/mpf/tests/machine_files/spinners/config/test_spinners.yaml
+++ b/mpf/tests/machine_files/spinners/config/test_spinners.yaml
@@ -9,6 +9,8 @@ switches:
     number:
   switch4:
     number:
+  switch5:
+    number:
 
 spinners:
   spin1:
@@ -25,3 +27,6 @@ spinners:
     active_ms: 400
     idle_ms: 800
     reset_when_inactive: false
+  spin_with_buffer:
+    switches: switch5
+    max_events_per_second: 2

--- a/mpf/tests/test_Spinners.py
+++ b/mpf/tests/test_Spinners.py
@@ -150,6 +150,35 @@ class TestSpinners(MpfTestCase):
         self.advance_time_and_run(0.3)
         self.assertEventCalled("spinner_spin2_idle")
 
+    def test_event_buffer(self):
+        self.mock_event("spinner_spin_with_buffer_active")
+        self.mock_event("spinner_spin_with_buffer_hit")
+
+        self.hit_and_release_switch("switch5")
+        self.assertEventCalled("spinner_spin_with_buffer_active")
+        self.assertEventCalled("spinner_spin_with_buffer_hit")
+        self.assertEqual({"hits": 1, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin_with_buffer_hit'])
+
+
+        self.mock_event("spinner_spin_with_buffer_hit")
+        self.hit_and_release_switch("switch5")
+        self.hit_and_release_switch("switch5")
+        self.hit_and_release_switch("switch5")
+        self.assertEventNotCalled("spinner_spin_with_buffer_hit")
+
+        self.advance_time_and_run(0.6)
+        self.assertEventCalled("spinner_spin_with_buffer_active")
+        self.assertEqual({"hits": 4, "change": 3, "label": None}, self._last_event_kwargs['spinner_spin_with_buffer_hit'])
+
+        self.mock_event("spinner_spin_with_buffer_hit")
+        self.hit_and_release_switch("switch5")
+        self.hit_and_release_switch("switch5")
+        self.assertEventNotCalled("spinner_spin_with_buffer_hit")
+
+        self.advance_time_and_run(0.5)
+        self.assertEventCalled("spinner_spin_with_buffer_active")
+        self.assertEqual({"hits": 6, "change": 2, "label": None}, self._last_event_kwargs['spinner_spin_with_buffer_hit'])
+
     def test_reset_when_inactive_false(self):
         self.mock_event("spinner_spin3_active")
         self.mock_event("spinner_spin3_hit")

--- a/mpf/tests/test_Spinners.py
+++ b/mpf/tests/test_Spinners.py
@@ -66,21 +66,21 @@ class TestSpinners(MpfTestCase):
         self.hit_and_release_switch("switch1")
         self.assertEventCalled("spinner_spin1_active")
         self.assertEventCalled("spinner_spin1_hit")
-        self.assertEqual({"hits": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
 
         self.hit_and_release_switch("switch1")
         self.advance_time_and_run(0.5)
-        self.assertEqual({"hits": 2, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 2, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
         self.assertEventNotCalled("spinner_spin1_inactive")
 
         self.hit_and_release_switch("switch1")
         self.advance_time_and_run(0.5)
-        self.assertEqual({"hits": 3, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 3, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
         self.assertEventNotCalled("spinner_spin1_inactive")
 
         self.hit_and_release_switch("switch1")
         self.advance_time_and_run(0.5)
-        self.assertEqual({"hits": 4, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 4, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
         self.assertEventNotCalled("spinner_spin1_inactive")
 
         self.advance_time_and_run(0.5)
@@ -101,25 +101,25 @@ class TestSpinners(MpfTestCase):
         self.assertEventCalled("spinner_spin2_active")
         self.assertEventCalled("spinner_spin2_hit")
         self.assertEventCalled("spinner_spin2_foo_hit")
-        self.assertEqual({"hits": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(0, self._events["spinner_spin2_bar_hit"])
 
         self.hit_and_release_switch("switch3")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 2, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 2, "change": 1, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(1, self._events["spinner_spin2_bar_hit"])
 
         self.hit_and_release_switch("switch3")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 3, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 3, "change": 1, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
 
         self.hit_and_release_switch("switch2")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 4, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 4, "change": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(2, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
         self.assertEventNotCalled("spinner_spin2_inactive")
@@ -131,7 +131,7 @@ class TestSpinners(MpfTestCase):
         # Re-activate the spinner before it goes idle
         self.hit_and_release_switch("switch2")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(3, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
         # Active should be called again
@@ -159,17 +159,17 @@ class TestSpinners(MpfTestCase):
         self.hit_and_release_switch("switch4")
         self.assertEventCalled("spinner_spin3_active")
         self.assertEventCalled("spinner_spin3_hit")
-        self.assertEqual({"hits": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         self.assertEventNotCalled("spinner_spin3_inactive")
 
         self.hit_and_release_switch("switch4")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 2, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 2, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         self.assertEventNotCalled("spinner_spin3_inactive")
 
         self.hit_and_release_switch("switch4")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 3, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 3, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         self.assertEventNotCalled("spinner_spin3_inactive")
 
         self.advance_time_and_run(0.3)
@@ -179,7 +179,7 @@ class TestSpinners(MpfTestCase):
         # Re-activate the spinner before it goes idle
         self.hit_and_release_switch("switch4")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 4, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 4, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         # Active should be called again
         self.assertEqual(2, self._events["spinner_spin3_active"])
         self.assertEqual(1, self._events["spinner_spin3_inactive"])


### PR DESCRIPTION
This PR adds a new config option `max_events_per_second` for Spinner devices to reduce event loads during spinner spins.

When `max_events_per_second` is set, the Spinner device will buffer the *spinner_(name)_hit* events and post a maximum number per second based on the configuration value. These events include a `hits` kwarg with the total number of hits so far and a `change` kwarg with the number of hits since the last event, so variable players can multiply scores and other values as needed.

The other spinner events for active, inactive, and idle, are unaffected.