### PR TITLE
Dedup 0.80.x-only config error codes

### DIFF
--- a/mpf/core/config_validator.py
+++ b/mpf/core/config_validator.py
@@ -335,7 +335,7 @@ class ConfigValidator:
 
                         raise ConfigFileError('Your config contains a value for "track" in '
                                               'setting "' + path_string + '", but "track" has '
-                                              'been replaced with "bus" in MPF 0.80.', 2, self.log.name)
+                                              'been replaced with "bus" in MPF 0.80.', 20, self.log.name)
 
                     else:
                         self.log.error('Your config contains a value for the '


### PR DESCRIPTION
I'm doing a sweep of error code fixes and copy tweaks for dev, and I noticed this code being used in 0.80.x with a duplicate number with another error in the file. The rest of the fixes are on another branch to merge separately.

I went up to 20 for this code because there are about a dozen codes already in use in the file, with many different cases actually grouping under case No. 5. I might add individual number codes for each of those grouped errors in the future.