### PR TITLE
Segment display replace

### DIFF
--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -161,7 +161,7 @@ class SegmentDisplay(SystemWideDevice):
             flash_mask = self._current_state.flash_mask
         if not color:
             color = self._current_state.text.get_colors()
-        
+
         new_text = TextTemplate(self.machine, text).evaluate({})
         text = SegmentDisplayText.from_str(new_text, self.size, self.config['integrated_dots'],
                                            self.config['integrated_commas'], self.config['use_dots_for_commas'],

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -178,7 +178,7 @@ class SegmentDisplay(SystemWideDevice):
     def remove_text_by_key(self, key: Optional[str]):
         """Remove entry from text stack."""
         if self.config['update_method'] != "stack":
-            self.info_log("Segment display 'remove' action is TBD.")
+            self.add_text("")
             return
 
         if key in self._text_stack:

--- a/mpf/devices/segment_display/segment_display.py
+++ b/mpf/devices/segment_display/segment_display.py
@@ -155,6 +155,13 @@ class SegmentDisplay(SystemWideDevice):
             raise ValueError(f"Unknown update_method '{self.config['update_method']}' for segment display {self.name}")
 
         # For the replace-text update method, skip the stack and write straight to the display
+        if flashing is None:
+            flashing = self._current_state.flashing
+        if flash_mask is None:
+            flash_mask = self._current_state.flash_mask
+        if not color:
+            color = self._current_state.text.get_colors()
+        
         new_text = TextTemplate(self.machine, text).evaluate({})
         text = SegmentDisplayText.from_str(new_text, self.size, self.config['integrated_dots'],
                                            self.config['integrated_commas'], self.config['use_dots_for_commas'],


### PR DESCRIPTION
This PR addresses issue #1839. The newly added replace feature ([https://github.com/missionpinball/mpf/pull/1779](Segment Displays: Stack vs Replace Option).

This update using the current states color, flashing and flash_mask settings for the incoming text if non are specified on the segment_display_player. Without this, the text isn't displayed due the the color being missing and the text is set to flash.

Additionally this update removes the text from the display when the update method is not stack.