### PR TITLE
Carousel Setting to Not Wrap

### DIFF
--- a/mpf/core/placeholder_manager.py
+++ b/mpf/core/placeholder_manager.py
@@ -642,9 +642,7 @@ class BasePlaceholderManager(MpfController):
         """Initialize."""
         super().__init__(machine)
         self._eval_methods = {
-            ast.Num: self._eval_num,
-            ast.Str: self._eval_str,
-            ast.NameConstant: self._eval_constant,
+            ast.Constant: self._eval_constant,
             ast.BinOp: self._eval_bin_op,
             ast.UnaryOp: self._eval_unary_op,
             ast.Compare: self._eval_compare,
@@ -667,18 +665,6 @@ class BasePlaceholderManager(MpfController):
             return ast.parse(template_str, mode='eval').body
         except SyntaxError:
             raise AssertionError('Failed to parse template "{}"'.format(template_str))
-
-    @staticmethod
-    def _eval_num(node, variables, subscribe):
-        del variables
-        del subscribe
-        return node.n, []
-
-    @staticmethod
-    def _eval_str(node, variables, subscribe):
-        del variables
-        del subscribe
-        return node.s, []
 
     @staticmethod
     def _eval_constant(node, variables, subscribe):

--- a/mpf/core/segment_mappings.py
+++ b/mpf/core/segment_mappings.py
@@ -14,6 +14,7 @@ MYPY = False
 if MYPY:   # pragma: no cover
     from mpf.core.rgb_color import RGBColor     # pylint: disable-msg=cyclic-import,unused-import; # noqa
 
+# pylint: disable-msg=line-too-long
 
 class TextToSegmentMapper:
 

--- a/mpf/core/segment_mappings.py
+++ b/mpf/core/segment_mappings.py
@@ -14,7 +14,6 @@ MYPY = False
 if MYPY:   # pragma: no cover
     from mpf.core.rgb_color import RGBColor     # pylint: disable-msg=cyclic-import,unused-import; # noqa
 
-# pylint: disable-msg=line-too-long
 
 class TextToSegmentMapper:
 

--- a/mpf/modes/carousel/code/carousel.py
+++ b/mpf/modes/carousel/code/carousel.py
@@ -10,7 +10,7 @@ class Carousel(Mode):
 
     __slots__ = ["_all_items", "_items", "_select_item_events", "_next_item_events",
                  "_previous_item_events", "_highlighted_item_index", "_done",
-                 "_block_events", "_release_events", "_is_blocking"]
+                 "_block_events", "_release_events", "_is_blocking", "_wrap_items"]
 
     def __init__(self, *args, **kwargs):
         """Initialize carousel mode."""
@@ -23,6 +23,7 @@ class Carousel(Mode):
         self._block_events = None
         self._release_events = None
         self._is_blocking = None
+        self._wrap_items = None
         self._done = None
         super().__init__(*args, **kwargs)
 
@@ -41,6 +42,7 @@ class Carousel(Mode):
         self._highlighted_item_index = 0
         self._block_events = Util.string_to_event_list(mode_settings.get("block_events", ""))
         self._release_events = Util.string_to_event_list(mode_settings.get("release_events", ""))
+        self._wrap_items = mode_settings.get("wrap_items", True)
 
         if not self._all_items:
             raise AssertionError("Specify at least one item to select from")
@@ -113,6 +115,9 @@ class Carousel(Mode):
             return
         self._highlighted_item_index += 1
         if self._highlighted_item_index >= len(self._get_available_items()):
+            if not self._wrap_items:
+                self._highlighted_item_index -= 1
+                return
             self._highlighted_item_index = 0
         self._update_highlighted_item("forwards")
 
@@ -122,6 +127,9 @@ class Carousel(Mode):
             return
         self._highlighted_item_index -= 1
         if self._highlighted_item_index < 0:
+            if not self._wrap_items:
+                self._highlighted_item_index = 0
+                return
             self._highlighted_item_index = len(self._get_available_items()) - 1
 
         self._update_highlighted_item("backwards")

--- a/mpf/tests/machine_files/carousel/config/config.yaml
+++ b/mpf/tests/machine_files/carousel/config/config.yaml
@@ -5,6 +5,7 @@ modes:
     - second_carousel
     - conditional_carousel
     - blocking_carousel
+    - nowrap_carousel
 
 machine:
     min_balls: 0

--- a/mpf/tests/machine_files/carousel/modes/nowrap_carousel/config/nowrap_carousel.yaml
+++ b/mpf/tests/machine_files/carousel/modes/nowrap_carousel/config/nowrap_carousel.yaml
@@ -1,0 +1,12 @@
+#config_version=6
+mode:
+  start_events: start_mode_nowrap_carousel
+  stop_events: stop_mode_nowrap_carousel, carousel_item_selected
+  code: mpf.modes.carousel.code.carousel.Carousel
+
+mode_settings:
+  selectable_items: item1, item2, item3
+  select_item_events: select, select_additional
+  next_item_events: next
+  previous_item_events: previous
+  wrap_items: false

--- a/mpf/tests/test_CarouselMode.py
+++ b/mpf/tests/test_CarouselMode.py
@@ -28,18 +28,18 @@ class TestCarouselMode(MpfTestCase):
         self.mock_event("blocking_carousel_item2_highlighted")
         self.mock_event("blocking_carousel_item3_highlighted")
         self.mock_event("flipper_cancel")
-        
+
         self._start_game()
         self.post_event("start_mode4")
 
         self.assertIn(self.machine.modes["blocking_carousel"], self.machine.mode_controller.active_modes)
         self.assertEqual(1, self._events["blocking_carousel_item1_highlighted"])
-        self.assertEqual(0, self._events["blocking_carousel_item2_highlighted"]) 
+        self.assertEqual(0, self._events["blocking_carousel_item2_highlighted"])
         self.post_event("s_flipper_right_active")
         self.post_event("s_flipper_right_inactive")
         self.assertEqual(1, self._events["blocking_carousel_item2_highlighted"])
-        self.assertEqual(0, self._events["blocking_carousel_item3_highlighted"]) 
-        self.assertEqual(0, self._events["flipper_cancel"]) 
+        self.assertEqual(0, self._events["blocking_carousel_item3_highlighted"])
+        self.assertEqual(0, self._events["flipper_cancel"])
         self.post_event("s_flipper_right_active")
         self.post_event("s_flipper_left_active")
         self.post_event("flipper_cancel")
@@ -47,11 +47,11 @@ class TestCarouselMode(MpfTestCase):
         self.post_event("s_flipper_left_inactive")
         self.assertEqual(1, self._events["flipper_cancel"])
         self.assertEqual(1, self._events["blocking_carousel_item1_highlighted"])
-        self.assertEqual(1, self._events["blocking_carousel_item2_highlighted"]) 
-        self.assertEqual(0, self._events["blocking_carousel_item3_highlighted"]) 
+        self.assertEqual(1, self._events["blocking_carousel_item2_highlighted"])
+        self.assertEqual(0, self._events["blocking_carousel_item3_highlighted"])
         self.post_event("both_flippers_inactive")
         self.post_event("s_flipper_right_inactive")
-        self.assertEqual(1, self._events["blocking_carousel_item3_highlighted"]) 
+        self.assertEqual(1, self._events["blocking_carousel_item3_highlighted"])
 
         # Restart the mode to ensure that the block is cleared
         self.post_event("flipper_cancel")
@@ -59,8 +59,58 @@ class TestCarouselMode(MpfTestCase):
         self.advance_time_and_run()
         self.post_event("start_mode4")
         self.post_event("s_flipper_right_inactive")
-        self.assertEqual(2, self._events["blocking_carousel_item2_highlighted"], 
-            "item2_highlighted should be called when a blocked mode restarts") 
+        self.assertEqual(2, self._events["blocking_carousel_item2_highlighted"],
+            "item2_highlighted should be called when a blocked mode restarts")
+
+    def testNoWrapCarousel(self):
+
+        self.mock_event("nowrap_carousel_item1_highlighted")
+        self.mock_event("nowrap_carousel_item2_highlighted")
+        self.mock_event("nowrap_carousel_item3_highlighted")
+        self._start_game()
+        self.post_event("start_mode_nowrap_carousel")
+        self.advance_time_and_run()
+        self.assertEqual(1, self._events["nowrap_carousel_item1_highlighted"])
+
+        # Advance forward one and back
+        self.post_event("next")
+        self.advance_time_and_run()
+        self.assertEqual(1, self._events["nowrap_carousel_item1_highlighted"])
+        self.assertEqual(1, self._events["nowrap_carousel_item2_highlighted"])
+        self.post_event("previous")
+        self.advance_time_and_run()
+        self.assertEqual(2, self._events["nowrap_carousel_item1_highlighted"])
+        # Try and go back but fail
+        self.post_event("previous")
+        self.advance_time_and_run()
+        self.assertEqual(2, self._events["nowrap_carousel_item1_highlighted"])
+        self.assertEqual(0, self._events["nowrap_carousel_item3_highlighted"])
+        self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 0)
+        self.post_event("previous")
+        self.advance_time_and_run()
+        self.assertEqual(2, self._events["nowrap_carousel_item1_highlighted"])
+        self.assertEqual(0, self._events["nowrap_carousel_item3_highlighted"])
+        self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 0)
+
+        # Go forward to the last item
+        self.post_event("next")
+        self.advance_time_and_run()
+        self.post_event("next")
+        self.advance_time_and_run()
+        self.assertEqual(2, self._events["nowrap_carousel_item1_highlighted"])
+        self.assertEqual(2, self._events["nowrap_carousel_item2_highlighted"])
+        self.assertEqual(1, self._events["nowrap_carousel_item3_highlighted"])
+        # Try and go forward but fail
+        self.post_event("next")
+        self.advance_time_and_run()
+        self.assertEqual(1, self._events["nowrap_carousel_item3_highlighted"])
+        self.assertEqual(2, self._events["nowrap_carousel_item1_highlighted"])
+        self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 2)
+        self.post_event("next")
+        self.advance_time_and_run()
+        self.assertEqual(1, self._events["nowrap_carousel_item3_highlighted"])
+        self.assertEqual(2, self._events["nowrap_carousel_item1_highlighted"])
+        self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 2)
 
     def testConditionalCarousel(self):
         self.mock_event("conditional_carousel_item1_highlighted")


### PR DESCRIPTION
This PR adds a new `mode_settings:` config option `wrap_items:` for Carousel modes.

When set to `false`, carousel items will not wrap around beginning-to-end or end-to-beginning, instead the carousel will remain stuck at the first or last item and can only be rotated forward or backward, respectively.

By default the value is `true`, so all existing carousels will be unaffected by this change. Only new carousels that explicitly set `wrap_items: false` will not wrap.

Tested by writing tests and validating pass/fail based on expected conditions.

*Also, added an updated to an old deprecated module to take advantage of the CI test runners on this PR. Unrelated to this change, but necessary.*

![Don't wrap!](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGRnN2I1MGd2cDUwY29tZDBuZWd0bzV6ZWkwZjJnOG9kd213c2g2OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ECtuHAGUrcITK/giphy.gif)