### PR TITLE
remove assertion on FAST exp breakout board matching product_id

### DIFF
--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -122,10 +122,6 @@ class FastExpansionBoard:
                                            f'Actual: {firmware_version}. Update at fastpinball.com/firmware')
 
             brk = self.breakouts[brk_board]
-
-            if product_id != brk.model:
-                raise AssertionError(f'EXP Board {self}, Breakout Port {brk.index}: '
-                                     f'Config is set for {brk.model}, but actually found "{id_string}"')
             brk.hw_verified = True
 
         else:


### PR DESCRIPTION
Removal recommended by Eli on slack

Neurons up to revision 5 respond differently than revision 6+ so a special case would have to be added here if we wanted to still check and allow for both possibilities