### PR TITLE
Evaluate PluginPlayer Templates prior to BCP

### DIFF
--- a/mpf/config_players/plugin_player.py
+++ b/mpf/config_players/plugin_player.py
@@ -91,7 +91,7 @@ class PluginPlayer(DeviceConfigPlayer):
         for s, settings_dict in settings.items():
             for key, value in settings_dict.items():
                 if isinstance(value, (BaseTemplate, NativeTypeTemplate)):
-                    if not s in eval_settings:
+                    if s not in eval_settings:
                         eval_settings[s] = settings_dict.copy()
                     eval_settings[s][key] = value.evaluate(kwargs)
 

--- a/mpf/config_players/plugin_player.py
+++ b/mpf/config_players/plugin_player.py
@@ -1,6 +1,6 @@
 """Plugin config player."""
 from mpf.config_players.device_config_player import DeviceConfigPlayer
-from mpf.core.placeholder_manager import BaseTemplate
+from mpf.core.placeholder_manager import BaseTemplate, NativeTypeTemplate
 
 
 class PluginPlayer(DeviceConfigPlayer):
@@ -90,7 +90,7 @@ class PluginPlayer(DeviceConfigPlayer):
         eval_settings = {}
         for s, settings_dict in settings.items():
             for key, value in settings_dict.items():
-                if isinstance(value, BaseTemplate):
+                if isinstance(value, (BaseTemplate, NativeTypeTemplate)):
                     if not s in eval_settings:
                         eval_settings[s] = settings_dict.copy()
                     eval_settings[s][key] = value.evaluate(kwargs)

--- a/mpf/config_players/plugin_player.py
+++ b/mpf/config_players/plugin_player.py
@@ -1,5 +1,6 @@
 """Plugin config player."""
 from mpf.config_players.device_config_player import DeviceConfigPlayer
+from mpf.core.placeholder_manager import BaseTemplate
 
 
 class PluginPlayer(DeviceConfigPlayer):
@@ -85,9 +86,19 @@ class PluginPlayer(DeviceConfigPlayer):
         # this play event won't be swallowed.
         if '_from_bcp' in kwargs:
             del kwargs['_from_bcp']
+        # If any templates need evaluating, do so *before* sending via BCP
+        eval_settings = {}
+        for s, settings_dict in settings.items():
+            for key, value in settings_dict.items():
+                if isinstance(value, BaseTemplate):
+                    if not s in eval_settings:
+                        eval_settings[s] = settings_dict.copy()
+                    eval_settings[s][key] = value.evaluate(kwargs)
+
         self.machine.bcp.interface.bcp_trigger(
             name='{}_play'.format(self.show_section),
-            settings=settings, context=context, calling_context=calling_context,
+            settings={**settings, **eval_settings},
+            context=context, calling_context=calling_context,
             priority=priority, **kwargs)
 
     def clear_context(self, context):

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1699,7 +1699,7 @@ sound_player:
     pan: single|float_or_token|None
     loops: single|int_or_token|None
     priority: single|int_or_token|None
-    start_at: single|secs|None
+    start_at: single|template_secs|None
     fade_in: single|secs|None
     fade_out: single|secs|None
     about_to_finish_time: single|secs|-1

--- a/mpf/modes/attract/code/attract.py
+++ b/mpf/modes/attract/code/attract.py
@@ -2,6 +2,7 @@
 
 from mpf.modes.carousel.code.carousel import Carousel
 
+
 class Attract(Carousel):
 
     """Default mode running in a machine when a game is not in progress.


### PR DESCRIPTION
## Summary

This PR extends the behavior of PluginPlayer to find and evaluate placeholder templates prior to sending player events over BCP. The following PluginPlayers will be affected: **BusPlayer, SlidePlayer, SoundPlayer, WidgetPlayer**

### Examples

This new behavior works with both path-based templates like player variables, as well as event kwarg templates.

**Player Variable Example**
```
sound_player:
  mode_rampage_started:
    rampage_music:
      bus: music
      start_at: (current_player.rampage_music_last_played_time)
```

**Event Kwarg Example**
```
event_player:
  some_triggering_event:
    play_music_starting_at:
      the_time: 65


sound_player:
  play_music_starting_at:
    victory_music:
      bus: music
      start_at: (the_time)
```

### Nested Logic

PluginPlayer events are nested dictionaries because a triggering event may have multiple items to play (e.g. a mode_started event triggering both music and voice callouts via `sound_player`). Therefore this code must nest one level deep to look for placeholder templates on each played item.

For efficiency (?) a separate dictionary is made to hold the evaluated values and only item dicts that have templates will be copied and their values overridden. The `settings` argument comes from the raw parsed config itself, so it should _not_ be modified in place. Instead, the temporary evaluated dictionary is passed as additional args into the settings dict, preserving the original values with (hopefully) minimum overhead.

This feels a bit clunky but in the past MPF has been bottlenecked by huge numbers of `dict.copy()` and `dict.deepcopy()` calls, which were the primary function call during profiling. My hope is that the implementation here will be low-profile enough to have negligible impact in almost all cases, and the occasional dict copy for template evaluations is an acceptable price.

![evaluate me](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDh1MHVqNzA4Y2R2aDUwdDgyd2FueDE3c214aHd1ZXVyaHY5azBpMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/O62idzzWt6wIU/giphy.gif)