### PR TITLE
Timer event order pollution

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -23,6 +23,7 @@ pylint:
   disable:
     - pointless-string-statement  # pointless statement, which is how our event docstrings are seen
     - too-few-public-methods
+    - too-many-positional-arguments  # many methods have many positional args
     - unsubscriptable-object    # broken on python 3.9
     # The following linter rules are disabled to make a refactor managable in chunks
     - consider-using-f-string  # temporarily disabling due to the 900+ instances to be replaced

--- a/mpf/devices/timer.py
+++ b/mpf/devices/timer.py
@@ -144,8 +144,8 @@ class Timer(ModeDevice):
     def _setup_control_events(self, event_list):
         self.debug_log("Setting up control events")
 
-        kwargs = {}
         for entry in event_list:
+            kwargs = {}
             if entry['action'] in ('add', 'subtract', 'jump', 'pause', 'set_tick_interval'):
                 handler = getattr(self, entry['action'])
                 kwargs = {'timer_value': entry['value']}

--- a/mpf/modes/service/code/service.py
+++ b/mpf/modes/service/code/service.py
@@ -560,6 +560,7 @@ sort_devices_by_number: single|bool|True
             return
 
         items.sort(key=lambda x: x.chain)
+        return items
 
     async def _volume_menu(self, platform=None):
         position = 0

--- a/mpf/tests/machine_files/timer/modes/mode_with_timers/config/mode_with_timers.yaml
+++ b/mpf/tests/machine_files/timer/modes/mode_with_timers/config/mode_with_timers.yaml
@@ -51,6 +51,11 @@ timers:
         tick_interval: 1s
         start_running: no
         control_events:
+            # Keep this event before the reset event to catch
+            # a regression about the order of timer events
+            - event: jump_timer_up
+              action: jump
+              value: 5
             - event: start_timer_up
               action: start
             - event: reset_timer_up
@@ -59,9 +64,6 @@ timers:
               action: stop
             - event: restart_timer_up
               action: restart
-            - event: jump_timer_up
-              action: jump
-              value: 5
             - event: jump_over_max_timer_up
               action: jump
               value: 20


### PR DESCRIPTION
This PR fixes a bug (found by https://groups.google.com/g/mpf-users/c/JtZxG7oOceQ/m/P3htggdmAwAJ) where the order of a Timer's `control_events` could cause a crash.

### The Problem

There has been a longstanding (7+ years) flaw in the timer control event code where the event handler kwargs were a singleton dictionary, so each event handler would alter/amend the same dictionary and attach it as kwargs. This oversight slipped by largely unnoticed until earlier this year, when the timer code was revamped to pass more event kwargs through (to support dynamic placeholder values for tick value, tick interval, et cetera., see #1761).

Even then, this oversight slipped through because the timer kwarg pollution is dependent on the order in which the timer's `control_events` are listed. Only if a control event with a `value` comes *before* a reset/restart will the former event's *timer_value* kwarg be polluted into the reset/restart handler, causing a duplicate argument error.

### The Fix

This PR simply moves the `kwargs = {}` declaration to be *inside* the control event iteration block, so each control event starts with a fresh, empty, unpolluted kwarg dictionary. With this change, the order of control events doesn't matter and pollution is avoided.

![tick tock tick tock](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExY3J2Z29oaHcwZGc4Y3g4eXRseGZhY2kzdnlzZWxsN251bDUzYmJsZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/a2SR6Ag8ChUlO/giphy.gif)