### PR TITLE
shh pylint, we need those locals

### DIFF
--- a/mpf/platforms/pin2dmd.py
+++ b/mpf/platforms/pin2dmd.py
@@ -107,6 +107,7 @@ class Pin2DmdDevice(DmdPlatformInterface):
 
         self.device.write(0x01, data)
 
+    # pylint: disable-msg=too-many-locals
     def _send_frame(self, buffer):
         if self.resolution == "128x32":
             elements = 2048


### PR DESCRIPTION
Didn't seem like there's a good seam or reason to refactor to reduce locals in this instance, so I added a disable