### PR TITLE
stop "shots" control handlers removal when the shot is destroyed

### DIFF
--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -425,8 +425,8 @@ class Shot(EnableDisableMixin, ModeDevice):
     def _register_control_event_handlers(self):
         for control_event in self.config['control_events']:
             for event in control_event['events']:
-                self._handlers.append(self.machine.events.add_handler(event, self._control_events,
-                                                                      control_event_config=control_event))
+                self.machine.events.add_handler(event, self._control_events,
+                                                control_event_config=control_event)
 
     @event_handler(7)
     def _control_events(self, control_event_config, **kwargs):


### PR DESCRIPTION
Currently, in the shots config, "control handlers" are mixed with "switch handlers". When the mode ends, all handlers are unregistered (both switch and control handlers).
But only the switch handlers should, because when the mode is activated again, only the switch handlers are registered back. The Control handlers are not.

This PR does register the control handlers without adding them to the switch handlers.