### PR TITLE
Bus player for MPF 0.80 (replaces Track player from MPF 0.57)

### DIFF
--- a/mpf/config_players/bus_player.py
+++ b/mpf/config_players/bus_player.py
@@ -4,8 +4,8 @@ from functools import partial
 from mpf.config_players.plugin_player import PluginPlayer
 
 
-class TrackPlayer(PluginPlayer):
-    """Base class for part of the track player which runs as part of MPF.
+class BusPlayer(PluginPlayer):
+    """Base class for part of the bus player which runs as part of MPF.
 
     Note: This class is loaded by MPF and everything in it is in the context of
     MPF, not the mc.

--- a/mpf/config_players/bus_player.py
+++ b/mpf/config_players/bus_player.py
@@ -5,12 +5,12 @@ from mpf.config_players.plugin_player import PluginPlayer
 
 
 class BusPlayer(PluginPlayer):
+
     """Base class for part of the bus player which runs as part of MPF.
 
     Note: This class is loaded by MPF and everything in it is in the context of
     MPF, not the mc.
     """
-
 
     config_file_section = 'bus_player'
     show_section = 'buses'

--- a/mpf/config_players/bus_player.py
+++ b/mpf/config_players/bus_player.py
@@ -1,0 +1,36 @@
+"""Bus player plugin for MPF to support GMC."""
+
+from functools import partial
+from mpf.config_players.plugin_player import PluginPlayer
+
+
+class TrackPlayer(PluginPlayer):
+    """Base class for part of the track player which runs as part of MPF.
+
+    Note: This class is loaded by MPF and everything in it is in the context of
+    MPF, not the mc.
+    """
+
+
+    config_file_section = 'bus_player'
+    show_section = 'buses'
+
+    def _validate_config_item(self, device, device_settings):
+        # device is bus name, device_settings is configuration
+
+        device_settings = self.machine.config_validator.validate_config(
+            'bus_player', device_settings)
+
+        return_dict = dict()
+        return_dict[device] = device_settings
+
+        return return_dict
+
+    def _register_trigger(self, event, **kwargs):
+        """Register trigger via BCP for MC."""
+        del kwargs
+        client = self.machine.bcp.transport.get_named_client("local_display")
+        if client:
+            self.machine.bcp.interface.add_registered_trigger_event_for_client(client, event)
+        else:
+            self.machine.events.add_handler("bcp_clients_connected", partial(self._register_trigger, event))

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -305,8 +305,7 @@ bonus_entries:
 bus_player:
     __valid_in__: machine, mode, show
     __type__: config_player
-    action: single|enum(play,stop,pause,set_volume,stop_all_sounds)|
-    volume: single|gain|None
+    action: single|enum(pause,stop,unpause)|
     fade: single|secs|0.1sec
 coils:
     __valid_in__: machine

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -302,6 +302,12 @@ bonus_entries:
     player_score_entry: single|str|None
     skip_if_zero: single|bool|true
     skip_if_negative: single|bool|false
+bus_player:
+    __valid_in__: machine, mode, show
+    __type__: config_player
+    action: single|enum(play,stop,pause,set_volume,stop_all_sounds)|
+    volume: single|gain|None
+    fade: single|secs|0.1sec
 coils:
     __valid_in__: machine
     __type__: device

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -25,6 +25,7 @@ mpf:
         coil: mpf.config_players.coil_player.CoilPlayer
         event: mpf.config_players.event_player.EventPlayer
         blocking: mpf.config_players.block_event_player.BlockEventPlayer
+        bus_player: mpf.config_players.bus_player.BusPlayer
         queue_event: mpf.config_players.queue_event_player.QueueEventPlayer
         queue_relay: mpf.config_players.queue_relay_player.QueueRelayPlayer
         flasher: mpf.config_players.flasher_player.FlasherPlayer


### PR DESCRIPTION
This PR introduces support for `bus_player` commands from MPF, akin to the `track_player` configs of MPF 0.57. The GMC companion PR is at https://github.com/missionpinball/mpf-gmc/pull/8

Three actions are supported: `pause`, `unpause`, and `stop`. 

```

bus_player:
  delay_pause:
    music:
      action: pause
      fade: 2s
  delay_resume:
    music:
      action: unpause
      fade: 2s
  delay_stop:
    music:
      action: stop
      fade: 1s
```

Note that when a bus pauses, the channel is no longer considered active and may be replaced by a new sound request. To ensure proper isolation of sound files on a bus, use a unique bus for those sounds.