### PR TITLE
FAST-0061 Stepper Controller

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.3.dev1'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.4.dev1'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -748,9 +748,9 @@ fast_servos:
     min_us: single|int|1000
     home_us: single|int|1500
     max_runtime: single|ms|2000  # 65535 max
-fast_steppers:
+fast_stepper_settings:
     __valid_in__: machine                 # todo add to validator
-    __allow_others__:
+    default_speed: single|int|600
 file_shows:
     __valid_in__: machine, mode                      # todo add to validator
     __type__: config_dict

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -748,6 +748,9 @@ fast_servos:
     min_us: single|int|1000
     home_us: single|int|1500
     max_runtime: single|ms|2000  # 65535 max
+fast_steppers:
+    __valid_in__: machine                 # todo add to validator
+    __allow_others__:
 file_shows:
     __valid_in__: machine, mode                      # todo add to validator
     __type__: config_dict

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1946,6 +1946,7 @@ steppers:
     __type__: device
     named_positions: dict|float:str|None
     home_events: event_handler|event_handler:ms|None
+    home_on_startup: single|bool|true
     homing_mode: single|enum(hardware,switch)|hardware
     homing_switch: single|machine(switches)|None
     homing_direction: single|enum(clockwise,counterclockwise)|clockwise

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1944,24 +1944,28 @@ spinners:
 steppers:
     __valid_in__: machine
     __type__: device
-    named_positions: dict|float:str|None
     home_events: event_handler|event_handler:ms|None
     home_on_startup: single|bool|true
     homing_mode: single|enum(hardware,switch)|hardware
     homing_switch: single|machine(switches)|None
     homing_direction: single|enum(clockwise,counterclockwise)|clockwise
+    homing_speed: single|int|None
     pos_min: single|int|0
     pos_max: single|int|1000
     ball_search_min: single|int|0
     ball_search_max: single|int|1
     ball_search_wait: single|ms|5s
     include_in_ball_search: single|bool|true
-    relative_positions: dict|float:str|None
+    relative_positions: dict|float:subconfig(stepper_position_settings)|None
     reset_position: single|int|0
     reset_events: event_handler|event_handler:ms|machine_reset_phase_3, ball_starting, ball_will_end, service_mode_entered
+    named_positions: dict|float:subconfig(stepper_position_settings)|None
     number: single|str|
     platform: single|str|None
     platform_settings: single|dict|None
+stepper_position_settings:
+    event: single|str|
+    speed: single|int|None
 spike_stepper_settings:
     homing_speed: single|int|10
     speed: single|int|20

--- a/mpf/devices/servo.py
+++ b/mpf/devices/servo.py
@@ -80,8 +80,10 @@ class Servo(SystemWideDevice):
 
         This should either home the servo or disable the output.
         """
-        self.debug_log("Stopping servo")
-        self.hw_servo.stop()
+        # A crash may occur during startup before hw_servo is instantiated
+        if self.hw_servo:
+            self.debug_log("Stopping servo")
+            self.hw_servo.stop()
 
     @event_handler(5)
     def _position_event(self, position, **kwargs):

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -92,7 +92,7 @@ class Stepper(SystemWideDevice):
             if cfg in config:
                 for pos, value in config[cfg].items():
                     if isinstance(value, str):
-                        config[cfg][pos] = { 'event': value }
+                        config[cfg][pos] = {'event': value}
         config = super().validate_and_parse_config(config, is_mode_config, debug_prefix)
         platform = self.machine.get_platform_sections(
             'stepper_controllers', getattr(config, "platform", None))

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -94,9 +94,13 @@ class Stepper(SystemWideDevice):
         # wait for switches to be initialized
         await self.machine.events.wait_for_event("init_phase_3")
 
-        # first home the stepper
-        self.info_log("Initializing stepper and homing.")
-        await self._home()
+        if self.config['home_on_startup']:
+            # first home the stepper
+            self.info_log("Initializing stepper and homing.")
+            await self._home()
+        else:
+            self.info_log("Initializing stepper but will not home.")
+            self._is_homed = True
 
         # run the loop at least once
         self._is_moving.set()

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -87,14 +87,12 @@ class Stepper(SystemWideDevice):
     def validate_and_parse_config(self, config, is_mode_config, debug_prefix: str = None):
         """Validate stepper config."""
         # If positions are just strings, expand them into strings and speeds
-        print(f"Initial stepper config: {config}")
+        # TODO: Figure out how to use express_config() to map this
         for cfg in ('named_positions', 'relative_positions'):
             if cfg in config:
                 for pos, value in config[cfg].items():
-                    print(f"Checking key {pos} with value {value}")
                     if isinstance(value, str):
                         config[cfg][pos] = { 'event': value }
-        print(f"Reworked stepper config: {config}")
         config = super().validate_and_parse_config(config, is_mode_config, debug_prefix)
         platform = self.machine.get_platform_sections(
             'stepper_controllers', getattr(config, "platform", None))

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -135,6 +135,9 @@ class Stepper(SystemWideDevice):
                               delta, target_position, self._current_position)
                 # move stepper
                 self.hw_stepper.move_rel_pos(delta, self._target_speed)
+                # Clear the speed override here, in case a subsequent move wants
+                # to set one before this one finishes.
+                self._target_speed = None
                 # wait for the move to complete
                 await self.hw_stepper.wait_for_move_completed()
             else:
@@ -142,15 +145,13 @@ class Stepper(SystemWideDevice):
                               self._target_position)
             # set current position
             self._current_position = target_position
-            # Clear the speed override
-            self._target_speed = None
             # post ready event
             self._post_ready_event()
 
     def _move_to_absolute_position(self, position, speed=None):
         """Move stepper to position."""
-        self.info_log("%s: Moving to absolute position %s. Current position: %s",
-                      self.hw_stepper, position, self._current_position)
+        self.info_log("Moving to absolute position %s. Current position: %s",
+                      position, self._current_position)
         if self.config['pos_min'] <= position <= self.config['pos_max']:
             self._target_position = position
             self._target_speed = speed

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -62,7 +62,7 @@ class Stepper(SystemWideDevice):
             self.machine.events.add_handler(self.config['relative_positions'][position]['event'],
                                             self.event_move_to_position,
                                             position=position,
-                                            speed=[self.config['relative_positions'][position]['speed']],
+                                            speed=self.config['relative_positions'][position]['speed'],
                                             is_relative=True)
 
         if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -194,7 +194,9 @@ class Stepper(SystemWideDevice):
 
     def stop_device(self):
         """Stop motor."""
-        self.hw_stepper.stop()
+        # A crash during startup may not have initialized the hw_stepper yet
+        if self.hw_stepper:
+            self.hw_stepper.stop()
         self._is_moving.clear()
         if self._move_task:
             self._move_task.cancel()

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -132,7 +132,7 @@ class Stepper(SystemWideDevice):
 
     def _move_to_absolute_position(self, position):
         """Move stepper to position."""
-        self.info_log("Moving to absolute position %s. Current position: %s",
+        self.info_log("%s: Moving to absolute position %s. Current position: %s",
                       self.hw_stepper, position, self._current_position)
         if self.config['pos_min'] <= position <= self.config['pos_max']:
             self._target_position = position

--- a/mpf/devices/stepper.py
+++ b/mpf/devices/stepper.py
@@ -26,7 +26,8 @@ class Stepper(SystemWideDevice):
     class_label = 'stepper'
 
     __slots__ = ["hw_stepper", "_target_position", "_current_position", "_ball_search_started",
-                 "_ball_search_old_target", "_is_homed", "_is_moving", "_move_task", "delay"]
+                 "_ball_search_old_target", "_is_homed", "_is_moving", "_move_task", "delay",
+                 "_target_speed"]
 
     def __init__(self, machine, name):
         """Initialize stepper."""
@@ -34,6 +35,7 @@ class Stepper(SystemWideDevice):
         self.platform = None            # type: Optional[Stepper]
         self._target_position = 0       # in user units
         self._current_position = 0      # in user units
+        self._target_speed = None       # in steps per second
         self._ball_search_started = False
         self._ball_search_old_target = 0
         self._is_homed = False
@@ -51,14 +53,16 @@ class Stepper(SystemWideDevice):
         self._target_position = self.config['reset_position']
 
         for position in self.config['named_positions']:
-            self.machine.events.add_handler(self.config['named_positions'][position],
-                                            self.event_move_to_position,
-                                            position=position)
-
-        for position in self.config['relative_positions']:
-            self.machine.events.add_handler(self.config['relative_positions'][position],
+            self.machine.events.add_handler(self.config['named_positions'][position]['event'],
                                             self.event_move_to_position,
                                             position=position,
+                                            speed=self.config['named_positions'][position]['speed'])
+
+        for position in self.config['relative_positions']:
+            self.machine.events.add_handler(self.config['relative_positions'][position]['event'],
+                                            self.event_move_to_position,
+                                            position=position,
+                                            speed=[self.config['relative_positions'][position]['speed']],
                                             is_relative=True)
 
         if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:
@@ -82,6 +86,15 @@ class Stepper(SystemWideDevice):
 
     def validate_and_parse_config(self, config, is_mode_config, debug_prefix: str = None):
         """Validate stepper config."""
+        # If positions are just strings, expand them into strings and speeds
+        print(f"Initial stepper config: {config}")
+        for cfg in ('named_positions', 'relative_positions'):
+            if cfg in config:
+                for pos, value in config[cfg].items():
+                    print(f"Checking key {pos} with value {value}")
+                    if isinstance(value, str):
+                        config[cfg][pos] = { 'event': value }
+        print(f"Reworked stepper config: {config}")
         config = super().validate_and_parse_config(config, is_mode_config, debug_prefix)
         platform = self.machine.get_platform_sections(
             'stepper_controllers', getattr(config, "platform", None))
@@ -123,7 +136,7 @@ class Stepper(SystemWideDevice):
                 self.info_log("Stepper moving relative %s to hit target %s from %s",
                               delta, target_position, self._current_position)
                 # move stepper
-                self.hw_stepper.move_rel_pos(delta)
+                self.hw_stepper.move_rel_pos(delta, self._target_speed)
                 # wait for the move to complete
                 await self.hw_stepper.wait_for_move_completed()
             else:
@@ -131,15 +144,18 @@ class Stepper(SystemWideDevice):
                               self._target_position)
             # set current position
             self._current_position = target_position
+            # Clear the speed override
+            self._target_speed = None
             # post ready event
             self._post_ready_event()
 
-    def _move_to_absolute_position(self, position):
+    def _move_to_absolute_position(self, position, speed=None):
         """Move stepper to position."""
         self.info_log("%s: Moving to absolute position %s. Current position: %s",
                       self.hw_stepper, position, self._current_position)
         if self.config['pos_min'] <= position <= self.config['pos_max']:
             self._target_position = position
+            self._target_speed = speed
             self._is_moving.set()
         else:
             raise ValueError("_move_to_absolute_position: position argument beyond limits")
@@ -205,22 +221,22 @@ class Stepper(SystemWideDevice):
         self._move_to_absolute_position(self.config['reset_position'])
 
     @event_handler(5)
-    def event_move_to_position(self, position=None, is_relative=False, **kwargs):
+    def event_move_to_position(self, position=None, speed=None, is_relative=False, **kwargs):
         """Event handler for move_to_position event."""
         del kwargs
         if position is None:
             raise AssertionError("move_to_position event is missing a position.")
 
-        self.move_to_position(position, is_relative)
+        self.move_to_position(position, speed, is_relative)
 
-    def move_to_position(self, position, is_relative=False):
+    def move_to_position(self, position, speed=None, is_relative=False):
         """Move stepper to a position."""
         self.info_log("Stepper at %s moving to %s position %s", self._current_position,
                       "relative" if is_relative else "absolute", position)
         self._target_position = (self._current_position + position) if is_relative else position
         if self._ball_search_started:
             return
-        self._move_to_absolute_position(self._target_position)
+        self._move_to_absolute_position(self._target_position, speed)
 
     def _ball_search_start(self, **kwargs):
         del kwargs

--- a/mpf/platforms/fast/communicators/exp.py
+++ b/mpf/platforms/fast/communicators/exp.py
@@ -110,9 +110,10 @@ class FastExpCommunicator(FastSerialCommunicator):
         self.send_and_forget(f'RF@{board_address}:{Util.int_to_hex_string(rate, True)}')
 
     def register_processor(self, message_prefix, board_address, device_id, callback):
+        """Register an exp board processor to handle messages."""
         if message_prefix not in self.message_processors:
             self.message_processors[message_prefix] = partial(self._process_device_msg, message_prefix)
-            self._device_processors[message_prefix]= dict()
+            self._device_processors[message_prefix] = dict()
         if board_address not in self._device_processors[message_prefix]:
             self._device_processors[message_prefix][board_address] = dict()
         self._device_processors[message_prefix][board_address][device_id] = callback

--- a/mpf/platforms/fast/communicators/exp.py
+++ b/mpf/platforms/fast/communicators/exp.py
@@ -118,8 +118,6 @@ class FastExpCommunicator(FastSerialCommunicator):
         self._device_processors[message_prefix][board_address][device_id] = callback
 
     def _process_device_msg(self, message_prefix, message):
-        print(f"Processing '{message_prefix}'message for devices: '{message}'")
-        print(f"Available processors: {self._device_processors[message_prefix]}")
         # Commands like MS: currently don't include the EXP board in the response,
         # so there's no way to know which board needs to be informed. Inform them
         # all? If multiple boards are running concurrently, it'll get ugly.

--- a/mpf/platforms/fast/communicators/exp.py
+++ b/mpf/platforms/fast/communicators/exp.py
@@ -1,6 +1,8 @@
 """FAST Expansion Board Serial Communicator."""
 # mpf/platforms/fast/communicators/exp.py
 
+from functools import partial
+
 from mpf.platforms.fast.fast_defines import EXPANSION_BOARD_FEATURES
 from mpf.platforms.fast.fast_exp_board import FastExpansionBoard
 from mpf.platforms.fast.communicators.base import FastSerialCommunicator
@@ -18,14 +20,16 @@ class FastExpCommunicator(FastSerialCommunicator):
 
     IGNORED_MESSAGES = ['XX:F']
 
-    __slots__ = ["exp_boards_by_address", "active_board"]
+    __slots__ = ["exp_boards_by_address", "active_board", "_device_processors"]
 
     def __init__(self, platform, processor, config):
         """Initialize the EXP communicator."""
         super().__init__(platform, processor, config)
 
         self.exp_boards_by_address = dict()  # keys = board addresses, values = FastExpansionBoard objects
+        self._device_processors = dict()
         self.active_board = None
+
         self.message_processors['BR:'] = self._process_br
 
     async def init(self):
@@ -104,3 +108,21 @@ class FastExpCommunicator(FastSerialCommunicator):
 
         self.platform.debug_log("%s - Setting LED fade rate to %sms", self, rate)
         self.send_and_forget(f'RF@{board_address}:{Util.int_to_hex_string(rate, True)}')
+
+    def register_processor(self, message_prefix, board_address, device_id, callback):
+        if message_prefix not in self.message_processors:
+            self.message_processors[message_prefix] = partial(self._process_device_msg, message_prefix)
+            self._device_processors[message_prefix]= dict()
+        if board_address not in self._device_processors[message_prefix]:
+            self._device_processors[message_prefix][board_address] = dict()
+        self._device_processors[message_prefix][board_address][device_id] = callback
+
+    def _process_device_msg(self, message_prefix, message):
+        print(f"Processing '{message_prefix}'message for devices: '{message}'")
+        print(f"Available processors: {self._device_processors[message_prefix]}")
+        # Commands like MS: currently don't include the EXP board in the response,
+        # so there's no way to know which board needs to be informed. Inform them
+        # all? If multiple boards are running concurrently, it'll get ugly.
+        device_id = message.split(",")[0]
+        for board_callback in self._device_processors[message_prefix].values():
+            board_callback[device_id](message)

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -458,11 +458,12 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
         # verify this board support servos
         assert int(port) <= int(brk_board.features['stepper_ports'])  # TODO should this be stored as an int?
 
-        if 'platform_settings' in config:
-            config.update(self.machine.config_validator.validate_config('fast_steppers', config['platform_settings']))
-            del config['platform_settings']
-
         return FastStepper(brk_board, port, config)
+
+    @classmethod
+    def get_stepper_config_section(cls):
+        """Return config section."""
+        return "fast_stepper_settings"
 
     def _parse_switch_number(self, number):
         try:

--- a/mpf/platforms/fast/fast_defines.py
+++ b/mpf/platforms/fast/fast_defines.py
@@ -61,7 +61,7 @@ EXPANSION_BOARD_FEATURES = {
 
 BREAKOUT_FEATURES = {
     'FP-EXP-0061': {
-        'min_fw': '0.31',
+        'min_fw': '0.33',
         'led_ports': 4,
         'stepper_ports': 2
     },

--- a/mpf/platforms/fast/fast_defines.py
+++ b/mpf/platforms/fast/fast_defines.py
@@ -27,6 +27,12 @@ VALID_IO_BOARDS = (
 )
 
 EXPANSION_BOARD_FEATURES = {
+    'FP-EXP-0061': {
+        'min_fw': '0.31',
+        'local_breakouts': ['FP-EXP-0061'],
+        'breakout_ports': 0,
+        'default_address': '90'
+    },
     'FP-EXP-0071': {
         'min_fw': '0.11',
         'local_breakouts': ['FP-EXP-0071'],
@@ -54,6 +60,11 @@ EXPANSION_BOARD_FEATURES = {
 }
 
 BREAKOUT_FEATURES = {
+    'FP-EXP-0061': {
+        'min_fw': '0.31',
+        'led_ports': 4,
+        'stepper_ports': 2
+    },
     'FP-EXP-0071': {
         'min_fw': '0.11',
         'led_ports': 4,

--- a/mpf/platforms/fast/fast_servo.py
+++ b/mpf/platforms/fast/fast_servo.py
@@ -16,7 +16,7 @@ class FastServo(ServoPlatformInterface):
         self.exp_connection = breakout_board.communicator
 
         self.base_address = breakout_board.address
-        self.servo_index = Util.int_to_hex_string(int(port) - 1)  # Servos are 0-indexed
+        self.servo_index = f"{(int(port) - 1):X}"  # Servos are 0-indexed hex
         self.max_runtime = f"{config['max_runtime']:02X}"
 
         self.write_config_to_servo()

--- a/mpf/platforms/fast/fast_servo.py
+++ b/mpf/platforms/fast/fast_servo.py
@@ -1,6 +1,5 @@
 """Fast servo implementation."""
 
-from mpf.core.utility_functions import Util
 from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
 
 

--- a/mpf/platforms/fast/fast_servo.py
+++ b/mpf/platforms/fast/fast_servo.py
@@ -1,4 +1,6 @@
 """Fast servo implementation."""
+
+from mpf.core.utility_functions import Util
 from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
 
 
@@ -14,7 +16,7 @@ class FastServo(ServoPlatformInterface):
         self.exp_connection = breakout_board.communicator
 
         self.base_address = breakout_board.address
-        self.servo_index = str(int(port) - 1)  # Servos are 0-indexed
+        self.servo_index = Util.int_to_hex_string(int(port) - 1)  # Servos are 0-indexed
         self.max_runtime = f"{config['max_runtime']:02X}"
 
         self.write_config_to_servo()

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -93,9 +93,10 @@ class FastStepper(StepperPlatformInterface):
 
     def set_home_position(self):
         """Not used."""
-        pass
 
-    def _send_command(self, base_command, payload=set()):
+    def _send_command(self, base_command, payload=None):
+        if not payload:
+            payload = []
         self.exp_connection.send_and_forget(','.join([
             f'{base_command}@{self.base_address}:{self.stepper_index}', *payload]))
 

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -10,6 +10,7 @@ POLL_MS = 100
 MIN_SPEED = 350
 MAX_SPEED = 1650
 
+
 class FastStepper(StepperPlatformInterface):
 
     """A stepper in the FAST platform connected to a FAST Expansion Board."""
@@ -31,6 +32,7 @@ class FastStepper(StepperPlatformInterface):
         self._default_speed = Util.int_to_hex_string(self.config['default_speed'], True)
 
     def home(self, direction):
+        """Return the stepper to its home position."""
         if direction != 'counterclockwise':
             raise ConfigFileError("FAST Stepper only supports home in counter-clockwise direction. "
                                   "Please rewire your motor and set homing_direction: counterclockwise "
@@ -39,6 +41,7 @@ class FastStepper(StepperPlatformInterface):
         self._send_command("MH")
 
     async def wait_for_move_completed(self):
+        """Wait for the stepper to stop moving."""
         # If not moving, return immediately
         if not self._is_moving:
             return
@@ -73,7 +76,8 @@ class FastStepper(StepperPlatformInterface):
     def move_vel_mode(self, velocity):
         """Move the motor indefinitely in either direction.
 
-        FAST does not support this, so instead send the longest possible move time."""
+        FAST does not support this, so instead send the longest possible move time.
+        """
         base_command = "MR" if velocity < 0 else "MF"
         # The only place in MPF code that uses move_vel_mode is the software-based
         # homing, which sends 1/-1 as values. Interpret that as slowest possible
@@ -88,9 +92,10 @@ class FastStepper(StepperPlatformInterface):
         self._send_command("MC")
 
     def set_home_position(self):
+        """Not used."""
         pass
 
-    def _send_command(self, base_command, payload=[]):
+    def _send_command(self, base_command, payload=set()):
         self.exp_connection.send_and_forget(','.join([
             f'{base_command}@{self.base_address}:{self.stepper_index}', *payload]))
 

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -56,7 +56,7 @@ class FastStepper(StepperPlatformInterface):
 
         base_command = "MF" if position > 0 else "MR"
         hex_position = Util.int_to_hex_string(position, True)
-        self.log.debug("Moving stepper index %s: %s steps with speed %s", self.stepper_index, position, speed)
+        self.log.info("Moving stepper index %s: %s steps with speed %s", self.stepper_index, position, speed)
 
         if speed:
             if speed < MIN_SPEED or speed > MAX_SPEED:

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -2,12 +2,13 @@
 
 
 from mpf.core.utility_functions import Util
+from mpf.exceptions.config_file_error import ConfigFileError
 from mpf.platforms.interfaces.stepper_platform_interface import StepperPlatformInterface
 
 
 class FastStepper(StepperPlatformInterface):
 
-    """A servo in the FAST platform connected to a FAST Expansion Board."""
+    """A stepper in the FAST platform connected to a FAST Expansion Board."""
 
     # __slots__ = ["number", "exp_connection"]
 
@@ -17,7 +18,7 @@ class FastStepper(StepperPlatformInterface):
         self.exp_connection = breakout_board.communicator
 
         self.base_address = breakout_board.address
-        self.servo_index = str(int(port) - 1)  # Servos are 0-indexed
+        self.stepper_index = str(int(port) - 1)  # Steppers are 0-indexed
         # self.max_runtime = f"{config['max_runtime']:02X}"
 
     #     self.write_config_to_servo()
@@ -30,11 +31,15 @@ class FastStepper(StepperPlatformInterface):
 
     #     # EM:<INDEX>,1,<MAX_TIME_MS>,<MIN>,<MAX>,<NEUTRAL><CR>
     #     self.exp_connection.send_with_confirmation(
-    #         f"EM@{self.base_address}:{self.servo_index},1,{self.max_runtime},{min_us},{max_us},{home_us}",
+    #         f"EM@{self.base_address}:{self.stepper_index},1,{self.max_runtime},{min_us},{max_us},{home_us}",
     #         'EM:P')
 
     def home(self, direction):
-        pass
+        if direction != 'counterclockwise':
+            raise ConfigFileError("FAST Stepper only supports home in counter-clockwise direction. "
+                                  "Please rewire your motor and set homing_direction: counterclockwise "
+                                  "in your stepper config.", 1, self.__class__.__name__)
+        self._send_command("MH")
 
     async def wait_for_move_completed(self):
         pass
@@ -47,17 +52,20 @@ class FastStepper(StepperPlatformInterface):
         base_command = "MF" if position > 0 else "MR"
         hex_position = Util.int_to_hex_string(position, True)
 
-        # MP:<INDEX>,<POSITION>,<TIME_MS><CR>
-        self.exp_connection.send_and_forget(f'{base_command}@{self.base_address}:{self.servo_index},'
-                                            f'{hex_position}') #,{self.max_runtime}')
+        self._send_command(base_command, [hex_position])
 
-    def move_vel_mode(self, velocity):
+    def move_vel_mode(self, _velocity):
         pass
 
     def stop(self):
         """Called during shutdown."""
-        # TODO: send command to go home and power off servo
+        self._send_command("MC")
 
     def set_home_position(self):
         pass
+
+    def _send_command(self, base_command, payload=[]):
+        self.exp_connection.send_and_forget(','.join([
+            f'{base_command}@{self.base_address}:{self.stepper_index}', *payload]))
+
 

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -39,11 +39,14 @@ class FastStepper(StepperPlatformInterface):
         self._send_command("MH")
 
     async def wait_for_move_completed(self):
-        # return
+        # If not moving, return immediately
+        if not self._is_moving:
+            return
         while True:
+            await asyncio.sleep(POLL_MS / 1000)
+            # We may have stopped since the last poll, so check again
             if not self._is_moving:
                 return
-            await asyncio.sleep(1 / POLL_MS)
             self._send_command('MS')
 
     def move_rel_pos(self, position, speed=None):

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -42,17 +42,31 @@ class FastStepper(StepperPlatformInterface):
         self._send_command("MH")
 
     async def wait_for_move_completed(self):
-        pass
+        return
 
-    def move_rel_pos(self, position):
+        # while True:
+        #     await asyncio.sleep(1 / POLL_MS)
+        #     status = await self.exp_connection.
+
+    def move_rel_pos(self, position, speed=None):
         """Move the servo a relative number of steps position."""
         if not position:
             return
 
         base_command = "MF" if position > 0 else "MR"
         hex_position = Util.int_to_hex_string(position, True)
+        cmd_args = [hex_position]
+        print(f"Moving stepper {self.stepper_index} with speed {speed}")
 
-        self._send_command(base_command, [hex_position])
+        if speed:
+            if speed < 350 or speed > 1650:
+                raise ConfigFileError("FAST Stepper only supports speeds between 350-1650, "
+                                      f"but received value of {speed}.",
+                                      2, self.__class__.__name__)
+            speed = Util.int_to_hex_string(speed, True)
+            cmd_args.append(speed)
+
+        self._send_command(base_command, cmd_args)
 
     def move_vel_mode(self, _velocity):
         pass

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -1,0 +1,63 @@
+"""Fast servo implementation."""
+
+
+from mpf.core.utility_functions import Util
+from mpf.platforms.interfaces.stepper_platform_interface import StepperPlatformInterface
+
+
+class FastStepper(StepperPlatformInterface):
+
+    """A servo in the FAST platform connected to a FAST Expansion Board."""
+
+    # __slots__ = ["number", "exp_connection"]
+
+    def __init__(self, breakout_board, port, config):
+        """Initialize servo."""
+        self.config = config
+        self.exp_connection = breakout_board.communicator
+
+        self.base_address = breakout_board.address
+        self.servo_index = str(int(port) - 1)  # Servos are 0-indexed
+        # self.max_runtime = f"{config['max_runtime']:02X}"
+
+    #     self.write_config_to_servo()
+
+    # def write_config_to_servo(self):
+    #     """Send the servo configuration to the platform."""
+    #     min_us = f"{self.config['min_us']:02X}"
+    #     max_us = f"{self.config['max_us']:02X}"
+    #     home_us = f"{self.config['home_us']:02X}"
+
+    #     # EM:<INDEX>,1,<MAX_TIME_MS>,<MIN>,<MAX>,<NEUTRAL><CR>
+    #     self.exp_connection.send_with_confirmation(
+    #         f"EM@{self.base_address}:{self.servo_index},1,{self.max_runtime},{min_us},{max_us},{home_us}",
+    #         'EM:P')
+
+    def home(self, direction):
+        pass
+
+    async def wait_for_move_completed(self):
+        pass
+
+    def move_rel_pos(self, position):
+        """Move the servo a relative number of steps position."""
+        if not position:
+            return
+
+        base_command = "MF" if position > 0 else "MR"
+        hex_position = Util.int_to_hex_string(position, True)
+
+        # MP:<INDEX>,<POSITION>,<TIME_MS><CR>
+        self.exp_connection.send_and_forget(f'{base_command}@{self.base_address}:{self.servo_index},'
+                                            f'{hex_position}') #,{self.max_runtime}')
+
+    def move_vel_mode(self, velocity):
+        pass
+
+    def stop(self):
+        """Called during shutdown."""
+        # TODO: send command to go home and power off servo
+
+    def set_home_position(self):
+        pass
+

--- a/mpf/platforms/fast/fast_stepper.py
+++ b/mpf/platforms/fast/fast_stepper.py
@@ -7,14 +7,13 @@ from mpf.exceptions.config_file_error import ConfigFileError
 from mpf.platforms.interfaces.stepper_platform_interface import StepperPlatformInterface
 
 POLL_MS = 100
-DEFAULT_SPEED = Util.int_to_hex_string(600, True)
 
 class FastStepper(StepperPlatformInterface):
 
     """A stepper in the FAST platform connected to a FAST Expansion Board."""
 
     __slots__ = ["base_address", "config", "exp_connection", "log", "stepper_index",
-                 "_is_moving"]
+                 "_is_moving", "_default_speed"]
 
     def __init__(self, breakout_board, port, config):
         """Initialize servo."""
@@ -27,7 +26,7 @@ class FastStepper(StepperPlatformInterface):
 
         self.exp_connection.register_processor('MS:', self.base_address, self.stepper_index, self._process_ms)
         self._is_moving = False
-
+        self._default_speed = Util.int_to_hex_string(self.config['default_speed'], True)
 
     def home(self, direction):
         if direction != 'counterclockwise':
@@ -61,7 +60,7 @@ class FastStepper(StepperPlatformInterface):
                                       2, self.__class__.__name__)
             speed = Util.int_to_hex_string(speed, True)
         else:
-            speed = DEFAULT_SPEED
+            speed = self._default_speed
 
         self._is_moving = True
         self._send_command(base_command, [hex_position, speed])

--- a/mpf/platforms/interfaces/stepper_platform_interface.py
+++ b/mpf/platforms/interfaces/stepper_platform_interface.py
@@ -35,7 +35,7 @@ class StepperPlatformInterface(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def move_rel_pos(self, position):
+    def move_rel_pos(self, position, speed=None):
         """Move axis to a certain relative position."""
         raise NotImplementedError
 

--- a/mpf/platforms/p_roc_devices.py
+++ b/mpf/platforms/p_roc_devices.py
@@ -487,7 +487,7 @@ class PdLedStepper(StepperPlatformInterface):
         else:
             self.move_rel_pos(-16384)
 
-    def move_rel_pos(self, position):
+    def move_rel_pos(self, position, speed=None):
         """Move stepper by x steps."""
         if abs(position) > 16384:
             raise ValueError("Cannot move more than 16384 steps but tried {}".format(position))

--- a/mpf/platforms/pololu/pololu_tic.py
+++ b/mpf/platforms/pololu/pololu_tic.py
@@ -189,7 +189,7 @@ class PololuTICStepper(StepperPlatformInterface):
         self._move_complete.clear()
         self.tic.rotate_to_position(self._position)
 
-    def move_rel_pos(self, position):
+    def move_rel_pos(self, position, speed=None):
         """Move axis to a relative position."""
         self._position += position
         self._move_complete.clear()

--- a/mpf/platforms/spike/spike.py
+++ b/mpf/platforms/spike/spike.py
@@ -420,10 +420,10 @@ class SpikeStepper(StepperPlatformInterface):
             return False
         return info['position'] == self._position
 
-    def move_rel_pos(self, position):
+    def move_rel_pos(self, position, speed=None):
         """Move relative to current position."""
         self._position += int(position)
-        self._move_to_absolute_position(self._position, self.config['speed'])
+        self._move_to_absolute_position(self._position, speed or self.config['speed'])
 
     def move_vel_mode(self, velocity):
         """Move stepper in a direction."""

--- a/mpf/platforms/step_stick.py
+++ b/mpf/platforms/step_stick.py
@@ -35,7 +35,7 @@ class DigitalOutputStepStickStepper(StepperPlatformInterface):
         if self.enable_output:
             self.enable_output.enable()
 
-    def move_rel_pos(self, position):
+    def move_rel_pos(self, position, speed=None):
         """Move a number of steps in one direction."""
         if self._move_task and not self._move_task.done():
             raise AssertionError("Last move has not been completed. Calls stop first.")

--- a/mpf/platforms/trinamics_steprocker.py
+++ b/mpf/platforms/trinamics_steprocker.py
@@ -110,7 +110,7 @@ class TrinamicsTMCLStepper(StepperPlatformInterface):
         microstep_pos = self._uu_to_microsteps(position)
         self.tmcl.mvp(self._mn, "ABS", microstep_pos)
 
-    def move_rel_pos(self, position):
+    def move_rel_pos(self, position, speed=None):
         """Move axis to a relative position."""
         microstep_rel = self._uu_to_microsteps(position)
         self.tmcl.mvp(self._mn, "REL", microstep_rel)

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -512,7 +512,7 @@ class VirtualStepper(StepperPlatformInterface):
         """Wait until move completed."""
         await asyncio.sleep(0.1)
 
-    def move_rel_pos(self, position):
+    def move_rel_pos(self, position, speed=None):
         """Move axis to a relative position."""
         self._current_position += position
 


### PR DESCRIPTION
This PR adds support for the FAST 0061 Stepper Controller board, based on a prototype board provided by FAST. It aims to maintain the same stepper command configuration as other stepper platforms, while exposing FAST-specific functionality.

```
#config_version=6

hardware:
  platform: fast

fast:
  exp:
    debug: true
    port: /dev/tty.usbmodem3103
    boards:
      stepperboard:
        model: FP-EXP-0061

steppers:
  stepper_unit:
    number: stepperboard-1
    debug: true
    homing_direction: counterclockwise
    home_on_startup: false
    pos_min: 0
    pos_max: 7000
    platform_settings:
      default_speed: 400
    relative_positions:
      1400:
        event: servo_go_1
        speed: 350
      500: servo_go_2
      600:
        event: servo_go_3
        speed: 1200
      700:
        event: servo_go_4
        speed: 700
      800:
        event: servo_go_5
        speed: 800
      900:
        event: servo_go_6
        speed: 900
      1000:
        event: servo_go_7
        speed: 1000

```

![](https://c.tenor.com/ArW4DhCnxiQAAAAM/split-qwop.gif)
