### PR TITLE
add event_player hooks to high_score built-in mode

### DIFF
--- a/mpf/modes/high_score/config/high_score.yaml
+++ b/mpf/modes/high_score/config/high_score.yaml
@@ -7,7 +7,7 @@ mode:
   use_wait_queue: true
 
 # Instructions on how to use this mode:
-# https://missionpinball.org/game_logic/high_scores
+# https://missionpinball.org/latest/game_logic/high_scores
 
 high_score:
   enter_initials_timeout: 60
@@ -26,6 +26,17 @@ high_score:
       - JK: 1337
       - QC: 42
       - MPF: 23
+
+event_player:
+  sw_left_flipper_active:
+    text_input:
+      action: left
+  sw_right_flipper_active:
+    text_input:
+      action: right
+  sw_start_active:
+    text_input:
+      action: select
 
 slide_player:
   high_score_enter_initials:


### PR DESCRIPTION
Uses `left_flipper`, `right_flipper`, and `start` that many players will already have incorporated in their switch configurations. I'll make a docs PR as well to go along with this (the switch tags list(s), the MPFTextInput reference, and eventually a custom high_score slide override guide).


I looked at the high score tests and wasn't sure what would be right to add for this addition. I could add a test that says "when I press a switch with a relevant tag, the text_input event with the correct action is fired" but that feels pretty mock-y vs. the usual integration style I would describe as the MPF standard. I think it's because the "text_input" event behaviors are only handled on the GMC side, which is out of scope for this test suite.