### PR TITLE
Update light numbering for virtual, OPP, and PKOne

### DIFF
--- a/mpf/platforms/opp/opp_modern_lights.py
+++ b/mpf/platforms/opp/opp_modern_lights.py
@@ -80,8 +80,8 @@ class OPPModernLightChannel(PlatformBatchLight):
 
     def get_board_name(self):
         """Return OPP chain and addr."""
-        return "OPP Light {} on Chain {} Board {} Type {}".format(
-            self.pixel_num, self.chain_serial, self.addr, self.get_type_string())
+        return "OPP Chain {} Board {} Type {}".format(
+            self.chain_serial, self.addr, self.get_type_string())
 
     def is_successor_of(self, other):
         """Return true if the other light has the previous pixel_num and is on the same chain and addr."""

--- a/mpf/platforms/pkone/pkone_lights.py
+++ b/mpf/platforms/pkone/pkone_lights.py
@@ -89,11 +89,9 @@ class PKONELEDChannel(PlatformBatchLight):
 
     def get_board_name(self):
         """Return the board of this light."""
-        return "PKONE LED Channel {} on Lightshow Board (Address ID {}, Group {}, Light: {}, " \
-               "Hardware Aligned: {})".format(self.index,
-                                              self.board_address_id,
+        return "PKONE Lightshow Board (Address ID {}, Group {}, " \
+               "Hardware Aligned: {})".format(self.board_address_id,
                                               self.group,
-                                              self.config.name,
                                               "Yes" if self._hardware_aligned else "No")
 
     def is_successor_of(self, other):

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -497,14 +497,29 @@ class VirtualLight(LightPlatformInterface):
 
     def is_successor_of(self, other):
         """Return true if the other light has the same number string plus the suffix '+1'."""
-        return self.number == other.number + "+1"
+        self_addr, self_offset = VirtualLight.split_light_address(self.number)
+        other_addr, other_offset = VirtualLight.split_light_address(other.number)
+        return self_addr == other_addr and int(self_offset) == int(other_offset) + 1
 
     def get_successor_number(self):
         """Return the number with the suffix '+1'.
 
         As there is not real number format for virtual is this is all we can do here.
         """
-        return self.number + "+1"
+        addr, offset = VirtualLight.split_light_address(self.number)
+        return f"{addr}+{int(offset) + 1}"
+
+    @staticmethod
+    def split_light_address(address):
+        """Return a light address (without 'led-' prefix) and an offset number as a list.
+
+        Used when calculating relative light addresses,
+        e.g. led-2-0-1 -> led-2-0-1+1 -> led-2-0-1+2
+        """
+        address = address.replace("led-", "")
+        if "+" in address:
+            return address.rsplit("+", 1)
+        return (address, '0')
 
     def __lt__(self, other):
         """Order lights by string."""

--- a/mpf/tests/test_LightGroups.py
+++ b/mpf/tests/test_LightGroups.py
@@ -40,12 +40,12 @@ class TestLightGroups(MpfTestCase):
 
         # stripe 3
         self.assertEqual("led-ABC-123", self.machine.lights["stripe3_light_0"].hw_drivers["red"][0].number)
-        self.assertEqual("led-led-ABC-123+1", self.machine.lights["stripe3_light_0"].hw_drivers["green"][0].number)
-        self.assertEqual("led-led-led-ABC-123+1+1",
+        self.assertEqual("led-ABC-123+1", self.machine.lights["stripe3_light_0"].hw_drivers["green"][0].number)
+        self.assertEqual("led-ABC-123+2",
                          self.machine.lights["stripe3_light_0"].hw_drivers["blue"][0].number)
-        self.assertEqual("led-led-led-led-ABC-123+1+1+1",
+        self.assertEqual("led-ABC-123+3",
                          self.machine.lights["stripe3_light_0"].hw_drivers["white"][0].number)
-        self.assertEqual("led-led-led-led-led-ABC-123+1+1+1+1",
+        self.assertEqual("led-ABC-123+4",
                          self.machine.lights["stripe3_light_1"].hw_drivers["red"][0].number)
 
         # ring 1
@@ -69,8 +69,8 @@ class TestLightGroups(MpfTestCase):
 
         # neoSeg_0
         self.assertEqual("led-0-0-0", self.machine.lights["neoSeg_0_light_0"].hw_drivers["white"][0].number)
-        self.assertEqual("led-led-0-0-0+1", self.machine.lights["neoSeg_0_light_1"].hw_drivers["white"][0].number)
-        self.assertEqual("led-led-led-0-0-0+1+1", self.machine.lights["neoSeg_0_light_2"].hw_drivers["white"][0].number)
+        self.assertEqual("led-0-0-0+1", self.machine.lights["neoSeg_0_light_1"].hw_drivers["white"][0].number)
+        self.assertEqual("led-0-0-0+2", self.machine.lights["neoSeg_0_light_2"].hw_drivers["white"][0].number)
         self.assertEqual("neoSeg_0_light_119", self.machine.lights["neoSeg_0_light_119"].name)
         # sanity check order...not 100%
         self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[0].name, self.machine.lights["neoSeg_0_light_95"].name)
@@ -83,8 +83,8 @@ class TestLightGroups(MpfTestCase):
 
         # neoSeg_1
         self.assertEqual("led-0-0-120", self.machine.lights["neoSeg_1_light_0"].hw_drivers["white"][0].number)
-        self.assertEqual("led-led-0-0-120+1", self.machine.lights["neoSeg_1_light_1"].hw_drivers["white"][0].number)
-        self.assertEqual("led-led-led-0-0-120+1+1", self.machine.lights["neoSeg_1_light_2"].hw_drivers["white"][0].number)
+        self.assertEqual("led-0-0-120+1", self.machine.lights["neoSeg_1_light_1"].hw_drivers["white"][0].number)
+        self.assertEqual("led-0-0-120+2", self.machine.lights["neoSeg_1_light_2"].hw_drivers["white"][0].number)
         self.assertEqual("neoSeg_1_light_29", self.machine.lights["neoSeg_1_light_29"].name)
         # sanity check order...not 100%
         self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[0].name, self.machine.lights["neoSeg_1_light_5"].name)


### PR DESCRIPTION
This PR updates some light numbering strings for the virtual, OPP (including Cobra), and PKOne platforms.

### Virtual Platform Numbering

Virtual platform lights have no boards or addresses, so a rudimentary numbering system of adding "led-(name)+1" was made to quickly throw together relative addresses for lights using `previous:` address chaining.

Unfortunately the naming would compound ond multiple chained lights, creating names like "led-led-(name)+1+1" and "led-led-led-led-(name)+1+1+1+1". This is not very intuitive and could lead to crashes when large light chains were converted to JSON (for transmission over BCP) and exceeded the payload byte size.

This PR adds a little more logic to the virtual numbering to calculate the relative increment and prevent duplicate prefixes, so "led-led-led-(name)+1+1+1" becomes "led-(name)+3".

_Note: there may be a risk of duplicate names in this setup. I'm not sure, it doesn't seem like it but it's a risk._

### OPP and PKOne Board Names

The "board name" of a light is mostly for informational purposes, but is also used for sorting lights into intuitive sequences during Service mode. The OPP and PKOne platforms included the light address/number as the first data point in the board name, which is (1) not correct for being a "board name" and (2) messes up the sorting. 

This PR removes the light address/number from the board name on those platforms, to be consistent with other platforms and to keep the Service mode light tests in an expected (board-sequential) order.

![TOTALLY NORMAL](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjVjeHZxZjhrNmFieGdyd24xMjR6ZGV4ejNwZHB5a3d2amVsd2cybiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/so8KXAphERsre/giphy.gif)