### PR TITLE
Update Tilt slide behaviors for GMC

### DIFF
--- a/mpf/modes/tilt/config/tilt.yaml
+++ b/mpf/modes/tilt/config/tilt.yaml
@@ -19,9 +19,22 @@ tilt:
   tilt_warnings_player_var: tilt_warnings
 
 slide_player:
-  tilt_warning_1: tilt_warning_1
-  tilt_warning_2: tilt_warning_2
-  tilt: tilt
+  tilt_warning_1:
+    tilt:
+      expire: 1s
+      tokens:
+        text: WARNING
+  tilt_warning_2:
+    tilt:
+      expire: 1s
+      tokens:
+        text: DANGER
+  tilt:
+    tilt:
+      action: play
+      tokens:
+        text: TILT
+
   tilt_clear:
     tilt:
       action: remove

--- a/mpf/modes/tilt/config/tilt.yaml
+++ b/mpf/modes/tilt/config/tilt.yaml
@@ -7,7 +7,7 @@ mode:
   stop_on_ball_end: False
 
 # Instructions on how to use this mode:
-# https://missionpinball.org/game_logic/tilt
+# https://missionpinball.org/latest/game_logic/tilt
 
 tilt:
   tilt_warning_switch_tag: tilt_warning
@@ -25,24 +25,3 @@ slide_player:
   tilt_clear:
     tilt:
       action: remove
-slides:
-  tilt_warning_1:
-    widgets:
-    - type: text
-      text: WARNING
-    expire: 1s
-  tilt_warning_2:
-    widgets:
-    - type: text
-      text: WARNING
-      y: top-2
-      anchor_y: top
-    - type: text
-      text: WARNING
-      y: top-18
-      anchor_y: top
-      expire: 1s
-    expire: 2s
-  tilt:
-  - type: text
-    text: TILT


### PR DESCRIPTION
GMC moved slide definition from yaml to Godot tscns in large part, removing the slides: config value from MPF. Slide expiration handling thus had to move into the slide_player configurations.

This PR is accompanied by https://github.com/missionpinball/mpf-gmc/pull/28 and documented by https://github.com/missionpinball/mpf-docs/pull/585