### PR TITLE
`ball_device: auto_fire_on_unexpected_ball` template support

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -165,7 +165,7 @@ ball_devices:
     mechanical_eject: single|bool|false
     player_controlled_eject_event: single|event_handler|None
     ball_search_order: single|int|200
-    auto_fire_on_unexpected_ball: single|bool|true
+    auto_fire_on_unexpected_ball: single|template_bool|true
     target_on_unexpected_ball: single|machine(ball_devices)|None
     ejector: ignore
     counter: ignore

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -165,7 +165,7 @@ ball_devices:
     mechanical_eject: single|bool|false
     player_controlled_eject_event: single|event_handler|None
     ball_search_order: single|int|200
-    auto_fire_on_unexpected_ball: single|template_bool|true
+    auto_fire_on_unexpected_ball: single|template_bool|True
     target_on_unexpected_ball: single|machine(ball_devices)|None
     ejector: ignore
     counter: ignore

--- a/mpf/devices/ball_device/ball_device.py
+++ b/mpf/devices/ball_device/ball_device.py
@@ -436,7 +436,7 @@ class BallDevice(SystemWideDevice):
                 self.info_log("Ejecting %s unexpected balls using path %s", unclaimed_balls, path)
 
                 for _ in range(unclaimed_balls):
-                    self.setup_eject_chain(path, not self.config['auto_fire_on_unexpected_ball'])
+                    self.setup_eject_chain(path, not self.config['auto_fire_on_unexpected_ball'].evaluate({}))
 
         # we might have ball requests locally. serve them first
         if self._ball_requests:

--- a/mpf/tests/machine_files/ball_controller/config/regression.yaml
+++ b/mpf/tests/machine_files/ball_controller/config/regression.yaml
@@ -75,7 +75,7 @@ ball_devices:
     ball_switches: s_underRightRampEject
     eject_coil: c_UpperRightEject
     ball_search_order: 1220 # default 200 so do this last
-    auto_fire_on_unexpected_ball: true
+    auto_fire_on_unexpected_ball: True
     entrance_event_timeout: 1500ms  # default is 5 second
     jam_switch: s_underRightRampJam # only happens if 2 balls in there, one on top of the other
     eject_coil_jam_pulse: 100       # if jammed, pulse harder since 2 balls there (in ms)
@@ -84,7 +84,7 @@ ball_devices:
     ball_switches: s_sandTrap
     eject_coil: c_SandTrapEject
     ball_search_order: 2
-    auto_fire_on_unexpected_ball: true
+    auto_fire_on_unexpected_ball: True
     entrance_event_timeout: 400ms # default is 5 second
 
 virtual_platform_start_active_switches:

--- a/mpf/tests/machine_files/ball_device/config/test_ball_device_manual_with_target.yaml
+++ b/mpf/tests/machine_files/ball_device/config/test_ball_device_manual_with_target.yaml
@@ -72,7 +72,7 @@ ball_devices:
         eject_timeouts: 6s
         eject_targets: playfield
         mechanical_eject: true
-        auto_fire_on_unexpected_ball: false
+        auto_fire_on_unexpected_ball: False
         confirm_eject_type: target
     test_vuk:
         eject_coil: eject_coil5
@@ -80,5 +80,5 @@ ball_devices:
         debug: true
         eject_timeouts: 3s
         eject_targets: test_launcher
-        auto_fire_on_unexpected_ball: false
+        auto_fire_on_unexpected_ball: False
         confirm_eject_type: target


### PR DESCRIPTION
Draft PR for now - I haven't actually tested whether this evaluates the template live, or just at setup-time.

Unfortunately this is also a breaking change. The property in question was previously a bool, which allows lowercase specification in our yamls ("true"). But changing to template_bool changes the requirement to a python bool, which MUST be either "True" or "False" if specified simply. We could instead make template_bool support either case of boolean, or even more variants (0/1, T/F, t/f, yes/no, etc), but Jan specifically coded this exception in and I hesitate to change this. ([Current line](https://github.com/missionpinball/mpf/blob/e3929487b272e495a062d65bda242c9232afb49b/mpf/core/placeholder_manager.py#L758)) ([Original Commit](https://github.com/missionpinball/mpf/commit/90ac1dee0fcb76c1eea9880fea2563a2437311c1)) So if we take this change, anyone who happened to use lowercase in their config there (I did) will crash until they find their ball device setting and capitalize it. Awkward

My use case is that my right outlane has a diverter post to redirect a trough-bound ball directly to the plunger lane instead. I'd like the option, when activating the diverter, to either let the auto-launcher fire as normal (which currently works) OR disable the autolaunching until the eject is confirmed or I manually turn autolaunch back on.

---


I've tried a few different solutions already, and I think managing the auto-launch setting myself has the most future promise right now. Failed solutions were:
- ball hold on the plunger
- new ball device representing the redirection pathway when the diverter makes a save
- ^ but registered to a separate playfield
- ^ but with a ball hold
- ^ with plunger attempting to request a ball (seems like because the plunger can request from trough, and trough has ample extra balls to provide, I can't make the plunger's request come from the fake ball device nor from the playfield, so it always results in an extra ball in play.

My other direction to try now is the fake ball save suggestion from https://missionpinball.org/latest/cookbook/fake_ball_save/ or see how mpf uses the ball_saves:auto_launch to manage this