### PR TITLE
Release 0.57.2

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.2.dev3'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev4'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.2.dev1'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev2'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.2.dev2'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev3'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.2.dev6'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.1'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev1'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.2.dev4'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev5'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.2.dev5'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.2.dev6'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -521,7 +521,7 @@ class RunningShow:
     def _start_play(self):
         if self._stopped:
             return
-        self.machine.show_controller.info_log("Starting show %s", self.show.name)
+        self.machine.show_controller.debug_log("Starting show %s", self.show.name)
 
         self._total_steps = len(self.show_steps)
 
@@ -561,7 +561,7 @@ class RunningShow:
         """Stop show."""
         if self._stopped:
             return
-        self.machine.show_controller.info_log("Stopping show %s", self.show.name)
+        self.machine.show_controller.debug_log("Stopping show %s", self.show.name)
 
         self._stopped = True
 
@@ -591,14 +591,14 @@ class RunningShow:
 
     def pause(self):
         """Pause show."""
-        self.machine.show_controller.info_log("Pausing show %s", self.show.name)
+        self.machine.show_controller.debug_log("Pausing show %s", self.show.name)
         self._remove_delay_handler()
         if self.show_config.events_when_paused:
             self._post_events(self.show_config.events_when_paused)
 
     def resume(self):
         """Resume paused show."""
-        self.machine.show_controller.info_log("Resuming show %s", self.show.name)
+        self.machine.show_controller.debug_log("Resuming show %s", self.show.name)
         self.next_step_time = self.machine.clock.get_time()
         self._run_next_step(post_events=self.show_config.events_when_resumed)
 

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -488,7 +488,7 @@ class RunningShow:
 
     __slots__ = ["machine", "show", "show_steps", "show_config", "callback", "start_step", "start_running",
                  "start_callback", "_delay_handler", "next_step_index", "current_step_index", "next_step_time",
-                 "name", "loops", "id", "_ctrl", "_players", "debug", "_stopped", "_total_steps", "context"]
+                 "name", "loops", "id", "_players", "debug", "_stopped", "_total_steps", "context"]
 
     # pylint: disable-msg=too-many-arguments
     # pylint: disable-msg=too-many-locals
@@ -509,7 +509,6 @@ class RunningShow:
         self.loops = self.show_config.loops
 
         self.id = self.machine.show_controller.get_next_show_id()
-        self._ctrl = self.machine.show_controller
         self.context = "show_{}".format(self.id)
         self._players = set()
 
@@ -522,7 +521,7 @@ class RunningShow:
     def _start_play(self):
         if self._stopped:
             return
-        self._ctrl.info_log("Starting show %s", self.show.name)
+        self.machine.show_controller.info_log("Starting show %s", self.show.name)
 
         self._total_steps = len(self.show_steps)
 
@@ -562,7 +561,7 @@ class RunningShow:
         """Stop show."""
         if self._stopped:
             return
-        self._ctrl.info_log("Stopping show %s", self.show.name)
+        self.machine.show_controller.info_log("Stopping show %s", self.show.name)
 
         self._stopped = True
 
@@ -592,14 +591,14 @@ class RunningShow:
 
     def pause(self):
         """Pause show."""
-        self._ctrl.info_log("Pausing show %s", self.show.name)
+        self.machine.show_controller.info_log("Pausing show %s", self.show.name)
         self._remove_delay_handler()
         if self.show_config.events_when_paused:
             self._post_events(self.show_config.events_when_paused)
 
     def resume(self):
         """Resume paused show."""
-        self._ctrl.info_log("Resuming show %s", self.show.name)
+        self.machine.show_controller.info_log("Resuming show %s", self.show.name)
         self.next_step_time = self.machine.clock.get_time()
         self._run_next_step(post_events=self.show_config.events_when_resumed)
 

--- a/mpf/assets/show.py
+++ b/mpf/assets/show.py
@@ -488,7 +488,7 @@ class RunningShow:
 
     __slots__ = ["machine", "show", "show_steps", "show_config", "callback", "start_step", "start_running",
                  "start_callback", "_delay_handler", "next_step_index", "current_step_index", "next_step_time",
-                 "name", "loops", "id", "_players", "debug", "_stopped", "_total_steps", "context"]
+                 "name", "loops", "id", "_ctrl", "_players", "debug", "_stopped", "_total_steps", "context"]
 
     # pylint: disable-msg=too-many-arguments
     # pylint: disable-msg=too-many-locals
@@ -509,6 +509,7 @@ class RunningShow:
         self.loops = self.show_config.loops
 
         self.id = self.machine.show_controller.get_next_show_id()
+        self._ctrl = self.machine.show_controller
         self.context = "show_{}".format(self.id)
         self._players = set()
 
@@ -521,6 +522,7 @@ class RunningShow:
     def _start_play(self):
         if self._stopped:
             return
+        self._ctrl.info_log("Starting show %s", self.show.name)
 
         self._total_steps = len(self.show_steps)
 
@@ -560,6 +562,7 @@ class RunningShow:
         """Stop show."""
         if self._stopped:
             return
+        self._ctrl.info_log("Stopping show %s", self.show.name)
 
         self._stopped = True
 
@@ -589,12 +592,14 @@ class RunningShow:
 
     def pause(self):
         """Pause show."""
+        self._ctrl.info_log("Pausing show %s", self.show.name)
         self._remove_delay_handler()
         if self.show_config.events_when_paused:
             self._post_events(self.show_config.events_when_paused)
 
     def resume(self):
         """Resume paused show."""
+        self._ctrl.info_log("Resuming show %s", self.show.name)
         self.next_step_time = self.machine.clock.get_time()
         self._run_next_step(post_events=self.show_config.events_when_resumed)
 

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -115,7 +115,7 @@ autofire_coils:
     coil_overwrite: single|subconfig(coil_overwrites)|None
     switch_overwrite: dict|str:str|None
     ball_search_order: single|int|100
-    playfield: single|machine(playfields)|playfield
+    playfield: single|machine(playfields)|None
     timeout_watch_time: single|ms|0
     timeout_max_hits: single|int|0
     timeout_disable_time: single|ms|0
@@ -493,7 +493,7 @@ drop_targets:
     reset_coil_max_wait_ms: single|ms|100ms
     knockdown_coil_max_wait_ms: single|ms|100ms
     ignore_switch_ms: single|ms|500ms
-    playfield: single|machine(playfields)|playfield
+    playfield: single|machine(playfields)|None
 drop_target_banks:
     __valid_in__: machine, mode
     __type__: device
@@ -1076,7 +1076,7 @@ magnets:
     release_time: single|ms|500ms
     fling_drop_time: single|ms|250ms
     fling_regrab_time: single|ms|50ms
-    playfield: single|machine(playfields)|playfield
+    playfield: single|machine(playfields)|None
     enable_events: event_handler|event_handler:ms|ball_started
     disable_events: event_handler|event_handler:ms|ball_will_end, service_mode_entered
     reset_events: event_handler|event_handler:ms|machine_reset_phase_3, ball_starting
@@ -1986,7 +1986,7 @@ sequence_shots:
     delay_switch_list: dict|machine(switches):ms|None
     delay_event_list: event_handler|event_handler:ms|None
     sequence_timeout: single|ms|0
-    playfield: single|machine(playfields)|playfield
+    playfield: single|machine(playfields)|None
 switches:
     __valid_in__: machine
     __type__: device
@@ -1999,6 +1999,7 @@ switches:
     events_when_deactivated: list|event_posted|None
     platform: single|str|None
     platform_settings: single|dict|None
+    playfield: single|machine(playfields)|playfield
     x: single|float|None
     y: single|float|None
     z: single|float|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1928,6 +1928,7 @@ spinners:
     labels: list|str|None
     active_ms: single|ms|1000ms
     idle_ms: single|ms|None
+    max_events_per_second: single|int|-1
     playfield: single|machine(playfields)|playfield
     reset_when_inactive: single|bool|true
     enable_events: event_handler|event_handler:ms|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1992,6 +1992,7 @@ switches:
     type: single|enum(NC,NO)|NO
     debounce: single|enum(auto,quick,normal)|auto
     ignore_window_ms: single|ms|0
+    ignore_during_ball_search: single|bool|false
     events_when_activated: list|event_posted|None
     events_when_deactivated: list|event_posted|None
     platform: single|str|None

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -498,6 +498,7 @@ drop_target_banks:
     __valid_in__: machine, mode
     __type__: device
     drop_targets: list|machine(drop_targets)|
+    ball_search_order: single|int|100
     max_reset_attempts: single|int|None
     reset_on_complete: single|ms|None
     reset_coil: single|machine(coils)|None
@@ -505,6 +506,7 @@ drop_target_banks:
     reset_coil_max_wait_ms: single|ms|100ms
     reset_events: event_handler|event_handler:ms|machine_reset_phase_3, ball_starting
     ignore_switch_ms: single|ms|500ms
+    playfield: single|machine(playfields)|playfield
 effects:
     common:
         type: single|str|

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1300,7 +1300,7 @@ player_vars:
 playfields:
     __valid_in__: machine
     __type__: device
-    enable_ball_search: single|bool|None
+    enable_ball_search: single|template_bool|None
     ball_search_timeout: single|ms|15s
     ball_search_interval: single|ms|150ms
     ball_search_phase_1_searches: single|int|3

--- a/mpf/core/ball_search.py
+++ b/mpf/core/ball_search.py
@@ -121,13 +121,16 @@ class BallSearch(MpfController):
             return
 
         del kwargs
-        if self.playfield.config['enable_ball_search'] is False or (
-            not self.playfield.config['enable_ball_search'] and
+        is_ball_search_enabled = self.playfield.config['enable_ball_search'].evaluate({}) if \
+            self.playfield.config['enable_ball_search'] else None
+        if is_ball_search_enabled is False or (
+            is_ball_search_enabled is None and
                 not self.machine.config['mpf']['default_ball_search']):
             return
 
         if not self.callbacks:
-            raise AssertionError("No callbacks registered")
+            raise AssertionError(f"Cannot run ball search on playfield '{self.playfield.name}', no callbacks "
+                                 "registered. Do you have any shots/devices defined in this playfield?")
 
         self.debug_log("Enabling Ball Search")
 

--- a/mpf/core/ball_search.py
+++ b/mpf/core/ball_search.py
@@ -255,14 +255,6 @@ class BallSearch(MpfController):
                 element = next(self.iterator)
             except StopIteration:
                 self.iteration += 1
-                self.machine.events.post('ball_search_phase_{}'.format(self.phase),
-                                         iteration=self.iteration)
-                '''event: ball_search_phase_(num)
-
-                desc: The ball search phase (num) has started.
-                args:
-                    iteration: Current iteration of phase (num)
-                '''
                 # give up at some point
                 if self.iteration > self.playfield.config[
                         'ball_search_phase_{}_searches'.format(self.phase)]:
@@ -271,6 +263,15 @@ class BallSearch(MpfController):
                     if self.phase > 3:
                         self.give_up()
                         return
+
+                self.machine.events.post('ball_search_phase_{}'.format(self.phase),
+                                         iteration=self.iteration)
+                '''event: ball_search_phase_(num)
+
+                desc: The ball search phase (num) has started.
+                args:
+                    iteration: Current iteration of phase (num)
+                '''
 
                 self.iterator = iter(self.callbacks)
                 element = next(self.iterator)

--- a/mpf/core/switch_controller.py
+++ b/mpf/core/switch_controller.py
@@ -374,7 +374,8 @@ class SwitchController(MpfController):
 
         self._cancel_timed_handlers(obj)
 
-        self._call_handlers(obj, state)
+        if not obj.is_muted:
+            self._call_handlers(obj, state)
 
         for monitor in self.monitors:
             monitor(MonitoredSwitchChange(name=obj.name, label=obj.label, platform=obj.platform,

--- a/mpf/core/switch_controller.py
+++ b/mpf/core/switch_controller.py
@@ -367,10 +367,12 @@ class SwitchController(MpfController):
         obj.state = state
         obj.last_change = timestamp
 
+
+        muted_state = "(muted) " if obj.is_muted else ""
         if state:
-            self.info_log("<<<<<<< '%s' active >>>>>>>", obj.name)
+            self.info_log("<<<<<<< '%s' active %s>>>>>>>", obj.name, muted_state)
         else:
-            self.info_log("<<<<<<< '%s' inactive >>>>>>>", obj.name)
+            self.info_log("<<<<<<< '%s' inactive %s>>>>>>>", obj.name, muted_state)
 
         self._cancel_timed_handlers(obj)
 

--- a/mpf/core/switch_controller.py
+++ b/mpf/core/switch_controller.py
@@ -367,7 +367,6 @@ class SwitchController(MpfController):
         obj.state = state
         obj.last_change = timestamp
 
-
         muted_state = "(muted) " if obj.is_muted else ""
         if state:
             self.info_log("<<<<<<< '%s' active %s>>>>>>>", obj.name, muted_state)

--- a/mpf/core/switch_controller.py
+++ b/mpf/core/switch_controller.py
@@ -375,7 +375,9 @@ class SwitchController(MpfController):
 
         self._cancel_timed_handlers(obj)
 
-        if not obj.is_muted:
+        # Don't call switch callbacks during initialization, or devices may try and
+        # flag playfields active and mess up the ball counts.
+        if self._initialized and not obj.is_muted:
             self._call_handlers(obj, state)
 
         for monitor in self.monitors:

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -169,7 +169,7 @@ class AutofireCoil(SystemWideDevice):
         if not self._enabled:
             return
         if not self._ball_search_in_progress:
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
         if self._timeout_watch_time:
             current_time = self.machine.clock.get_time()
             self._timeout_hits = [t for t in self._timeout_hits if t > current_time - self._timeout_watch_time / 1000.0]

--- a/mpf/devices/autofire.py
+++ b/mpf/devices/autofire.py
@@ -34,7 +34,8 @@ class AutofireCoil(SystemWideDevice):
     collection = 'autofire_coils'
     class_label = 'autofire'
 
-    __slots__ = ["_enabled", "_rule", "delay", "_ball_search_in_progress", "_timeout_watch_time", "_timeout_max_hits",
+    __slots__ = ["_enabled", "_rule", "delay", "_ball_search_in_progress", "playfield",
+                 "_timeout_watch_time", "_timeout_max_hits",
                  "_timeout_disable_time", "_timeout_hits"]
 
     def __init__(self, machine: "MachineController", name: str) -> None:
@@ -44,6 +45,7 @@ class AutofireCoil(SystemWideDevice):
         super().__init__(machine, name)
         self.delay = DelayManager(self.machine)
         self._ball_search_in_progress = False
+        self.playfield = None
         self._timeout_watch_time = None
         self._timeout_max_hits = None
         self._timeout_disable_time = None
@@ -51,8 +53,9 @@ class AutofireCoil(SystemWideDevice):
 
     async def _initialize(self):
         await super()._initialize()
+        self.playfield = self.config['playfield'] or self.config['switch'].playfield
         if self.config['ball_search_order']:
-            self.config['playfield'].ball_search.register(
+            self.playfield.ball_search.register(
                 self.config['ball_search_order'], self._ball_search, self.name)
         # pulse is handled via rule but add a handler so that we take notice anyway
         self.config['switch'].add_handler(self._hit)
@@ -61,13 +64,13 @@ class AutofireCoil(SystemWideDevice):
             self._timeout_max_hits = self.config['timeout_max_hits']
             self._timeout_disable_time = self.config['timeout_disable_time']
 
-        if f"{self.config['playfield'].name}_active" in self.config['switch'].tags:
+        if f"{self.playfield.name}_active" in self.config['switch'].tags:
             self.raise_config_error(
                 "Autofire device '{}' uses switch '{}' which has a "
                 "'{}_active' tag. This is handled internally by the device. Remove the "
                 "redundant '{}_active' tag from that switch.".format(
-                    self.name, self.config['switch'].name, self.config['playfield'].name,
-                    self.config['playfield'].name), 1)
+                    self.name, self.config['switch'].name, self.playfield.name,
+                    self.playfield.name), 1)
 
     @event_handler(1)
     def event_enable(self, **kwargs):
@@ -169,7 +172,7 @@ class AutofireCoil(SystemWideDevice):
         if not self._enabled:
             return
         if not self._ball_search_in_progress:
-            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
+            self.playfield.mark_playfield_active_from_device_action(self.name)
         if self._timeout_watch_time:
             current_time = self.machine.clock.get_time()
             self._timeout_hits = [t for t in self._timeout_hits if t > current_time - self._timeout_watch_time / 1000.0]

--- a/mpf/devices/diverter.py
+++ b/mpf/devices/diverter.py
@@ -379,15 +379,15 @@ class Diverter(SystemWideDevice):
         del phase
         del iteration
         if self.active:
-            self.info_log("Temporarily deactivating diverter to search ball for %sms",
-                          self.config['ball_search_hold_time'])
+            self.debug_log("Temporarily deactivating diverter to search ball for %sms",
+                           self.config['ball_search_hold_time'])
             self._coil_deactivate()
             self.machine.delay.add(self.config['ball_search_hold_time'],
                                    self._coil_activate,
                                    'diverter_{}_ball_search'.format(self.name))
         else:
-            self.info_log("Temporarily activating diverter to search ball for %sms",
-                          self.config['ball_search_hold_time'])
+            self.debug_log("Temporarily activating diverter to search ball for %sms",
+                           self.config['ball_search_hold_time'])
             self._coil_activate()
             self.machine.delay.add(self.config['ball_search_hold_time'],
                                    self._coil_deactivate,

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -358,7 +358,7 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
             target.add_to_bank(self)
             assert self.config['playfield'] == target.playfield, \
                    f"Drop target bank has a playfield {self.config['playfield']} but target {target.name} " \
-                    "has playfield {target.playfield}. Banks do not support targets on multiple playfields."
+                   "has playfield {target.playfield}. Banks do not support targets on multiple playfields."
 
         self.member_target_change()
 

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -70,13 +70,13 @@ class DropTarget(SystemWideDevice):
 
     def _ignore_switch_hits_for(self, ms, reset_attempt=None):
         """Ignore switch hits for ms."""
-        self.info_log("Ignoring switch hits for %sms", ms)
+        self.debug_log("Ignoring switch hits for %sms", ms)
         self.config['switch'].mute()
         self._ignore_switch_hits = True
         self.delay.reset(name="ignore_switch", callback=self._restore_switch_hits, ms=ms, reset_attempt=reset_attempt)
 
     def _restore_switch_hits(self, reset_attempt=None):
-        self.info_log("Restoring switch hits")
+        self.debug_log("Restoring switch hits")
         self.config['switch'].unmute()
         self._ignore_switch_hits = False
         self._update_state_from_switch(reconcile=True)
@@ -92,15 +92,12 @@ class DropTarget(SystemWideDevice):
             self.debug_log("Reset confirmed!")
 
     def _ball_search_phase1(self):
-        self.info_log("Ball search phase 1: complete is %s", self.complete)
         if not self.complete and self.reset_coil:
-            self.info_log(" - not complete, firing reset coil")
             self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
             self.reset_coil.pulse()
             return True
         # if down. knock down again
         if self.complete and self.knockdown_coil:
-            self.info_log(" - complete, firing knockdown coil")
             self.knockdown_coil.pulse()
             return True
         return False
@@ -222,14 +219,13 @@ class DropTarget(SystemWideDevice):
             self.config['switch'])
 
         self.debug_log("Drop target %s switch %s has active value %s compared to drop complete %s",
-                      self.name, self.config['switch'].name, is_complete, self.complete)
+                       self.name, self.config['switch'].name, is_complete, self.complete)
         if self._in_ball_search or self._ignore_switch_hits:
             self.debug_log("Ignoring state change in drop target %s due to being in ball search "
                            "or ignoring switch hits", self.name)
             return
 
         if not reconcile:
-            self.debug_log("Hit without reconciling, marking playfield as active")
             self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
         if is_complete != self.complete:

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -356,10 +356,10 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
         """Add targets to bank."""
         for target in self.drop_targets:
             target.add_to_bank(self)
-            assert(self.config['playfield'] == target.playfield,
-                   "Drop target bank has a playfield %s but target %s has playfield %s. "
-                   "Banks do not support targets on multiple playfields.",
-                   self.config['playfield'], target.name, target.playfield)
+            assert self.config['playfield'] == target.playfield, \
+                   f"Drop target bank has a playfield {self.config['playfield']} but target {target.name} " \
+                    "has playfield {target.playfield}. Banks do not support targets on multiple playfields."
+
         self.member_target_change()
 
         self.debug_log('Drop Targets: %s', self.drop_targets)

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -99,7 +99,7 @@ class DropTarget(SystemWideDevice):
             self.reset_coil.pulse()
             return True
         # if down. knock down again
-        elif self.complete and self.knockdown_coil:
+        if self.complete and self.knockdown_coil:
             self.info_log(" - complete, firing knockdown coil")
             self.knockdown_coil.pulse()
             return True
@@ -221,16 +221,16 @@ class DropTarget(SystemWideDevice):
         is_complete = self.machine.switch_controller.is_active(
             self.config['switch'])
 
-        self.info_log("Drop target %s switch %s has active value %s compared to drop complete %s",
-                       self.name, self.config['switch'].name, is_complete, self.complete)
+        self.debug_log("Drop target %s switch %s has active value %s compared to drop complete %s",
+                      self.name, self.config['switch'].name, is_complete, self.complete)
         if self._in_ball_search or self._ignore_switch_hits:
             self.debug_log("Ignoring state change in drop target %s due to being in ball search "
                            "or ignoring switch hits", self.name)
             return
 
         if not reconcile:
-            self.info_log("Hit without reconciling, marking playfield as active")
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.debug_log("Hit without reconciling, marking playfield as active")
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
         if is_complete != self.complete:
 

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -432,7 +432,7 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
             target.external_reset_from_bank()
         self.member_target_change()
 
-        if self.down != 0 and reset_attempt is not None:
+        if self.down != 0 and reset_attempt is not None and self.config['max_reset_attempts'] is not None:
             if reset_attempt < self.config['max_reset_attempts']:
                 self.debug_log("Reset failed after attempt %s, trying again.", reset_attempt)
                 reset_attempt += 1

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -333,6 +333,12 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
         self.reset_coil = self.config['reset_coil']
         self.reset_coils = self.config['reset_coils']
 
+        # If individual drop targets have reset coils, they will ball search themselves.
+        # The bank will only trigger in ball search if it has its own bank coils defined
+        if self.config['ball_search_order'] and (self.config['reset_coil'] or self.config['reset_coils']):
+            self.config['playfield'].ball_search.register(
+                self.config['ball_search_order'], self.reset, self.name)
+
     def device_loaded_in_mode(self, mode: Mode, player: Player):
         """Add targets."""
         self._add_targets_to_bank()

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -72,12 +72,12 @@ class DropTarget(SystemWideDevice):
     def _ignore_switch_hits_for(self, ms, reset_attempt=None):
         """Ignore switch hits for ms."""
         self.debug_log("Ignoring switch hits for %sms", ms)
-        self.config['switch'].mute()
+        self.config['switch'].mute(self)
         self.delay.reset(name="ignore_switch", callback=self._restore_switch_hits, ms=ms, reset_attempt=reset_attempt)
 
     def _restore_switch_hits(self, reset_attempt=None):
         self.debug_log("Restoring switch hits")
-        self.config['switch'].unmute()
+        self.config['switch'].unmute(self)
         self._update_state_from_switch(reconcile=True)
 
         if self.complete and reset_attempt:
@@ -358,7 +358,7 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
             target.add_to_bank(self)
             assert self.config['playfield'] == target.playfield, \
                    f"Drop target bank has a playfield {self.config['playfield']} but target {target.name} " \
-                   "has playfield {target.playfield}. Banks do not support targets on multiple playfields."
+                   f"has playfield {target.playfield}. Banks do not support targets on multiple playfields."
 
         self.member_target_change()
 
@@ -398,7 +398,7 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
 
             # Mute all the bank's switches
             if self.config['ignore_switch_ms']:
-                drop_target.config['switch'].mute()
+                drop_target.config['switch'].mute(self)
 
         for coil in self.reset_coils:
             coils.add(coil)
@@ -428,7 +428,7 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
     def _restore_switch_hits(self, reset_attempt=None):
         self.debug_log("Restoring switch hits")
         for target in self.drop_targets:
-            target.config['switch'].unmute()
+            target.config['switch'].unmute(self)
             target.external_reset_from_bank()
         self.member_target_change()
 

--- a/mpf/devices/drop_target.py
+++ b/mpf/devices/drop_target.py
@@ -277,8 +277,7 @@ class DropTarget(SystemWideDevice):
         device.
         Make sure we do not mark the playfield as active.
         """
-        if self.machine.switch_controller.is_active(self.config['switch']):
-            self._ignore_switch_hits_for(ms=self.config['ignore_switch_ms'])
+        self._update_state_from_switch(reconcile=True)
 
     def remove_from_bank(self, bank):
         """Remove the DropTarget from a bank.
@@ -440,6 +439,7 @@ class DropTargetBank(SystemWideDevice, ModeDevice):
     def _restore_switch_hits(self, reset_attempt=None):
         for target in self.drop_targets:
             target.config['switch'].unmute()
+            target.external_reset_from_bank()
         self._ignore_switch_hits = False
         self.member_target_change()
 

--- a/mpf/devices/magnet.py
+++ b/mpf/devices/magnet.py
@@ -26,7 +26,6 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         self.delay = DelayManager(machine)
         self._active = False
         self._release_in_progress = False
-        self.playfield = self.config['playfield'] or self.config['grab_switch'].playfield
 
     def _enable(self):
         """Enable magnet."""
@@ -34,6 +33,9 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
         if self.config['grab_switch']:
             self.config['grab_switch'].add_handler(self.grab_ball)
+            self.playfield = self.config['playfield'] or self.config['grab_switch'].playfield
+        else:
+            self.playfield = self.config['playfield']
 
     def _disable(self):
         """Disable magnet."""
@@ -62,8 +64,8 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
     def grab_ball(self):
         """Grab a ball."""
-        # mark the playfield active no matter what
-        self.playfield.mark_playfield_active_from_device_action(self.name)
+        if self.playfield:
+            self.playfield.mark_playfield_active_from_device_action(self.name)
         # check if magnet is enabled or already active
         if not self.enabled or self._active or self._release_in_progress:
             return

--- a/mpf/devices/magnet.py
+++ b/mpf/devices/magnet.py
@@ -14,7 +14,7 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
     """Controls a playfield magnet in a pinball machine."""
 
-    __slots__ = ["delay", "_active", "_release_in_progress"]
+    __slots__ = ["delay", "_active", "_release_in_progress", "playfield"]
 
     config_section = 'magnets'
     collection = 'magnets'
@@ -26,6 +26,7 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         self.delay = DelayManager(machine)
         self._active = False
         self._release_in_progress = False
+        self.playfield = self.config['playfield'] or self.config['grab_switch'].playfield
 
     def _enable(self):
         """Enable magnet."""
@@ -62,7 +63,7 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
     def grab_ball(self):
         """Grab a ball."""
         # mark the playfield active no matter what
-        self.config['playfield'].mark_playfield_active_from_device_action(self.name)
+        self.playfield.mark_playfield_active_from_device_action(self.name)
         # check if magnet is enabled or already active
         if not self.enabled or self._active or self._release_in_progress:
             return

--- a/mpf/devices/magnet.py
+++ b/mpf/devices/magnet.py
@@ -24,6 +24,7 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         """Initialize magnet."""
         super().__init__(machine, name)
         self.delay = DelayManager(machine)
+        self.playfield = None
         self._active = False
         self._release_in_progress = False
 

--- a/mpf/devices/magnet.py
+++ b/mpf/devices/magnet.py
@@ -62,7 +62,7 @@ class Magnet(EnableDisableMixinSystemWideDevice, SystemWideDevice):
     def grab_ball(self):
         """Grab a ball."""
         # mark the playfield active no matter what
-        self.config['playfield'].mark_playfield_active_from_device_action()
+        self.config['playfield'].mark_playfield_active_from_device_action(self.name)
         # check if magnet is enabled or already active
         if not self.enabled or self._active or self._release_in_progress:
             return

--- a/mpf/devices/playfield.py
+++ b/mpf/devices/playfield.py
@@ -261,19 +261,19 @@ class Playfield(SystemWideDevice):
             incoming_ball.ball_arrived()
             break
 
-    def _mark_playfield_active(self):
+    def _mark_playfield_active(self, source=None):
         self.ball_arrived()
-        self.machine.events.post_boolean(self.name + "_active")
+        self.machine.events.post_boolean(self.name + "_active", source=source)
         '''event: (name)_active
         desc: The playfield called (name) is now active, meaning there's
         at least one loose ball on it.
         '''
 
-    def mark_playfield_active_from_device_action(self):
+    def mark_playfield_active_from_device_action(self, device_name=None):
         """Mark playfield active because a device on the playfield detected activity."""
-        self._playfield_switch_hit()
+        self._playfield_switch_hit(source=device_name)
 
-    def _playfield_switch_hit(self, **kwargs):
+    def _playfield_switch_hit(self, source=None, **kwargs):
         """Playfield switch was hit.
 
         A switch tagged with '<this playfield name>_active' was just hit,
@@ -281,7 +281,7 @@ class Playfield(SystemWideDevice):
 
         """
         if self.balls <= 0 or (kwargs.get('balls') and self.balls - kwargs['balls'] < 0):
-            self._mark_playfield_active()
+            self._mark_playfield_active(source)
 
             if not self.num_balls_requested:
                 self.debug_log("Playfield was activated with no balls expected.")

--- a/mpf/devices/sequence_shot.py
+++ b/mpf/devices/sequence_shot.py
@@ -102,7 +102,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
 
         # mark playfield active
         if self.config['playfield']:
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
         self.debug_log("Sequence advance: %s", event_name)
 

--- a/mpf/devices/sequence_shot.py
+++ b/mpf/devices/sequence_shot.py
@@ -100,7 +100,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
         # switch is starting a new sequence or continuing an existing one
         del kwargs
 
-        # mark playfield active
+        # mark playfield active if a playfield is defined for this sequence
         if self.config['playfield']:
             self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -55,7 +55,7 @@ class Shot(EnableDisableMixin, ModeDevice):
         """Mark playfield active."""
         del kwargs
         if self.config['mark_playfield_active']:
-            self.config['playfield'].mark_playfield_active_from_device_action()
+            self.config['playfield'].mark_playfield_active_from_device_action(self.name)
 
     def device_loaded_in_mode(self, mode: Mode, player: Player):
         """Add device to a mode that was already started.

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -88,7 +88,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         self.hits += 1
 
         if not self._event_buffer_ms or not self.delay.check("event_buffer"):
-            self._post_hit_event(label=label)
+            self._post_hit_event(label=label, last_hits=self.hits - 1)
 
     def _post_hit_event(self, **kwargs):
         last_hits = kwargs.get("last_hits", 0)

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -43,7 +43,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         # Cache this value because it's used a lot in rapid succession
         self._active_ms = self.config['active_ms']
         if self.config['max_events_per_second'] > 0:
-            self._event_buffer_ms =  (1 / self.config['max_events_per_second']) * 1000
+            self._event_buffer_ms = (1 / self.config['max_events_per_second']) * 1000
             self.log.debug("Configured event buffer for %s", self._event_buffer_ms)
         # Can't read the switch until the switch controller is set up
         self.machine.events.add_handler('init_phase_4',

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -91,7 +91,7 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
             self._post_hit_event(label=label)
 
     def _post_hit_event(self, **kwargs):
-        last_hits = kwargs.get("last_hits")
+        last_hits = kwargs.get("last_hits", 0)
         self.log.debug("Buffer check has %s previous hits, current is %s", last_hits, self.hits)
         if last_hits and last_hits == self.hits:
             self.delay.remove("event_buffer")
@@ -99,7 +99,8 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
         label = kwargs.get("label")
 
-        self.machine.events.post("spinner_{}_hit".format(self.name), hits=self.hits, label=label)
+        self.machine.events.post("spinner_{}_hit".format(self.name), hits=self.hits,
+                                 change=self.hits - last_hits, label=label)
         '''event: spinner_(name)_hit
         desc: The spinner (name) was just hit.
 
@@ -110,7 +111,8 @@ class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
         label: The label of the switch that was hit
         '''
         if label:
-            self.machine.events.post("spinner_{}_{}_hit".format(self.name, label))
+            self.machine.events.post("spinner_{}_{}_hit".format(self.name, label),
+                                     hits=self.hits, change=self.hits - last_hits)
             '''event: spinner_(name)_(label)_hit
             desc: The spinner (name) was just hit on the switch labelled (label).
 

--- a/mpf/devices/switch.py
+++ b/mpf/devices/switch.py
@@ -264,4 +264,5 @@ class Switch(SystemWideDevice, DevicePositionMixin):
 
     @property
     def is_muted(self):
+        """True if this switch is currently muted."""
         return self._mutes > 0

--- a/mpf/devices/switch.py
+++ b/mpf/devices/switch.py
@@ -266,3 +266,8 @@ class Switch(SystemWideDevice, DevicePositionMixin):
     def is_muted(self):
         """True if this switch is currently muted."""
         return self._mutes > 0
+
+    @property
+    def playfield(self):
+        """Return the playfield this switch is assigned to."""
+        return self.config['playfield']

--- a/mpf/devices/switch.py
+++ b/mpf/devices/switch.py
@@ -27,7 +27,7 @@ class Switch(SystemWideDevice, DevicePositionMixin):
     class_label = 'switch'
 
     __slots__ = ["hw_switch", "state", "hw_state", "invert", "recycle_secs", "recycle_clear_time",
-                 "recycle_jitter_count", "_events_to_post", "last_change", "is_muted"]
+                 "recycle_jitter_count",  "last_change", "_events_to_post", "_mutes"]
 
     def __init__(self, machine: MachineController, name: str) -> None:
         """Initialize switch."""
@@ -44,7 +44,7 @@ class Switch(SystemWideDevice, DevicePositionMixin):
         not consider whether a switch is NC or NO."""
 
         self.invert = 0
-        self.is_muted = False
+        self._mutes = 0
 
         self.recycle_secs = 0
         self.recycle_clear_time = None
@@ -254,9 +254,14 @@ class Switch(SystemWideDevice, DevicePositionMixin):
     def mute(self, **kwargs):
         """Mute this switch so that switch hits do not trigger handlers."""
         del kwargs
-        self.is_muted = True
+        self._mutes += 1
 
     def unmute(self, **kwargs):
         """Unmute this switch so that hits again trigger handlers."""
         del kwargs
-        self.is_muted = False
+        self._mutes -= 1
+        assert self._mutes >= 0, "Switch %s has unmuted more times than muted." % self.name
+
+    @property
+    def is_muted(self):
+        return self._mutes > 0

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -676,13 +676,14 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                 if 0 <= channel <= 2:
                     result = []
                     for i in range(3):
+                        working_parts = parts.copy()
                         if i + channel > 2:
                             # Channel rolls over, increment the LED number
-                            parts[3] = str(int(parts[3]) + 1)
-                            parts[4] = '0'
+                            working_parts[3] = str(int(working_parts[3]) + 1)
+                            working_parts[4] = str((channel + i) % 3)
                         else:
-                            parts[4] = str(channel + i)
-                        result.append({'number': '-'.join(parts)})
+                            working_parts[4] = str(channel + i)
+                        result.append({'number': '-'.join(working_parts)})
                     return result
                 raise AssertionError(f"Invalid LED channel: {channel}")
             raise AssertionError(f"Invalid LED number: {number}")

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -512,6 +512,7 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
 
         return switch
 
+    # pylint: disable-msg=too-many-locals
     def configure_light(self, number, subtype, config, platform_settings) -> LightPlatformInterface:
         """Configure light in platform."""
         del platform_settings
@@ -567,7 +568,10 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
 
             elif int(parts[0]) > 255:
                 # EXP LED in int form, which is how "previous:" values are calculated
-                this_led_number = hex(int(parts[0]))[2:]
+
+                raw_hex_string = hex(int(parts[0]))[2:]  # lowercase with 0x prefix stripped"
+                this_led_number = Util.normalize_hex_string(raw_hex_string, len(raw_hex_string))
+
                 exp_board = self.exp_boards_by_address[this_led_number[:2]]
 
                 if this_led_number not in self.fast_exp_leds:

--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -462,6 +462,8 @@ class OppHardwarePlatform(LightsPlatform, SwitchPlatform, DriverPlatform, ServoP
             if msg[2 + wing_index] == ord(OppRs232Intf.WING_SOL):
                 sol_mask |= (0x0f << (4 * wing_index))
                 inp_mask |= (0x0f << (8 * wing_index))
+            if msg[2 + wing_index] == ord(OppRs232Intf.WING_SOL_8):
+                sol_mask |= (0xff << (8 * wing_index))
             elif msg[2 + wing_index] == ord(OppRs232Intf.WING_INP):
                 inp_mask |= (0xff << (8 * wing_index))
             elif msg[2 + wing_index] == ord(OppRs232Intf.WING_INCAND):

--- a/mpf/platforms/opp/opp_rs232_intf.py
+++ b/mpf/platforms/opp/opp_rs232_intf.py
@@ -54,6 +54,7 @@ class OppRs232Intf:
     WING_SW_MATRIX_OUT_LOW_WING = b'\x0a'
     WING_LAMP_MATRIX_COL_WING = b'\x0b'
     WING_LAMP_MATRIX_ROW_WING = b'\x0c'
+    WING_SOL_8 = b'\x0d'
 
     NUM_G2_INP_PER_BRD = 32
     CFG_INP_STATE = b'\x00'

--- a/mpf/platforms/virtual_pinball/virtual_pinball.py
+++ b/mpf/platforms/virtual_pinball/virtual_pinball.py
@@ -124,7 +124,7 @@ class VirtualPinballDriver(DriverPlatformInterface):
             return bool(self.clock.get_time() < self._state)
 
 
-class VirtualSegmentDisplay(SegmentDisplayPlatformInterface):
+class VirtualPinballSegmentDisplay(SegmentDisplayPlatformInterface):
 
     """Virtual segment display."""
 
@@ -168,7 +168,7 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, Seg
         self._drivers = {}          # type: Dict[str, VirtualPinballDriver]
         self._last_drivers = {}     # type: Dict[str, bool]
         self._last_lights = {}      # type: Dict[str, float]
-        self._configured_segment_displays = []  # type: List[VirtualSegmentDisplay]
+        self._configured_segment_displays = []  # type: List[VirtualPinballSegmentDisplay]
         self._last_segment_text = {}# type: Dict[str, str]
         self._started = asyncio.Event()
         self.log = logging.getLogger("VPX Platform")
@@ -450,7 +450,7 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, Seg
         """Configure segment display."""
         del platform_settings
         del display_size
-        segment_display = VirtualSegmentDisplay(number, self.machine)
+        segment_display = VirtualPinballSegmentDisplay(number, self.machine)
         self._configured_segment_displays.append(segment_display)
         self._last_segment_text[number] = None
         return segment_display

--- a/mpf/platforms/virtual_pinball/virtual_pinball.py
+++ b/mpf/platforms/virtual_pinball/virtual_pinball.py
@@ -12,7 +12,7 @@ from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInt
 from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface
 from mpf.platforms.interfaces.switch_platform_interface import SwitchPlatformInterface
 from mpf.core.platform import LightsPlatform, SwitchPlatform, DriverPlatform, SwitchSettings, DriverSettings, \
-    SwitchConfig, DriverConfig, RepulseSettings,SegmentDisplayPlatform
+    SwitchConfig, DriverConfig, RepulseSettings, SegmentDisplayPlatform
 
 
 class VirtualPinballSwitch(SwitchPlatformInterface):
@@ -154,11 +154,13 @@ class VirtualPinballSegmentDisplay(SegmentDisplayPlatformInterface):
         """Return colors."""
         return self._text.get_colors()
 
+
 class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, SegmentDisplayPlatform):
 
     """VPX platform."""
 
-    __slots__ = ["_lights", "_switches", "_drivers", "_last_drivers", "_last_lights", "_started", "rules", "_configured_segment_displays", "_last_segment_text"]
+    __slots__ = ["_lights", "_switches", "_drivers", "_last_drivers", "_last_lights", 
+                 "_started", "rules", "_configured_segment_displays", "_last_segment_text"]
 
     def __init__(self, machine):
         """Initialize VPX platform."""
@@ -169,7 +171,7 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, Seg
         self._last_drivers = {}     # type: Dict[str, bool]
         self._last_lights = {}      # type: Dict[str, float]
         self._configured_segment_displays = []  # type: List[VirtualPinballSegmentDisplay]
-        self._last_segment_text = {}# type: Dict[str, str]
+        self._last_segment_text = {}  # type: Dict[str, str]
         self._started = asyncio.Event()
         self.log = logging.getLogger("VPX Platform")
         self.log.debug("Configuring VPX hardware interface.")

--- a/mpf/platforms/virtual_pinball/virtual_pinball.py
+++ b/mpf/platforms/virtual_pinball/virtual_pinball.py
@@ -1,14 +1,18 @@
 """VPX platform."""
 import asyncio
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import logging
+
+
+from mpf.devices.segment_display.segment_display_text import ColoredSegmentDisplayText
+from mpf.platforms.interfaces.segment_display_platform_interface import SegmentDisplayPlatformInterface, FlashingType
 
 from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface, PulseSettings, HoldSettings
 from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface
 from mpf.platforms.interfaces.switch_platform_interface import SwitchPlatformInterface
 from mpf.core.platform import LightsPlatform, SwitchPlatform, DriverPlatform, SwitchSettings, DriverSettings, \
-    SwitchConfig, DriverConfig, RepulseSettings
+    SwitchConfig, DriverConfig, RepulseSettings,SegmentDisplayPlatform
 
 
 class VirtualPinballSwitch(SwitchPlatformInterface):
@@ -62,13 +66,16 @@ class VirtualPinballLight(LightPlatformInterface):
         return "VPX"
 
     def is_successor_of(self, other):
-        """Not implemented."""
-        raise AssertionError("Not implemented. Let us know if you need it.")
+        """Return true if the other light has the same number string plus the suffix '+1'."""
+        return self.number == other.number + "+1"
 
     def get_successor_number(self):
-        """Not implemented."""
-        raise AssertionError("Not implemented. Let us know if you need it.")
+        """Return the number with the suffix '+1'.
 
+        As there is not real number format for virtual is this is all we can do here.
+        """
+        return self.number + "+1"
+    
     def __lt__(self, other):
         """Not implemented."""
         raise AssertionError("Not implemented. Let us know if you need it.")
@@ -117,11 +124,41 @@ class VirtualPinballDriver(DriverPlatformInterface):
             return bool(self.clock.get_time() < self._state)
 
 
-class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
+class VirtualSegmentDisplay(SegmentDisplayPlatformInterface):
+
+    """Virtual segment display."""
+
+    __slots__ = ["_text", "flashing", "flash_mask", "machine"]
+
+    def __init__(self, number, machine) -> None:
+        """Initialise virtual segment display."""
+        super().__init__(number)
+        self.machine = machine
+        self._text = None
+        self.flashing = FlashingType.NO_FLASH
+        self.flash_mask = ""
+
+    def set_text(self, text: ColoredSegmentDisplayText, flashing: FlashingType, flash_mask: str) -> None:
+        """Set text."""
+        self._text = text
+        self.flashing = flashing
+        self.flash_mask = flash_mask
+
+    @property
+    def text(self):
+        """Return text."""
+        return self._text.convert_to_str()
+
+    @property
+    def colors(self):
+        """Return colors."""
+        return self._text.get_colors()
+
+class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, SegmentDisplayPlatform):
 
     """VPX platform."""
 
-    __slots__ = ["_lights", "_switches", "_drivers", "_last_drivers", "_last_lights", "_started", "rules"]
+    __slots__ = ["_lights", "_switches", "_drivers", "_last_drivers", "_last_lights", "_started", "rules", "_configured_segment_displays", "_last_segment_text"]
 
     def __init__(self, machine):
         """Initialize VPX platform."""
@@ -131,6 +168,8 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         self._drivers = {}          # type: Dict[str, VirtualPinballDriver]
         self._last_drivers = {}     # type: Dict[str, bool]
         self._last_lights = {}      # type: Dict[str, float]
+        self._configured_segment_displays = []  # type: List[VirtualSegmentDisplay]
+        self._last_segment_text = {}# type: Dict[str, str]
         self._started = asyncio.Event()
         self.log = logging.getLogger("VPX Platform")
         self.log.debug("Configuring VPX hardware interface.")
@@ -244,6 +283,18 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
 
         return changed_lamps
 
+    def _get_changed_segment_text(self):
+        """Return changed configured segment text since last call."""
+        changed_segments = []
+        for segment_display in self._configured_segment_displays:
+            text = segment_display.text
+            number = segment_display.number
+            if text != self._last_segment_text[number]:
+                changed_segments.append((number, text))
+                self._last_segment_text[number] = text
+
+        return changed_segments
+
     def vpx_changed_lamps(self):
         """Return changed lamps since last call."""
         return self._get_changed_lights_by_subtype("matrix")
@@ -278,6 +329,10 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         """Not implemented."""
         self.log.warning("Command \"set_mech\" unimplemented: %s %s", number, value)
         return True
+    
+    def vpx_changed_segment_text(self):
+        """Return changed segment text since last call."""
+        return self._get_changed_segment_text()
 
     def configure_switch(self, number: str, config: SwitchConfig, platform_config: dict) -> "SwitchPlatformInterface":
         """Configure VPX switch."""
@@ -293,6 +348,11 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
         self._drivers[number] = driver
         self._last_drivers[number] = False
         return driver
+
+    def validate_segment_display_section(self, segment_display, config):
+        """Validate segment display sections."""
+        del segment_display
+        return config
 
     def vpx_get_hardwarerules(self):
         """Return hardware rules."""
@@ -384,3 +444,14 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform):
             ]
         else:
             raise AssertionError("Unknown subtype {}".format(subtype))
+        
+    async def configure_segment_display(self, number: str, display_size: int,
+                                        platform_settings) -> SegmentDisplayPlatformInterface:
+        """Configure segment display."""
+        del platform_settings
+        del display_size
+        segment_display = VirtualSegmentDisplay(number, self.machine)
+        self._configured_segment_displays.append(segment_display)
+        self._last_segment_text[number] = None
+        return segment_display
+    

--- a/mpf/platforms/virtual_pinball/virtual_pinball.py
+++ b/mpf/platforms/virtual_pinball/virtual_pinball.py
@@ -329,7 +329,7 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, Seg
         """Not implemented."""
         self.log.warning("Command \"set_mech\" unimplemented: %s %s", number, value)
         return True
-    
+
     def vpx_changed_segment_text(self):
         """Return changed segment text since last call."""
         return self._get_changed_segment_text()
@@ -444,7 +444,7 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, Seg
             ]
         else:
             raise AssertionError("Unknown subtype {}".format(subtype))
-        
+
     async def configure_segment_display(self, number: str, display_size: int,
                                         platform_settings) -> SegmentDisplayPlatformInterface:
         """Configure segment display."""
@@ -454,4 +454,3 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, Seg
         self._configured_segment_displays.append(segment_display)
         self._last_segment_text[number] = None
         return segment_display
-    

--- a/mpf/platforms/virtual_pinball/virtual_pinball.py
+++ b/mpf/platforms/virtual_pinball/virtual_pinball.py
@@ -75,7 +75,7 @@ class VirtualPinballLight(LightPlatformInterface):
         As there is not real number format for virtual is this is all we can do here.
         """
         return self.number + "+1"
-    
+
     def __lt__(self, other):
         """Not implemented."""
         raise AssertionError("Not implemented. Let us know if you need it.")

--- a/mpf/tests/machine_files/drop_targets/config/test_drop_targets.yaml
+++ b/mpf/tests/machine_files/drop_targets/config/test_drop_targets.yaml
@@ -100,3 +100,4 @@ drop_target_banks:
      reset_coils: coil5
      ignore_switch_ms: 1000
      reset_events: reset_right_bank
+     debug: true

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -120,7 +120,7 @@ lights:
     start_channel: brian-b2-2-3-0  #88222-0, 88222-1, 88222-2, 88223-0
     type: rgbw
   led29:
-    channels:  # testing out of order, non-contiquous channels
+    channels:  # testing out of order, non-contiguous channels
       red:
         number: neuron-1-10-0  # 48009-0
       green:
@@ -129,6 +129,13 @@ lights:
         number: neuron-1-10-1  # 48009-1
       white:
         number: neuron-1-11-2  # 4800A-2
+
+  led30:
+    number: dave-4-12
+    type: rgb
+  led31:
+    previous: led30
+    type: rgb
 
 servos:
     servo1:

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -63,11 +63,11 @@ lights:
   led3:
     number: brian-1-3
   led4:
-    number: brian-b1-2-1
+    number: brian-b1-2-1-0
   led5:
-    number: brian-b1-2-2
+    number: brian-b1-2-2-1
   led6:
-    number: aaron-b2-1-1
+    number: aaron-b2-1-1-2
   led7:
     number: aaron-1-1
   led8:

--- a/mpf/tests/machine_files/head2head/config/config.yaml
+++ b/mpf/tests/machine_files/head2head/config/config.yaml
@@ -13,45 +13,65 @@ playfields:
 switches:
   s_trough1_front:
     number:
+    playfield: playfield_front
   s_trough2_front:
     number:
+    playfield: playfield_front
   s_trough3_front:
     number:
+    playfield: playfield_front
   s_trough4_front:
     number:
+    playfield: playfield_front
   s_trough1_back:
     number:
+    playfield: playfield_back
   s_trough2_back:
     number:
+    playfield: playfield_back
   s_trough3_back:
     number:
+    playfield: playfield_back
   s_trough4_back:
     number:
+    playfield: playfield_back
   s_launcher_lane_front:
     number:
+    playfield: playfield_front
   s_launcher_lane_back:
     number:
+    playfield: playfield_back
   s_middle_front1:
     number:
+    playfield: playfield_front
   s_middle_back1:
     number:
+    playfield: playfield_front
   s_feeder_front:
     number:
+    playfield: playfield_front
   s_feeder_back:
     number:
+    playfield: playfield_back
   s_launcher_diverter_front:
     number:
+    playfield: playfield_front
   s_launcher_diverter_back:
     number:
+    playfield: playfield_back
   s_transfer_front_back:
     number:
+    playfield: playfield_back
   s_transfer_back_front:
     number:
+    playfield: playfield_front
   s_playfield_front:
     number:
+    playfield: playfield_front
     tags: playfield_front_active
   s_playfield_back:
     number:
+    playfield: playfield_back
     tags: playfield_back_active
 
 coils:

--- a/mpf/tests/machine_files/spinners/config/test_spinners.yaml
+++ b/mpf/tests/machine_files/spinners/config/test_spinners.yaml
@@ -9,6 +9,8 @@ switches:
     number:
   switch4:
     number:
+  switch5:
+    number:
 
 spinners:
   spin1:
@@ -25,3 +27,6 @@ spinners:
     active_ms: 400
     idle_ms: 800
     reset_when_inactive: false
+  spin_with_buffer:
+    switches: switch5
+    max_events_per_second: 2

--- a/mpf/tests/test_BallSearch.py
+++ b/mpf/tests/test_BallSearch.py
@@ -1,3 +1,4 @@
+from mpf.core.placeholder_manager import NativeTypeTemplate
 from mpf.tests.MpfGameTestCase import MpfGameTestCase
 from unittest.mock import MagicMock
 
@@ -16,7 +17,7 @@ class TestBallSearch(MpfGameTestCase):
         return 'smart_virtual'
 
     def test_ball_search_does_not_start_when_disabled(self):
-        self.machine.playfields["playfield"].config['enable_ball_search'] = False
+        self.machine.playfields["playfield"].config['enable_ball_search'] = NativeTypeTemplate(False, self.machine)
 
         self.machine.ball_controller.num_balls_known = 0
         self.machine.switch_controller.process_switch("s_ball_switch1", 1)
@@ -34,14 +35,14 @@ class TestBallSearch(MpfGameTestCase):
         self.assertFalse(self.machine.ball_devices['playfield'].ball_search.enabled)
         self.assertFalse(self.machine.ball_devices['playfield'].ball_search.started)
 
-        self.machine.playfields["playfield"].config['enable_ball_search'] = None
+        self.machine.playfields["playfield"].config['enable_ball_search'] =  NativeTypeTemplate(None, self.machine)
         self.machine.config['mpf']['default_ball_search'] = True
         self.machine.ball_devices['playfield'].ball_search.enable()
         self.assertTrue(self.machine.ball_devices['playfield'].ball_search.enabled)
         self.machine.ball_devices['playfield'].ball_search.disable()
         self.assertFalse(self.machine.ball_devices['playfield'].ball_search.enabled)
 
-        self.machine.playfields["playfield"].config['enable_ball_search'] = None
+        self.machine.playfields["playfield"].config['enable_ball_search'] =  NativeTypeTemplate(None, self.machine)
         self.machine.config['mpf']['default_ball_search'] = False
         self.machine.ball_devices['playfield'].ball_search.enable()
         self.assertFalse(self.machine.ball_devices['playfield'].ball_search.enabled)

--- a/mpf/tests/test_DropTargets.py
+++ b/mpf/tests/test_DropTargets.py
@@ -1,3 +1,4 @@
+from mpf.core.placeholder_manager import NativeTypeTemplate
 from mpf.tests.MpfFakeGameTestCase import MpfFakeGameTestCase
 from unittest.mock import MagicMock, patch
 
@@ -323,7 +324,7 @@ class TestDropTargets(MpfTestCase):
 
     def test_drop_target_ignore_ms_ball_search(self):
 
-        self.machine.playfields["playfield"].config['enable_ball_search'] = True
+        self.machine.playfields["playfield"].config['enable_ball_search'] = NativeTypeTemplate(True, self.machine)
         self.machine.playfields["playfield"].balls += 1
 
         self.mock_event('drop_target_center1_down')

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -89,6 +89,12 @@ class TestFastExp(TestFastBase):
         self.assertEqual(self.led5.hw_drivers['green'][0].number, '88121-2')
         self.assertEqual(self.led5.hw_drivers['blue'][0].number, '88122-0')
 
+        # Intentionally-failing test to prove that third channel rollover has an issue
+        self.assertEqual(self.led6.hw_drivers['red'][0].number, '89200-2')
+        self.assertEqual(self.led6.hw_drivers['green'][0].number, '89201-0')
+        # Bug is generating as 202-0 instead of 201-1
+        self.assertEqual(self.led6.hw_drivers['blue'][0].number, '89201-1')
+
 
         # Make sure all the RGBW, channels, previous, and start_channels are working
         self.assertEqual(self.led22.hw_drivers['red'][0].number, '48002-0')

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -80,6 +80,16 @@ class TestFastExp(TestFastBase):
         self.assertIn("88121", self.fast_exp_leds)
         self.assertIn("89200", self.fast_exp_leds)
 
+        # Make sure explicit offset declarations work
+        self.assertEqual(self.led4.hw_drivers['red'][0].number, '88120-0')
+        self.assertEqual(self.led4.hw_drivers['green'][0].number, '88120-1')
+        self.assertEqual(self.led4.hw_drivers['blue'][0].number, '88120-2')
+
+        self.assertEqual(self.led5.hw_drivers['red'][0].number, '88121-1')
+        self.assertEqual(self.led5.hw_drivers['green'][0].number, '88121-2')
+        self.assertEqual(self.led5.hw_drivers['blue'][0].number, '88122-0')
+
+
         # Make sure all the RGBW, channels, previous, and start_channels are working
         self.assertEqual(self.led22.hw_drivers['red'][0].number, '48002-0')
         self.assertEqual(self.led22.hw_drivers['green'][0].number, '48002-1')

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -84,15 +84,11 @@ class TestFastExp(TestFastBase):
         self.assertEqual(self.led4.hw_drivers['red'][0].number, '88120-0')
         self.assertEqual(self.led4.hw_drivers['green'][0].number, '88120-1')
         self.assertEqual(self.led4.hw_drivers['blue'][0].number, '88120-2')
-
         self.assertEqual(self.led5.hw_drivers['red'][0].number, '88121-1')
         self.assertEqual(self.led5.hw_drivers['green'][0].number, '88121-2')
         self.assertEqual(self.led5.hw_drivers['blue'][0].number, '88122-0')
-
-        # Intentionally-failing test to prove that third channel rollover has an issue
         self.assertEqual(self.led6.hw_drivers['red'][0].number, '89200-2')
         self.assertEqual(self.led6.hw_drivers['green'][0].number, '89201-0')
-        # Bug is generating as 202-0 instead of 201-1
         self.assertEqual(self.led6.hw_drivers['blue'][0].number, '89201-1')
 
 

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -122,6 +122,13 @@ class TestFastExp(TestFastBase):
         self.assertEqual(self.led29.hw_drivers['green'][0].number, '48009-2')
         self.assertEqual(self.led29.hw_drivers['blue'][0].number, '48009-1')
         self.assertEqual(self.led29.hw_drivers['white'][0].number, '4800A-2')
+        self.assertEqual(self.led30.hw_drivers['red'][0].number, 'B406B-0')
+        self.assertEqual(self.led30.hw_drivers['green'][0].number, 'B406B-1')
+        self.assertEqual(self.led30.hw_drivers['blue'][0].number, 'B406B-2')
+        self.assertEqual(self.led31.hw_drivers['red'][0].number, 'B406C-0')
+        self.assertEqual(self.led31.hw_drivers['green'][0].number, 'B406C-1')
+        self.assertEqual(self.led31.hw_drivers['blue'][0].number, 'B406C-2')
+
 
     def _test_led_colors(self):
 

--- a/mpf/tests/test_Spinners.py
+++ b/mpf/tests/test_Spinners.py
@@ -150,6 +150,35 @@ class TestSpinners(MpfTestCase):
         self.advance_time_and_run(0.3)
         self.assertEventCalled("spinner_spin2_idle")
 
+    def test_event_buffer(self):
+        self.mock_event("spinner_spin_with_buffer_active")
+        self.mock_event("spinner_spin_with_buffer_hit")
+
+        self.hit_and_release_switch("switch5")
+        self.assertEventCalled("spinner_spin_with_buffer_active")
+        self.assertEventCalled("spinner_spin_with_buffer_hit")
+        self.assertEqual({"hits": 1, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin_with_buffer_hit'])
+
+
+        self.mock_event("spinner_spin_with_buffer_hit")
+        self.hit_and_release_switch("switch5")
+        self.hit_and_release_switch("switch5")
+        self.hit_and_release_switch("switch5")
+        self.assertEventNotCalled("spinner_spin_with_buffer_hit")
+
+        self.advance_time_and_run(0.6)
+        self.assertEventCalled("spinner_spin_with_buffer_active")
+        self.assertEqual({"hits": 4, "change": 3, "label": None}, self._last_event_kwargs['spinner_spin_with_buffer_hit'])
+
+        self.mock_event("spinner_spin_with_buffer_hit")
+        self.hit_and_release_switch("switch5")
+        self.hit_and_release_switch("switch5")
+        self.assertEventNotCalled("spinner_spin_with_buffer_hit")
+
+        self.advance_time_and_run(0.5)
+        self.assertEventCalled("spinner_spin_with_buffer_active")
+        self.assertEqual({"hits": 6, "change": 2, "label": None}, self._last_event_kwargs['spinner_spin_with_buffer_hit'])
+
     def test_reset_when_inactive_false(self):
         self.mock_event("spinner_spin3_active")
         self.mock_event("spinner_spin3_hit")

--- a/mpf/tests/test_Spinners.py
+++ b/mpf/tests/test_Spinners.py
@@ -66,21 +66,21 @@ class TestSpinners(MpfTestCase):
         self.hit_and_release_switch("switch1")
         self.assertEventCalled("spinner_spin1_active")
         self.assertEventCalled("spinner_spin1_hit")
-        self.assertEqual({"hits": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
 
         self.hit_and_release_switch("switch1")
         self.advance_time_and_run(0.5)
-        self.assertEqual({"hits": 2, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 2, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
         self.assertEventNotCalled("spinner_spin1_inactive")
 
         self.hit_and_release_switch("switch1")
         self.advance_time_and_run(0.5)
-        self.assertEqual({"hits": 3, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 3, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
         self.assertEventNotCalled("spinner_spin1_inactive")
 
         self.hit_and_release_switch("switch1")
         self.advance_time_and_run(0.5)
-        self.assertEqual({"hits": 4, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
+        self.assertEqual({"hits": 4, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin1_hit'])
         self.assertEventNotCalled("spinner_spin1_inactive")
 
         self.advance_time_and_run(0.5)
@@ -101,25 +101,25 @@ class TestSpinners(MpfTestCase):
         self.assertEventCalled("spinner_spin2_active")
         self.assertEventCalled("spinner_spin2_hit")
         self.assertEventCalled("spinner_spin2_foo_hit")
-        self.assertEqual({"hits": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(0, self._events["spinner_spin2_bar_hit"])
 
         self.hit_and_release_switch("switch3")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 2, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 2, "change": 1, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(1, self._events["spinner_spin2_bar_hit"])
 
         self.hit_and_release_switch("switch3")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 3, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 3, "change": 1, "label": "bar"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(1, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
 
         self.hit_and_release_switch("switch2")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 4, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 4, "change": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(2, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
         self.assertEventNotCalled("spinner_spin2_inactive")
@@ -131,7 +131,7 @@ class TestSpinners(MpfTestCase):
         # Re-activate the spinner before it goes idle
         self.hit_and_release_switch("switch2")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": "foo"}, self._last_event_kwargs['spinner_spin2_hit'])
         self.assertEqual(3, self._events["spinner_spin2_foo_hit"])
         self.assertEqual(2, self._events["spinner_spin2_bar_hit"])
         # Active should be called again
@@ -159,17 +159,17 @@ class TestSpinners(MpfTestCase):
         self.hit_and_release_switch("switch4")
         self.assertEventCalled("spinner_spin3_active")
         self.assertEventCalled("spinner_spin3_hit")
-        self.assertEqual({"hits": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 1, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         self.assertEventNotCalled("spinner_spin3_inactive")
 
         self.hit_and_release_switch("switch4")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 2, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 2, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         self.assertEventNotCalled("spinner_spin3_inactive")
 
         self.hit_and_release_switch("switch4")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 3, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 3, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         self.assertEventNotCalled("spinner_spin3_inactive")
 
         self.advance_time_and_run(0.3)
@@ -179,7 +179,7 @@ class TestSpinners(MpfTestCase):
         # Re-activate the spinner before it goes idle
         self.hit_and_release_switch("switch4")
         self.advance_time_and_run(0.3)
-        self.assertEqual({"hits": 4, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
+        self.assertEqual({"hits": 4, "change": 1, "label": None}, self._last_event_kwargs['spinner_spin3_hit'])
         # Active should be called again
         self.assertEqual(2, self._events["spinner_spin3_active"])
         self.assertEqual(1, self._events["spinner_spin3_inactive"])

--- a/mpf/tests/test_Stepper.py
+++ b/mpf/tests/test_Stepper.py
@@ -1,3 +1,4 @@
+from mpf.core.placeholder_manager import NativeTypeTemplate
 from unittest.mock import MagicMock
 from mpf.tests.MpfTestCase import MpfTestCase
 
@@ -142,7 +143,7 @@ class TestStepper(MpfTestCase):
     def test_ball_search(self):
         stepper = self.machine.steppers["linearAxis_stepper"]
 
-        self.machine.playfields["playfield"].config['enable_ball_search'] = True
+        self.machine.playfields["playfield"].config['enable_ball_search'] = NativeTypeTemplate(True, self.machine)
         self.machine.playfields["playfield"].balls += 1
 
         event_future = self.machine.events.wait_for_event("stepper_linearAxis_stepper_ready")


### PR DESCRIPTION
This PR contains all of the changes from MPF 0.57.1 to 0.57.2

### New Features
* Switch `ignore_during_ball_search:` config option to prevent false positives during searches
* Switch support for `playfield:` config option to propagate to devices (drop targets, shots, etc.)
* Playfield `enable_ball_search:` now supports templates, e.g. `settings.enable_ball_search==1`
* OPP: Support for `WING_SOL_8` wings with up to 32 solenoids
* Virtual Pinball: Support for segment displays
* Spinners: `max_events_per_second:` config option to reduce event load during spins

### Improvements
* Playfield *playfield_active* event now includes the source of the active trigger
* Better (more reliable) suppression of switch hits from Drop Target firings during ball search with `switch.mute()`
* Better error messaging for ball search on a playfield without iterator devices
* Ball devices that mark playfield active can now inherit the playfield from their switch
* Switches no longer post active events during startup
* Shows now include debug logging for starting, stopping, and pausing

### Bug Fixes
* Fixed a bug in ball search phase/iteration counting that miscounted the number of phases and iterations to perform
* Fixed a bug in FAST LED channel numbering for rolling over channel offsets