### PR TITLE
Boolean setting support

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1414,7 +1414,7 @@ settings:
     label: single|str|
     sort: single|int|
     values: dict|str:str|
-    key_type: single|enum(str,float,int)|str
+    key_type: single|enum(str,float,int,bool)|str
     default: single|str|
     machine_var: single|str|None
     settingType: single|str|standard

--- a/mpf/core/utility_functions.py
+++ b/mpf/core/utility_functions.py
@@ -57,6 +57,8 @@ class Util:
             return float(value)
         if type_name == "str":
             return str(value)
+        if type_name == "bool":
+            return str(value).lower() in ['true', 't', 'yes', 'enable', 'on', '1']
 
         raise AssertionError("Unknown type {}".format(type_name))
 

--- a/mpf/tests/machine_files/settings/config/config.yaml
+++ b/mpf/tests/machine_files/settings/config/config.yaml
@@ -19,3 +19,30 @@ settings:
             zero: "Zero"
             one: "One"
             two: "Two"
+    custom_setting_float:
+        label: "Float Setting"
+        key_type: float
+        default: 0.1
+        sort: 3
+        values:
+            0: "Zero"
+            0.1: "Point One"
+            1.0: "One"
+            2.5: "Two Point Five"
+    custom_setting_bool_t:
+        label: "Boolean Setting Default True"
+        key_type: bool
+        default: true
+        sort: 4
+        values:
+            true: "yes"
+            false: "off"
+
+    custom_setting_bool_f:
+        label: "Boolean Setting Default False"
+        key_type: bool
+        default: false
+        sort: 5
+        values:
+            true: "on"
+            false: "no"

--- a/mpf/tests/test_Settings.py
+++ b/mpf/tests/test_Settings.py
@@ -24,3 +24,19 @@ class TestSettings(MpfTestCase):
         self.assertEqual("one", self.machine.settings.custom_setting_str)
         self.machine.settings.set_setting_value("custom_setting_str", "zero")
         self.assertEqual("zero", self.machine.settings.custom_setting_str)
+
+        self.assertEqual(0.1, self.machine.settings.custom_setting_float)
+        self.machine.settings.set_setting_value("custom_setting_float", 2.5)
+        self.assertEqual(2.5, self.machine.settings.custom_setting_float)
+        self.machine.settings.set_setting_value("custom_setting_float", 0)
+        self.assertEqual(0, self.machine.settings.custom_setting_float)
+
+        self.assertEqual(True, self.machine.settings.custom_setting_bool_t)
+        self.machine.settings.set_setting_value("custom_setting_bool_t", False)
+        self.assertEqual(False, self.machine.settings.custom_setting_bool_t)
+        self.machine.settings.set_setting_value("custom_setting_bool_t", True)
+        self.assertEqual(True, self.machine.settings.custom_setting_bool_t)
+
+        self.assertEqual(False, self.machine.settings.custom_setting_bool_f)
+        self.machine.settings.set_setting_value("custom_setting_bool_f", True)
+        self.assertEqual(True, self.machine.settings.custom_setting_bool_f)


### PR DESCRIPTION
Add support to for boolean settings. There's no real reason why you couldnt use a more complex type for a boolean setting, and you would be more prepared if you have to add a third (or more) option in the future -- HOWEVER! I think bool settings are still useful because you should be able to embed them in other templates and logic checks more simply than the other settings types.

Tests include a backfill for float support, and both the cases of true and false defaults (just in case the yaml-to-python conversion could have an issue with e.g. any non-empty-string converting as truthy.

I still need to test the boolean setting in the settings management interface, and also embedded in other templates, but I'm posting now because it's close enough to be worth comment already.