### PR TITLE
skip coils without hardware drivers when generating coil info for service menu

### DIFF
--- a/mpf/core/service_controller.py
+++ b/mpf/core/service_controller.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from typing import List
 
 from mpf.core.mpf_controller import MpfController
+from mpf.devices.dual_wound_coil import DualWoundCoil
 
 SwitchMap = namedtuple("SwitchMap", ["board", "switch"])
 CoilMap = namedtuple("CoilMap", ["board", "coil"])
@@ -92,8 +93,10 @@ class ServiceController(MpfController):
         """Return a map of all coils in the machine."""
         coil_map = []
         for coil in self.machine.coils.values():
-            assert coil.hw_driver is not None
-            coil_map.append(CoilMap(coil.hw_driver.get_board_name(), coil))
+            if isinstance(coil, DualWoundCoil):
+                self.info_log("Coil mapping skipped dual-wound coil %s", coil.name)
+            else:
+                coil_map.append(CoilMap(coil.hw_driver.get_board_name(), coil))
 
         # sort by board + driver number
         if do_sort:

--- a/mpf/tests/machine_files/service_mode/config/config.yaml
+++ b/mpf/tests/machine_files/service_mode/config/config.yaml
@@ -34,6 +34,10 @@ coils:
         number: 10
         label: Fourth coil
 
+dual_wound_coils:
+    c_dualwound_1_2:
+        hold_coil: c_test
+        main_coil: c_test2
 
 switches:
     s_door_open:


### PR DESCRIPTION
https://github.com/missionpinball/mpf/issues/1874 resolution - skip coils without hw_drivers (such as dual wound coils) for service controller use cases