### PR TITLE
Bugfix bonus unset player vars

### DIFF
--- a/mpf/modes/bonus/code/bonus.py
+++ b/mpf/modes/bonus/code/bonus.py
@@ -91,11 +91,10 @@ class Bonus(Mode):
             self._subtotal()
             return
 
-        # Calling player.vars.get() instead of player.get() bypasses the
-        # auto-fill zero and will throw if there is no player variable.
-        # The fallback value of 1 is used for bonus entries that don't use
-        # a player score, which are multiplied by one to get the bonus.
-        hits = self.player.vars.get(entry['player_score_entry'], 1)
+        # If a player_score_entry is provided, use player getattr to get a
+        # fallback value of zero if the variable is not set. Otherwise
+        # use 1 as the multiplier for non-player-score bonuses.
+        hits = self.player[entry['player_score_entry']] if entry['player_score_entry'] else 1
         score = entry['score'].evaluate([]) * hits
 
         if (not score and entry['skip_if_zero']) or (score < 0 and entry['skip_if_negative']):

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -196,7 +196,8 @@ class HighScore(AsyncMode):
                     # ask player for initials if we do not know them
                     if not player.initials:
                         try:
-                            player.initials = await self._ask_player_for_initials(player, award_names[i], value, category_name)
+                            player.initials = await self._ask_player_for_initials(player, award_names[i],
+                                                                                  value, category_name)
                         except asyncio.TimeoutError:
                             del new_list[i]
                             # no entry when the player missed the timeout

--- a/mpf/platforms/fast/communicators/net_neuron.py
+++ b/mpf/platforms/fast/communicators/net_neuron.py
@@ -293,7 +293,7 @@ class FastNetNeuronCommunicator(FastSerialCommunicator):
         This will silently sync the switch.hw_state. If the logical state changes,
         it will process it like any switch change.
         """
-        for switch in self.machine.switches:
+        for switch in self.machine.switches.values():
             hw_state = self.platform.hw_switch_data[switch.hw_switch.number]
 
             if hw_state != switch.hw_state:

--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from base64 import b16decode
+from binascii import Error as binasciiError
 from importlib import import_module
 
 from packaging import version
@@ -176,7 +177,7 @@ class FastExpansionBoard:
 
                 try:
                     self.communicator.send_bytes(b16decode(f'{msg_header}{msg}'), log_msg)
-                except Exception as e:
+                except binasciiError as e:
                     self.log.error(
                         f"Error decoding the following message for board {breakout_address} : {msg_header}{msg}")
                     self.log.info("Attempted update that caused this error: %s", dirty_leds)

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -105,16 +105,16 @@ class VirtualHardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform,
 
             if 'virtual_platform_start_active_switches' in self.machine.config:
                 initial_active_switches = []
-                for switch in Util.string_to_list(self.machine.config['virtual_platform_start_active_switches']):
-                    if switch not in self.machine.switches:
+                for switch_name in Util.string_to_list(self.machine.config['virtual_platform_start_active_switches']):
+                    if switch_name not in self.machine.switches.keys():
                         if " " in switch:
                             self.raise_config_error("MPF no longer supports lists separated by space in "
                                                     "virtual_platform_start_active_switches. Please separate "
-                                                    "switches by comma: {}.".format(switch), 1)
+                                                    "switches by comma: {}.".format(switch_name), 1)
                         else:
                             self.raise_config_error("Switch {} used in virtual_platform_start_active_switches was not "
-                                                    "found in switches section.".format(switch), 1)
-                    initial_active_switches.append(self.machine.switches[switch].hw_switch.number)
+                                                    "found in switches section.".format(switch_name), 1)
+                    initial_active_switches.append(self.machine.switches[switch_name].hw_switch.number)
 
                 for k in self.hw_switches:
                     if k in initial_active_switches:

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -107,7 +107,7 @@ class VirtualHardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform,
                 initial_active_switches = []
                 for switch_name in Util.string_to_list(self.machine.config['virtual_platform_start_active_switches']):
                     if switch_name not in self.machine.switches.keys():
-                        if " " in switch:
+                        if " " in switch_name:
                             self.raise_config_error("MPF no longer supports lists separated by space in "
                                                     "virtual_platform_start_active_switches. Please separate "
                                                     "switches by comma: {}.".format(switch_name), 1)

--- a/mpf/plugins/platform_integration_test_runner.py
+++ b/mpf/plugins/platform_integration_test_runner.py
@@ -227,7 +227,7 @@ class MpfPlatformIntegrationTestRunner(MpfPlugin):
         drain_switches = self.machine.ball_devices.items_tagged('drain')[0].config.get('ball_switches')
         self.info_log("Found drain switches: %s of type %s", drain_switches, type(drain_switches))
         # If there's only one drain switch it might be a single value, rather than a list
-        drain_switch = drain_switches if type(drain_switches) is str else drain_switches[-1]
+        drain_switch = drain_switches if isinstance(drain_switches, str) else drain_switches[-1]
         self.info_log("Setting drain switch '%s' to zero", drain_switch)
         self.set_switch_sync(drain_switch, 0)
         await asyncio.sleep(0.25)

--- a/mpf/tests/machine_files/bonus/modes/bonus/config/bonus.yaml
+++ b/mpf/tests/machine_files/bonus/modes/bonus/config/bonus.yaml
@@ -16,3 +16,5 @@ mode_settings:
         score: 5000
         skip_if_zero: false
         player_score_entry: undefined_var
+      - event: bonus_static
+        score: 2000

--- a/mpf/tests/machine_files/bonus/modes/bonus/config/bonus.yaml
+++ b/mpf/tests/machine_files/bonus/modes/bonus/config/bonus.yaml
@@ -12,3 +12,7 @@ mode_settings:
         score: 5000
         player_score_entry: modes
         reset_player_score_entry: False
+      - event: bonus_undefined_var
+        score: 5000
+        skip_if_zero: false
+        player_score_entry: undefined_var

--- a/mpf/tests/test_Bonus.py
+++ b/mpf/tests/test_Bonus.py
@@ -39,6 +39,7 @@ class TestBonusMode(MpfTestCase):
         self.mock_event("bonus_ramps")
         self.mock_event("bonus_modes")
         self.mock_event("bonus_undefined_var")
+        self.mock_event("bonus_static")
         self.mock_event("bonus_subtotal")
         self.mock_event("bonus_multiplier")
         self.mock_event("bonus_total")
@@ -81,10 +82,12 @@ class TestBonusMode(MpfTestCase):
         self.assertEqual(2, self._last_event_kwargs["bonus_modes"]["hits"])
         self.assertEqual(0, self._last_event_kwargs["bonus_undefined_var"]["score"])
         self.assertEqual(0, self._last_event_kwargs["bonus_undefined_var"]["hits"])
-        self.assertEqual(13000, self._last_event_kwargs["bonus_subtotal"]["score"])
+        self.assertEqual(2000, self._last_event_kwargs["bonus_static"]["score"])
+        self.assertEqual(1, self._last_event_kwargs["bonus_static"]["hits"])
+        self.assertEqual(15000, self._last_event_kwargs["bonus_subtotal"]["score"])
         self.assertEqual(5, self._last_event_kwargs["bonus_multiplier"]["multiplier"])
-        self.assertEqual(65000, self._last_event_kwargs["bonus_total"]["score"])
-        self.assertEqual(66337, self.machine.game.player.score)
+        self.assertEqual(75000, self._last_event_kwargs["bonus_total"]["score"])
+        self.assertEqual(76337, self.machine.game.player.score)
 
         # check resets
         self.assertEqual(0, self.machine.game.player.ramps)
@@ -105,10 +108,10 @@ class TestBonusMode(MpfTestCase):
         self.assertEqual(0, self._last_event_kwargs["bonus_ramps"]["hits"])
         self.assertEqual(10000, self._last_event_kwargs["bonus_modes"]["score"])
         self.assertEqual(2, self._last_event_kwargs["bonus_modes"]["hits"])
-        self.assertEqual(10000, self._last_event_kwargs["bonus_subtotal"]["score"])
+        self.assertEqual(12000, self._last_event_kwargs["bonus_subtotal"]["score"])
         self.assertEqual(5, self._last_event_kwargs["bonus_multiplier"]["multiplier"])
-        self.assertEqual(50000, self._last_event_kwargs["bonus_total"]["score"])
-        self.assertEqual(116337, self.machine.game.player.score)
+        self.assertEqual(60000, self._last_event_kwargs["bonus_total"]["score"])
+        self.assertEqual(136337, self.machine.game.player.score)
 
         # multiplier should stay the same
         self.assertEqual(0, self.machine.game.player.ramps)
@@ -132,6 +135,7 @@ class TestBonusMode(MpfTestCase):
         self.mock_event("bonus_ramps")
         self.mock_event("bonus_modes")
         self.mock_event("bonus_undefined_var")
+        self.mock_event("bonus_static")
         self.mock_event("bonus_subtotal")
         self.mock_event("bonus_multiplier")
         self.mock_event("bonus_total")
@@ -163,6 +167,12 @@ class TestBonusMode(MpfTestCase):
 
         self.advance_time_and_run(.5)
         self.assertEventCalled('bonus_undefined_var')
+        self.assertEventNotCalled('bonus_subtotal')
+        self.assertEventNotCalled('bonus_multiplier')
+        self.assertEventNotCalled('bonus_total')
+
+        self.advance_time_and_run(.5)
+        self.assertEventCalled('bonus_static')
         self.assertEventNotCalled('bonus_subtotal')
         self.assertEventNotCalled('bonus_multiplier')
         self.assertEventNotCalled('bonus_total')

--- a/mpf/tests/test_Bonus.py
+++ b/mpf/tests/test_Bonus.py
@@ -38,6 +38,7 @@ class TestBonusMode(MpfTestCase):
     def testBonus(self):
         self.mock_event("bonus_ramps")
         self.mock_event("bonus_modes")
+        self.mock_event("bonus_undefined_var")
         self.mock_event("bonus_subtotal")
         self.mock_event("bonus_multiplier")
         self.mock_event("bonus_total")
@@ -78,6 +79,8 @@ class TestBonusMode(MpfTestCase):
         self.assertEqual(3, self._last_event_kwargs["bonus_ramps"]["hits"])
         self.assertEqual(10000, self._last_event_kwargs["bonus_modes"]["score"])
         self.assertEqual(2, self._last_event_kwargs["bonus_modes"]["hits"])
+        self.assertEqual(0, self._last_event_kwargs["bonus_undefined_var"]["score"])
+        self.assertEqual(0, self._last_event_kwargs["bonus_undefined_var"]["hits"])
         self.assertEqual(13000, self._last_event_kwargs["bonus_subtotal"]["score"])
         self.assertEqual(5, self._last_event_kwargs["bonus_multiplier"]["multiplier"])
         self.assertEqual(65000, self._last_event_kwargs["bonus_total"]["score"])
@@ -128,6 +131,7 @@ class TestBonusMode(MpfTestCase):
         self.mock_event("bonus_start")
         self.mock_event("bonus_ramps")
         self.mock_event("bonus_modes")
+        self.mock_event("bonus_undefined_var")
         self.mock_event("bonus_subtotal")
         self.mock_event("bonus_multiplier")
         self.mock_event("bonus_total")
@@ -153,6 +157,12 @@ class TestBonusMode(MpfTestCase):
 
         self.post_event('flipper_cancel', .1)
         self.assertEventCalled('bonus_modes')
+        self.assertEventNotCalled('bonus_subtotal')
+        self.assertEventNotCalled('bonus_multiplier')
+        self.assertEventNotCalled('bonus_total')
+
+        self.advance_time_and_run(.5)
+        self.assertEventCalled('bonus_undefined_var')
         self.assertEventNotCalled('bonus_subtotal')
         self.assertEventNotCalled('bonus_multiplier')
         self.assertEventNotCalled('bonus_total')


### PR DESCRIPTION
### Summary

This PR fixes a bug in how bonus scores are calculated for player variables. Includes tests to validate.

Currently, MPF does a single evaluation on bonus entries to look for player vars, and if the player variable is not set then it assumes that the bonus entry is static and not variable-dependent. This is the correct behavior for entries without `player_score_entry`, but erroneously includes the bonus score for entries that have `player_score_entry` but that entry variable is not defined on the player. In either case, the bonus calculation falls back to a multiplier value of 1 for calculating the bonus score.

### The Fix

This PR improves the logic to only look for a player variable if `player_score_entry` is defined, and to accept the player fallback value of 0 for the multiplier. If `player_score_entry` is not defined, then a fallback value of 1 is used.

With this change, bonus-driving player variables no longer need to be explicitly initialized in the `player_vars:` config section and will behave as expected.

*Also, corrects a few leftover attributes lookups that should not iterate over collections directly.* 

![](https://y.yarn.co/b004b40a-16a1-43c1-b95c-cc0558f8cdd7_text.gif)