### PR TITLE
fix: consider incand->card_num when checking opp lights

### DIFF
--- a/mpf/platforms/opp/opp_incand.py
+++ b/mpf/platforms/opp/opp_incand.py
@@ -53,6 +53,8 @@ class OPPIncand(LightPlatformSoftwareFade):
         super().__init__(number, loop, hardware_fade_ms)
         self.incand_card = incand_card  # type: OPPIncandCard
         self.index = int(number)
+        self.number = incand_card.chain_serial + "-" + \
+            incand_card.card_num + '-' + str(number)
 
     def set_brightness(self, brightness: float):
         """Enable (turns on) this driver.


### PR DESCRIPTION
Fixes #1867. Modifies how OPPIncand lights are numbered, so that the validation doesn't incorrectly determine duplicate light numbers for these boards.

Without this patch, **OPP Cypress builds having incandescents used across multiple boards will run into this issue** (unless they don't use the same numbered pin on any of the boards in the chain). The following videos demonstrate a game booting to attract mode with the patch in place:

https://github.com/user-attachments/assets/11b47d52-f028-4d96-8994-1e5a21bdb174

https://github.com/user-attachments/assets/5a9d9b38-f81e-4ec9-83a3-3bb6e2e43fc2
