### PR TITLE
Backport MPF 0.80 Updates to (dev) 0.57

### DIFF
--- a/mpf/core/bcp/bcp_interface.py
+++ b/mpf/core/bcp/bcp_interface.py
@@ -101,10 +101,10 @@ class BcpInterface(MpfController):
         if not self.machine.bcp.transport.get_transports_for_handler(event):
             self.machine.events.remove_handler_by_event(event=event, handler=self.bcp_trigger)
 
-    async def _bcp_receive_set_machine_var(self, client, name, value):
+    async def _bcp_receive_set_machine_var(self, client, name, value, persist=False):
         """Set machine var via bcp."""
         del client
-        self.machine.variables.set_machine_var(name, value)
+        self.machine.variables.set_machine_var(name, value, persist)
         # document variables injected by MC
         '''machine_var: mc_version
 
@@ -458,8 +458,8 @@ class BcpInterface(MpfController):
             self.machine.register_monitor('machine_vars', self._machine_var_change)
 
         # Send initial machine variable values
-        for s in ("standard", "feature", "game", "coin"):
-            self._send_machine_vars(client, setting_type=s)
+        self._send_machine_vars(client)
+        self._send_machine_settings(client)
 
         # Establish handler for machine variable changes
         self.machine.bcp.transport.add_handler_to_transport("_machine_vars", client)
@@ -471,10 +471,14 @@ class BcpInterface(MpfController):
         if not self.machine.bcp.transport.get_transports_for_handler("_machine_vars"):
             self.machine.machine_var_monitor = False
 
-    def _send_machine_vars(self, client, setting_type=None):
-        self.machine.bcp.transport.send_to_client(
-            client, bcp_command='settings',
-            settings=Util.convert_to_simply_type(self.machine.settings.get_settings(setting_type)))
+    def _send_machine_settings(self, client, setting_type=None):
+        settings = [setting_type] if setting_type else ["standard", "feature", "game", "coin", "hw_volume"]
+        for s in settings:
+            self.machine.bcp.transport.send_to_client(
+                client, bcp_command='settings',
+                settings=Util.convert_to_simply_type(self.machine.settings.get_settings(s)))
+
+    def _send_machine_vars(self, client):
         for var_name, settings in self.machine.variables.machine_vars.items():
             self.machine.bcp.transport.send_to_client(client, bcp_command='machine_variable',
                                                       name=var_name,

--- a/mpf/core/crash_reporter.py
+++ b/mpf/core/crash_reporter.py
@@ -176,7 +176,7 @@ def analyze_traceback(tb, inspection_level=None, limit=None):
 
 
 def _send_crash_report(report, reporting_url):
-    r = requests.post(reporting_url, json=report)
+    r = requests.post(reporting_url, json=report, timeout=60)
     if r.status_code != 200:
         print("Failed to send report. Got response code {}. Error: {}", r.status_code, r.content)
     else:

--- a/mpf/core/machine_vars.py
+++ b/mpf/core/machine_vars.py
@@ -93,6 +93,11 @@ class MachineVariables(LogMixin):
 
         desc: Architecture of your machine (32bit/64bit).
         '''
+        self.set_machine_var(name="log_file_path", value=self.machine.options.get('full_logfile_path', ""))
+        '''machine_var: log_file_path
+
+        desc: Absolute path of the file log for the current running game.
+        '''
 
     def __getitem__(self, key):
         """Allow the user to access a machine variable with []. This would be used is machine.variables["var_name"]."""
@@ -177,6 +182,9 @@ class MachineVariables(LogMixin):
         ----
             name: String name of the variable you're setting the value for.
             value: The value you're setting. This can be any Type.
+            persist: Whether to persist this machine var to disk. Only
+                applies to new/unconfigured vars; vars defined in the
+                machine_vars config will use their config setting.
         """
         if name not in self.machine_vars:
             self.configure_machine_var(name=name, persist=persist)

--- a/mpf/devices/shot_group.py
+++ b/mpf/devices/shot_group.py
@@ -47,7 +47,7 @@ class ShotGroup(ModeDevice):
         self.rotation_pattern = deque(self.profile.config['rotation_pattern'])
         self.rotation_enabled = not self.config['enable_rotation_events']
         for shot in self.config['shots']:
-            self.machine.events.add_handler("{}_hit".format(shot.name), self._hit)
+            self.machine.events.add_handler("{}_hit".format(shot.name), self._hit, shot=shot.name)
             self.machine.events.add_handler("player_shot_{}".format(shot.name), self._check_for_complete)
 
     def device_removed_from_mode(self, mode):
@@ -145,7 +145,7 @@ class ShotGroup(ModeDevice):
         for shot in self.config['shots']:
             shot.restart()
 
-    def _hit(self, advancing, **kwargs):
+    def _hit(self, advancing, shot, **kwargs):
         """One of the member shots in this shot group was hit.
 
         Args:
@@ -157,12 +157,12 @@ class ShotGroup(ModeDevice):
             }
         """
         del advancing
-        self.machine.events.post(self.name + '_hit')
+        self.machine.events.post(self.name + '_hit', shot=shot)
         '''event: (name)_hit
         desc: A member shots in the shot group called (name)
         has been hit.
         '''
-        self.machine.events.post("{}_{}_hit".format(self.name, kwargs['state']))
+        self.machine.events.post("{}_{}_hit".format(self.name, kwargs['state']), shot=shot)
         '''event: (name)_(state)_hit
         desc: A member shot with state (state) in the shot group (name)
         has been hit.

--- a/mpf/modes/attract/code/attract.py
+++ b/mpf/modes/attract/code/attract.py
@@ -1,9 +1,9 @@
 """Contains the Attract class which is the attract mode in a pinball machine."""
 
-from mpf.core.mode import Mode
+from mpf.modes.carousel.code.carousel import Carousel
 
 
-class Attract(Mode):
+class Attract(Carousel):
 
     """Default mode running in a machine when a game is not in progress.
 
@@ -21,6 +21,13 @@ class Attract(Mode):
         self.start_button_pressed_time = 0.0
         self.start_hold_time = 0.0
         self.start_buttons_held = list()
+
+    def mode_init(self):
+        """Initialize the mode and handle missing carousel items."""
+        try:
+            super().mode_init()
+        except AssertionError:
+            pass
 
     def mode_start(self, **kwargs):
         """Start the attract mode."""
@@ -49,6 +56,10 @@ class Attract(Mode):
             for playfield in self.machine.playfields.values():
                 playfield.ball_search.enable()
                 playfield.ball_search.start()
+
+        # Check for carousel items
+        if self._all_items:
+            super().mode_start(**kwargs)
 
     def start_button_pressed(self):
         """Handle start button press.

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -271,6 +271,7 @@ class HighScore(AsyncMode):
             input_initials = choice(unused_initials)
         return input_initials
 
+    # pylint: disable-msg=too-many-arguments
     async def _show_award_slide(self, player_num, player_name: str, category_name: str, award: str, value: int) -> None:
         if not self.high_score_config['award_slide_display_time']:
             return

--- a/mpf/tests/machine_files/fast/config/audio.yaml
+++ b/mpf/tests/machine_files/fast/config/audio.yaml
@@ -22,6 +22,14 @@ fast:
     power_pulse_time: 98
     reset_pulse_time: 97
 
+machine_vars:
+  fast_audio_sub_volume:
+    initial_value: 9
+  fast_audio_main_volume:
+    initial_value: 8
+  fast_audio_headphones_volume:
+    initial_value: 10
+
 variable_player:
   increase_main_volume:
     fast_audio_main_volume:

--- a/mpf/tests/machine_files/fast/config/audio2.yaml
+++ b/mpf/tests/machine_files/fast/config/audio2.yaml
@@ -27,6 +27,7 @@ fast:
       - 14
       - 15
     headphones_level: line
+    link_sub_to_main: true
 
 machine_vars:
   fast_audio_main_volume:

--- a/mpf/tests/test_Fast_Audio.py
+++ b/mpf/tests/test_Fast_Audio.py
@@ -25,10 +25,15 @@ class TestFastAudio(TestFastBase):
             self.serial_connections['aud'].autorespond_commands['WD:3E8'] = 'WD:3E8,03'
 
         else:
-            self.serial_connections['aud'].expected_commands = {'AM:0B':'AM:0B',
-                                                                'AV:08':'AV:08',
-                                                                'AS:09':'AS:09',
-                                                                'AH:0A':'AH:0A',}
+            self.serial_connections['aud'].expected_commands = {
+                # 'AV:00':'AV:00',
+                # 'AS:00':'AS:00',
+                # 'AH:00':'AH:00',
+                'AM:0B':'AM:0B',
+                'AV:08':'AV:08',
+                'AS:09':'AS:09',
+                'AH:0A':'AH:0A',
+            }
 
     def test_audio_basics(self):
 
@@ -68,10 +73,6 @@ class TestFastAudio(TestFastBase):
         self.assertTrue(fast_audio.communicator.amps['main']['enabled'])
         self.assertTrue(fast_audio.communicator.amps['sub']['enabled'])
         self.assertTrue(fast_audio.communicator.amps['headphones']['enabled'])
-
-        self.assertFalse(fast_audio.amps['main']['link_to_main'])
-        self.assertFalse(fast_audio.amps['sub']['link_to_main'])
-        self.assertFalse(fast_audio.amps['headphones']['link_to_main'])
 
         # Change the volume var and make sure it's reflected in the hardware
         self.aud_cpu.expected_commands['AV:0D'] = 'AV:0D'
@@ -113,9 +114,13 @@ class TestFastAudio(TestFastBase):
     @test_config('audio2.yaml')
     def test_machine_var_loading(self):
         fast_audio = self.machine.default_platform.audio_interface
+        self.advance_time_and_run()
         self.assertEqual(15, self.machine.variables.get_machine_var('fast_audio_main_volume'))
+        self.assertEqual(15, fast_audio.get_volume('main'))
         self.assertEqual(15, fast_audio.communicator.amps['main']['volume'])
+        # sub has a machine value set in the configs, which is persisted
+        self.assertEqual(2, self.machine.variables.get_machine_var('fast_audio_sub_volume'))
         # sub is linked to main, so it will be 15 even though the config value is 2
-        self.assertEqual(15, self.machine.variables.get_machine_var('fast_audio_sub_volume'))
+        self.assertEqual(15, fast_audio.get_volume('main'))
         self.assertEqual(15, fast_audio.communicator.amps['sub']['volume'])
         self.assertEqual(17, self.machine.variables.get_machine_var('fast_audio_headphones_volume'))


### PR DESCRIPTION
This PR backports some improvements from the 0.80 branch into dev for release in MPF 0.57.

### BCP Machine Vars and Settings

This PR fixes a bug where the machine variables were sent to a BCP client repeatedly, due to an iteration mistake. It also improves the schema for how settings are transported over BCP to better group them by setting type.

### Attract Mode Carousel

This PR changes the default Attract mode to inherit from Carousel, enabling an attract carousel without the addition of a dedicated mode. Attract mode includes custom code for triggering a game start, so users can't simply extend Attract from Carousel without losing that functionality. With this PR, the default Attract mode handles both. If no carousel is provided in the `mode_settings:`, the carousel functionality is ignored.

### FAST Audio Board

This PR improves the serial handling and persistence of FAST Audio board volume levels by exposing them as machine variables.

### Shot Group Events

This PR extends the shot_group hit event to include the shot that was hit, for better control of events triggered by shot group hits.

![get it!](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExYzJsOHBpcmJpMmoxZTVrYnhod2s3cGxkdTZwdHhoYTB2ZXNjbm0zayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/2UyZpqgmaKZvq/giphy.gif)