### PR TITLE
fix: remove line breaking mypinballs segment displays

### DIFF
--- a/mpf/platforms/mypinballs/mypinballs.py
+++ b/mpf/platforms/mypinballs/mypinballs.py
@@ -27,8 +27,6 @@ class MyPinballsSegmentDisplay(SegmentDisplayPlatformInterface):
             # remove any non-numbers and spaces
             text = re.sub(r'[^0-9 ]', "", text)
 
-            # special char for spaces
-            text = text.replace(" ", "?")
             # set text
             if flashing == FlashingType.FLASH_ALL:
                 cmd = b'2:'


### PR DESCRIPTION
This might be another naive PR from our side, but we have been trying to get our "mypinballs" segment displays going and have been running into a strange issue. The displays were initializing as expected, but any value we entered only ever displayed `"      0"` and was the case for all 4 displays we're running. I reached out to the guy who wrote the MyPinballs firmware and he provided instructions for the formats the displays expect which is as such:

`Control Code`  :  `Display ID`  :  `Integer Value to Display`

So to display a score of 500 on the 2nd display, the value is `1:2:500`. We were able to confirm our displays are working by simply connecting from the terminal as such: `echo "1:1:1234567\n" > /dev/ttyACM1`.

With this confirmed, we looked at the MyPinballs mpf source and noticed this curious piece:

```python
# special char for spaces
text = text.replace(" ", "?")
```

As a hunch, I removed the line... and instantly our attract values displayed. Further, starting a game reinitialized the displays and switch hits were scoring. I'm wondering if there are perhaps different versions of the MyPinballs segment display controller or maybe other updates downstream broke the existing implementation? Anyone else running these displays that could test against the `0.57.x` branch and report back?