### PR TITLE
Add shot block test cases

### DIFF
--- a/mpf/tests/machine_files/shots/config/test_shot_groups.yaml
+++ b/mpf/tests/machine_files/shots/config/test_shot_groups.yaml
@@ -12,6 +12,10 @@ switches:
     number:
   switch_4:
     number:
+  switch_5:
+    number:
+  switch_6:
+    number:
   s_rotate_l:
     number:
   s_rotate_r:

--- a/mpf/tests/machine_files/shots/modes/base2/config/base2.yaml
+++ b/mpf/tests/machine_files/shots/modes/base2/config/base2.yaml
@@ -20,6 +20,10 @@ shots:
       light: tag1
   shot_4:
     switch: switch_1
+  shot_5:
+    switch: switch_5
+  shot_6:
+    switch: switch_6
   led_1:
     switch: switch_1
     show_tokens:

--- a/mpf/tests/machine_files/shots/modes/mode1/config/mode1.yaml
+++ b/mpf/tests/machine_files/shots/modes/mode1/config/mode1.yaml
@@ -24,6 +24,12 @@ shots:
   mode1_shot_3:
     switch: switch_3
     profile: mode1_shot_3
+  mode1_shot_5:
+    switch: switch_5
+    profile: mode1_shot_5
+  mode1_shot_6:
+    switch: switch_6
+    profile: mode1_shot_6
 
 shot_profiles:
   mode1_shot_2:
@@ -32,10 +38,21 @@ shot_profiles:
     - name: mode1_one
     - name: mode1_two
     - name: mode1_three
-  mode1_shot_3:
+  mode1_shot_3: # Test block: True
     show: rainbow2
     block: True
     states:
     - name: mode1_one
     - name: mode1_two
     - name: mode1_three
+  mode1_shot_5: # Test block: False
+    show: rainbow2
+    block: False
+    states:
+    - name: mode1_one
+    - name: mode1_two
+  mode1_shot_6: # Test block default
+    show: rainbow2
+    states:
+    - name: mode1_one
+    - name: mode1_two

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -29,7 +29,7 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run()
         self.assertIsNone(self.machine.game)
 
-    def test_block(self):
+    def test_block_true(self):
         self.mock_event("playfield_active")
         self.hit_and_release_switch("switch_3")
         self.advance_time_and_run(.1)
@@ -59,6 +59,68 @@ class TestShots(MpfTestCase):
 
         self.assertEqual("unlit", self.machine.shots["shot_3"].state_name)
         self.assertEqual("mode1_two", self.machine.shots["mode1_shot_3"].state_name)
+
+    def test_block_false(self):
+        self.mock_event("playfield_active")
+        self.hit_and_release_switch("switch_5")
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("playfield_active")
+
+        self.start_game()
+        self.assertEqual("unlit", self.machine.shots["shot_5"].state_name)
+
+        self.hit_and_release_switch("switch_5")
+        self.advance_time_and_run(.1)
+        self.assertTrue(self.machine.shots["shot_5"].enabled)
+        self.assertEqual("lit", self.machine.shots["shot_5"].state_name)
+
+        self.machine.shots["shot_5"].reset()
+        self.assertEqual("unlit", self.machine.shots["shot_5"].state_name)
+
+        # Start the mode and make sure those shots load
+        self.start_mode("mode1")
+
+        self.assertTrue(self.machine.shots["shot_5"].enabled)
+        self.assertTrue(self.machine.shots["mode1_shot_5"].enabled)
+        self.assertEqual("unlit", self.machine.shots["shot_5"].state_name)
+        self.assertEqual("mode1_one", self.machine.shots["mode1_shot_5"].state_name)
+
+        self.hit_and_release_switch("switch_5")
+        self.advance_time_and_run(.1)
+
+        self.assertEqual("lit", self.machine.shots["shot_5"].state_name)
+        self.assertEqual("mode1_two", self.machine.shots["mode1_shot_5"].state_name)
+
+    def test_block_default(self): #Default behaves as false
+        self.mock_event("playfield_active")
+        self.hit_and_release_switch("switch_6")
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("playfield_active")
+
+        self.start_game()
+        self.assertEqual("unlit", self.machine.shots["shot_6"].state_name)
+
+        self.hit_and_release_switch("switch_6")
+        self.advance_time_and_run(.1)
+        self.assertTrue(self.machine.shots["shot_6"].enabled)
+        self.assertEqual("lit", self.machine.shots["shot_6"].state_name)
+
+        self.machine.shots["shot_6"].reset()
+        self.assertEqual("unlit", self.machine.shots["shot_6"].state_name)
+
+        # Start the mode and make sure those shots load
+        self.start_mode("mode1")
+
+        self.assertTrue(self.machine.shots["shot_6"].enabled)
+        self.assertTrue(self.machine.shots["mode1_shot_6"].enabled)
+        self.assertEqual("unlit", self.machine.shots["shot_6"].state_name)
+        self.assertEqual("mode1_one", self.machine.shots["mode1_shot_6"].state_name)
+
+        self.hit_and_release_switch("switch_6")
+        self.advance_time_and_run(.1)
+
+        self.assertEqual("lit", self.machine.shots["shot_6"].state_name)
+        self.assertEqual("mode1_two", self.machine.shots["mode1_shot_6"].state_name)
 
     def test_loading_shots(self):
         # Make sure machine-wide shots load & mode-specific shots do not

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -29,98 +29,51 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run()
         self.assertIsNone(self.machine.game)
 
-    def test_block_true(self):
+    def block_test(self, switch, shot, should_block):
+        high_priority_shot = "mode1_" + shot
         self.mock_event("playfield_active")
-        self.hit_and_release_switch("switch_3")
+        self.hit_and_release_switch(switch)
         self.advance_time_and_run(.1)
         self.assertEventCalled("playfield_active")
 
         self.start_game()
-        self.assertEqual("unlit", self.machine.shots["shot_3"].state_name)
+        self.assertEqual("unlit", self.machine.shots[shot].state_name)
 
-        self.hit_and_release_switch("switch_3")
+        self.hit_and_release_switch(switch)
         self.advance_time_and_run(.1)
-        self.assertTrue(self.machine.shots["shot_3"].enabled)
-        self.assertEqual("lit", self.machine.shots["shot_3"].state_name)
+        self.assertFalse(self.machine.shots[high_priority_shot].enabled)
+        self.assertTrue(self.machine.shots[shot].enabled)
+        self.assertEqual("lit", self.machine.shots[shot].state_name)
 
-        self.machine.shots["shot_3"].reset()
-        self.assertEqual("unlit", self.machine.shots["shot_3"].state_name)
+        self.machine.shots[shot].reset()
+        self.assertEqual("unlit", self.machine.shots[shot].state_name)
 
         # Start the mode and make sure those shots load
         self.start_mode("mode1")
 
-        self.assertTrue(self.machine.shots["shot_3"].enabled)
-        self.assertTrue(self.machine.shots["mode1_shot_3"].enabled)
-        self.assertEqual("unlit", self.machine.shots["shot_3"].state_name)
-        self.assertEqual("mode1_one", self.machine.shots["mode1_shot_3"].state_name)
+        self.assertTrue(self.machine.shots[shot].enabled)
+        self.assertTrue(self.machine.shots[high_priority_shot].enabled)
+        self.assertEqual("unlit", self.machine.shots[shot].state_name)
+        self.assertEqual("mode1_one", self.machine.shots[high_priority_shot].state_name)
 
-        self.hit_and_release_switch("switch_3")
+        self.hit_and_release_switch(switch)
         self.advance_time_and_run(.1)
 
-        self.assertEqual("unlit", self.machine.shots["shot_3"].state_name)
-        self.assertEqual("mode1_two", self.machine.shots["mode1_shot_3"].state_name)
+        if should_block:
+            self.assertEqual("unlit", self.machine.shots[shot].state_name)
+        else:
+            self.assertEqual("lit", self.machine.shots[shot].state_name)
+
+        self.assertEqual("mode1_two", self.machine.shots[high_priority_shot].state_name)
+
+    def test_block_true(self):
+        self.block_test("switch_3", "shot_3", True)
 
     def test_block_false(self):
-        self.mock_event("playfield_active")
-        self.hit_and_release_switch("switch_5")
-        self.advance_time_and_run(.1)
-        self.assertEventCalled("playfield_active")
-
-        self.start_game()
-        self.assertEqual("unlit", self.machine.shots["shot_5"].state_name)
-
-        self.hit_and_release_switch("switch_5")
-        self.advance_time_and_run(.1)
-        self.assertTrue(self.machine.shots["shot_5"].enabled)
-        self.assertEqual("lit", self.machine.shots["shot_5"].state_name)
-
-        self.machine.shots["shot_5"].reset()
-        self.assertEqual("unlit", self.machine.shots["shot_5"].state_name)
-
-        # Start the mode and make sure those shots load
-        self.start_mode("mode1")
-
-        self.assertTrue(self.machine.shots["shot_5"].enabled)
-        self.assertTrue(self.machine.shots["mode1_shot_5"].enabled)
-        self.assertEqual("unlit", self.machine.shots["shot_5"].state_name)
-        self.assertEqual("mode1_one", self.machine.shots["mode1_shot_5"].state_name)
-
-        self.hit_and_release_switch("switch_5")
-        self.advance_time_and_run(.1)
-
-        self.assertEqual("lit", self.machine.shots["shot_5"].state_name)
-        self.assertEqual("mode1_two", self.machine.shots["mode1_shot_5"].state_name)
+        self.block_test("switch_5", "shot_5", False)
 
     def test_block_default(self): #Default behaves as false
-        self.mock_event("playfield_active")
-        self.hit_and_release_switch("switch_6")
-        self.advance_time_and_run(.1)
-        self.assertEventCalled("playfield_active")
-
-        self.start_game()
-        self.assertEqual("unlit", self.machine.shots["shot_6"].state_name)
-
-        self.hit_and_release_switch("switch_6")
-        self.advance_time_and_run(.1)
-        self.assertTrue(self.machine.shots["shot_6"].enabled)
-        self.assertEqual("lit", self.machine.shots["shot_6"].state_name)
-
-        self.machine.shots["shot_6"].reset()
-        self.assertEqual("unlit", self.machine.shots["shot_6"].state_name)
-
-        # Start the mode and make sure those shots load
-        self.start_mode("mode1")
-
-        self.assertTrue(self.machine.shots["shot_6"].enabled)
-        self.assertTrue(self.machine.shots["mode1_shot_6"].enabled)
-        self.assertEqual("unlit", self.machine.shots["shot_6"].state_name)
-        self.assertEqual("mode1_one", self.machine.shots["mode1_shot_6"].state_name)
-
-        self.hit_and_release_switch("switch_6")
-        self.advance_time_and_run(.1)
-
-        self.assertEqual("lit", self.machine.shots["shot_6"].state_name)
-        self.assertEqual("mode1_two", self.machine.shots["mode1_shot_6"].state_name)
+        self.block_test("switch_6", "shot_6", False)
 
     def test_loading_shots(self):
         # Make sure machine-wide shots load & mode-specific shots do not


### PR DESCRIPTION
I've been learning about shot blocking and I realized through testing that the MPF docs are incorrect (on https://github.com/missionpinball/mpf-docs/blob/main/docs/config/shot_profiles.md ) about the default behavior of Block.

In order to prove that the default behavior is as block: False instead of True, I've added test cases for the False and True options. (config_spec:1617 for shot_profiles:block shows the default to be false as well)