### PR TITLE
Fast exp light redistribution

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -670,7 +670,6 @@ fast_breakout:
     led_ports: list|subconfig(fast_led_port)|None
 fast_led_port:
     port: single|str|
-    type: single|enum(ws2812,apa-102)|ws2812
     leds: single|int|32
 fast_aud:
     port: list|str|auto

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -596,7 +596,7 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                     # TODO change to mpf config exception
                     raise AssertionError(f'Board {exp_board} does not have a config entry for Breakout {breakout}')
 
-                index = self.port_idx_to_hex(port, led, 32, config.name)
+                index = self.port_idx_to_hex(port, led, 32, config.name, port_configurations=exp_board.led_port_configurations)
                 this_led_number = f'{brk_board.address}{index}'
 
                 # this code runs once for each channel, so it will be called 3x per LED which
@@ -646,7 +646,7 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
             return fast_led_channel
         raise AssertionError(f"Unknown light subtype {subtype}")
 
-    def port_idx_to_hex(self, port, device_num, devices_per_port, name=None):
+    def port_idx_to_hex(self, port, device_num, devices_per_port, name=None, port_configurations=None):
         """Converts port number and LED index into the proper FAST hex number.
 
         port: the LED port number printed on the board. First port is 1. No zeros.
@@ -665,6 +665,16 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
 
         if port < 1:
             raise AssertionError(f"Port {port} is not valid for device {device_num}")
+
+        if port_configurations:
+            #  port is 1-indexed, configs are 0-indexed
+
+            filtered_sum = sum([x['led_count'] for x in port_configurations if x['normalized_port'] < p])
+
+            port_offset = sum(map(filter(lambda x, p=port-1: x['normalized_port'] < p, port_configurations)))
+            device_num = device_num - 1
+            actual_position = port_offset + device_num
+            return f'{(actual_position):02X}'
 
         if device_num > devices_per_port:
             if name:

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -596,7 +596,13 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                     # TODO change to mpf config exception
                     raise AssertionError(f'Board {exp_board} does not have a config entry for Breakout {breakout}')
 
-                index = self.port_idx_to_hex(port, led, 32, config.name, port_configurations=exp_board.led_port_configurations)
+                port_configurations = exp_board.led_port_configurations
+                if port_configurations:
+                    ports_on_breakout = port_configurations[int(breakout)]
+                else:
+                    ports_on_breakout = None
+
+                index = self.port_idx_to_hex(port, led, 32, config.name, ports_on_breakout)
                 this_led_number = f'{brk_board.address}{index}'
 
                 # this code runs once for each channel, so it will be called 3x per LED which
@@ -646,13 +652,43 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
             return fast_led_channel
         raise AssertionError(f"Unknown light subtype {subtype}")
 
-    def port_idx_to_hex(self, port, device_num, devices_per_port, name=None, port_configurations=None):
+    def port_idx_to_hex_with_configurations(self, port, device_num, ports_on_breakout, name=None):
+        """Converts port number and LED index into the proper FAST hex number.
+
+        This accounts for rewriting LED chain lengths with the FAST EXP ER command
+
+        port: the LED port number printed on the board. First port is 1. No zeros.
+        device_num: LED position in the change, First LED is 1. No zeros.
+        name: used for config error logging
+        ports_on_breakout: configurations from the exp board breakout, using 0 based port numbers 0-7
+
+        Returns: FAST hex string for the LED
+        """
+        port_offset = sum([pc['led_count'] for pc in ports_on_breakout if pc['normalized_port'] % 4 < port - 1])
+        total_on_port = next(filter(lambda pc, p=port - 1:
+                                    pc['normalized_port'] % 4 == p, ports_on_breakout))['led_count']
+
+        if device_num > total_on_port:
+            if name:
+                self.raise_config_error(f"Device number {device_num} exceeds the number of devices per port "
+                                        f"({total_on_port}) for LED {name}", 9)
+            else:
+                raise AssertionError(f"Device number {device_num} exceeds the number of devices per port "
+                                     f"({total_on_port})")
+
+        actual_position = port_offset + device_num - 1
+
+        return f'{(actual_position):02X}'
+
+    # pylint: disable-msg=too-many-arguments 
+    def port_idx_to_hex(self, port, device_num, devices_per_port, name=None, ports_on_breakout=None):
         """Converts port number and LED index into the proper FAST hex number.
 
         port: the LED port number printed on the board. First port is 1. No zeros.
         device_num: LED position in the change, First LED is 1. No zeros.
         devices_per_port: number of LEDs per port. Typically 32.
         name: used for config error logging
+        ports_on_breakout: ports on breakout with number 0-7
 
         Returns: FAST hex string for the LED
         """
@@ -666,15 +702,8 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
         if port < 1:
             raise AssertionError(f"Port {port} is not valid for device {device_num}")
 
-        if port_configurations:
-            #  port is 1-indexed, configs are 0-indexed
-
-            filtered_sum = sum([x['led_count'] for x in port_configurations if x['normalized_port'] < p])
-
-            port_offset = sum(map(filter(lambda x, p=port-1: x['normalized_port'] < p, port_configurations)))
-            device_num = device_num - 1
-            actual_position = port_offset + device_num
-            return f'{(actual_position):02X}'
+        if ports_on_breakout:
+            return self.port_idx_to_hex_with_configurations(port, device_num, ports_on_breakout, name)
 
         if device_num > devices_per_port:
             if name:

--- a/mpf/platforms/fast/fast_defines.py
+++ b/mpf/platforms/fast/fast_defines.py
@@ -72,7 +72,7 @@ BREAKOUT_FEATURES = {
     },
     'FP-EXP-0081': {
         'min_fw': '0.11',
-        'led_ports': 4,
+        'led_ports': 8,
     },
     'FP-EXP-0091': {
         'min_fw': '0.11',

--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -4,10 +4,10 @@ import asyncio
 from base64 import b16decode
 from binascii import Error as binasciiError
 from importlib import import_module
-from mpf.core.utility_functions import Util
 
 from packaging import version
 
+from mpf.core.utility_functions import Util
 from mpf.platforms.fast.fast_defines import (BREAKOUT_FEATURES,
                                              EXPANSION_BOARD_FEATURES)
 
@@ -68,11 +68,11 @@ class FastExpansionBoard:
 
             self.create_breakout(brk)
 
-        self.create_led_ports()
-
+    # pylint: disable-msg=too-many-locals
+    # pylint: disable-msg=line-too-long
     def create_led_ports(self):
-        # create the led ports
-        led_port_configurations = [[], []] #grouped into breakout 0 and 1
+        """Parse the LED port overrides and create port configurations."""
+        led_port_configurations = [[], []]  # grouped into breakout 0 and 1
         for led_port in self.config['led_ports']:
             normalized_port_number = int(led_port['port']) - 1
             port_config = {
@@ -88,14 +88,14 @@ class FastExpansionBoard:
         for port_group_configurations in led_port_configurations:
             breakout_led_group_number += 1
             if len(port_group_configurations) == 0:
-                continue # no need to configure if no overrides are made in the breakout group
+                continue  # no need to configure if no overrides are made in the breakout group
 
             total_leds = sum(map(lambda item: item['led_count'], port_group_configurations))
 
             unclaimed_count = 128 - total_leds
-            if unclaimed_count < 0: # each breakout supports 128 lights total
-                self.log.error(f"Error configuring FAST EXP {self.address} breakout leds : {total_leds} total assigned but only 128 allowed per block of 4 ports")
-                return
+            if unclaimed_count < 0:  # each breakout supports 128 lights total
+                self.log.error(f"Error configuring FAST EXP {self.address} breakout leds : "
+                               f"{total_leds} total assigned but only 128 allowed per block of 4 ports")
 
             addresses = [
                 breakout_led_group_number * 4 + 0,
@@ -109,33 +109,39 @@ class FastExpansionBoard:
             while len(addresses) > 0:
                 attempts += 1
                 address = addresses.pop(0)
-                config_data = next(filter(lambda x: x['normalized_port'] == address, port_group_configurations), None)
+                config_data = next(filter(
+                    lambda x, a=address: x['normalized_port'] == a,
+                    port_group_configurations), None)
                 if config_data:
                     leds_claimed += config_data['led_count']
                     prepared_sets.append(config_data)
                 else:
                     if attempts <= 4:
-                        addresses.append(address) #put at end for retry after defined set
+                        addresses.append(address)  # put at end for retry after defined set
                     else:
-                        usable_leds = max(min(32, 128 - leds_claimed), 0) #claim 32 or whatever is left, never less than 0
+                        # claim 32 or whatever is left, never less than 0
+                        usable_leds = max(min(32, 128 - leds_claimed), 0)
                         leds_claimed += usable_leds
                         prepared_sets.append({'normalized_port': address, 'led_count': usable_leds})
 
             led_offset = 0
-            sorted_configs = sorted(prepared_sets, key = lambda x: x['normalized_port'])
+            sorted_configs = sorted(prepared_sets, key=lambda x: x['normalized_port'])
             for port_configuration in sorted_configs:
-                number = port_configuration['normalized_port']
-                type = '0'
+                number = port_configuration['normalized_port'] % 4
+                chain_type = '0'
                 start = led_offset
                 count = port_configuration['led_count']
                 led_offset += count
-                message = f'ER@{self.address}:{number},{type},{Util.int_to_hex_string(start)},{Util.int_to_hex_string(count)}'
-                if start < 128: # start at 128 for 0 lights is a possible case that we skip
+                if start < 129:  # start at 128 for 0 lights is a possible case
+                    hex_start = Util.int_to_hex_string(start)
+                    hex_count = Util.int_to_hex_string(count)
+                    breakout_address = f'{self.address}{breakout_led_group_number}'
+                    message = f'ER@{breakout_address}:{number},{chain_type},{hex_start},{hex_count}'
                     self.log.info(message)
                     self.communicator.send_with_confirmation(message, 'ER:P')
-                    msg2 = f'RA@{self.address}:ffffff'
-                    self.log.info(msg2)
-                    self.communicator.send_and_forget(msg2)
+                    # msg2 = f'RA@{self.address}:ffffff'
+                    # self.log.info(msg2)
+                    # self.communicator.send_and_forget(msg2)
 
     def create_breakout(self, config: dict) -> None:
         """Define a breakout board within an EXP board."""
@@ -210,6 +216,8 @@ class FastExpansionBoard:
         """Send a reset command to the EXP board."""
         await self.communicator.send_and_wait_for_response_processed(f'BR@{self.address}:', 'BR:P')
 
+        self.create_led_ports()
+
         # TODO move this to mixin classes for device types?
         if self.config['led_fade_time']:
             self.set_led_fade(self.config['led_fade_time'])
@@ -241,6 +249,7 @@ class FastExpansionBoard:
 
                 log_msg = f'RD@{breakout_address}:{msg}'  # pretty version of the message for the log
 
+                self.log.warning(log_msg)
                 try:
                     self.communicator.send_bytes(b16decode(f'{msg_header}{msg}'), log_msg)
                 except binasciiError as e:

--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -18,7 +18,7 @@ class FastExpansionBoard:
 
     # pylint: disable-msg=too-many-instance-attributes
     __slots__ = ["name", "communicator", "config", "platform", "log", "address", "model", "features", "breakouts",
-                 "breakouts_with_leds", "firmware_version", "hw_verified", "led_fade_rate",  "led_ports"]
+                 "breakouts_with_leds", "firmware_version", "hw_verified", "led_fade_rate",  "led_ports" , "led_port_configurations"]
 
     def __init__(self, name: str, communicator, address: str, config: dict) -> None:
         """Initializes a FAST Expansion Board.
@@ -85,6 +85,7 @@ class FastExpansionBoard:
                 led_port_configurations[1].append(port_config)
 
         breakout_led_group_number = -1
+        final_configurations = []
         for port_group_configurations in led_port_configurations:
             breakout_led_group_number += 1
             if len(port_group_configurations) == 0:
@@ -142,6 +143,8 @@ class FastExpansionBoard:
                     # msg2 = f'RA@{self.address}:ffffff'
                     # self.log.info(msg2)
                     # self.communicator.send_and_forget(msg2)
+            final_configurations.append(prepared_sets)
+        self.led_port_configurations = final_configurations
 
     def create_breakout(self, config: dict) -> None:
         """Define a breakout board within an EXP board."""

--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -4,6 +4,7 @@ import asyncio
 from base64 import b16decode
 from binascii import Error as binasciiError
 from importlib import import_module
+from mpf.core.utility_functions import Util
 
 from packaging import version
 
@@ -17,7 +18,7 @@ class FastExpansionBoard:
 
     # pylint: disable-msg=too-many-instance-attributes
     __slots__ = ["name", "communicator", "config", "platform", "log", "address", "model", "features", "breakouts",
-                 "breakouts_with_leds", "firmware_version", "hw_verified", "led_fade_rate"]
+                 "breakouts_with_leds", "firmware_version", "hw_verified", "led_fade_rate",  "led_ports"]
 
     def __init__(self, name: str, communicator, address: str, config: dict) -> None:
         """Initializes a FAST Expansion Board.
@@ -66,6 +67,75 @@ class FastExpansionBoard:
                 raise AssertionError(f'Breakout port {brk["port"]} is not available on {self}')
 
             self.create_breakout(brk)
+
+        self.create_led_ports()
+
+    def create_led_ports(self):
+        # create the led ports
+        led_port_configurations = [[], []] #grouped into breakout 0 and 1
+        for led_port in self.config['led_ports']:
+            normalized_port_number = int(led_port['port']) - 1
+            port_config = {
+                'normalized_port': normalized_port_number,
+                'led_count': int(led_port['leds'])
+            }
+            if normalized_port_number < 4:
+                led_port_configurations[0].append(port_config)
+            else:
+                led_port_configurations[1].append(port_config)
+
+        breakout_led_group_number = -1
+        for port_group_configurations in led_port_configurations:
+            breakout_led_group_number += 1
+            if len(port_group_configurations) == 0:
+                continue # no need to configure if no overrides are made in the breakout group
+
+            total_leds = sum(map(lambda item: item['led_count'], port_group_configurations))
+
+            unclaimed_count = 128 - total_leds
+            if unclaimed_count < 0: # each breakout supports 128 lights total
+                self.log.error(f"Error configuring FAST EXP {self.address} breakout leds : {total_leds} total assigned but only 128 allowed per block of 4 ports")
+                return
+
+            addresses = [
+                breakout_led_group_number * 4 + 0,
+                breakout_led_group_number * 4 + 1,
+                breakout_led_group_number * 4 + 2,
+                breakout_led_group_number * 4 + 3
+            ]
+            prepared_sets = []
+            attempts = 0
+            leds_claimed = 0
+            while len(addresses) > 0:
+                attempts += 1
+                address = addresses.pop(0)
+                config_data = next(filter(lambda x: x['normalized_port'] == address, port_group_configurations), None)
+                if config_data:
+                    leds_claimed += config_data['led_count']
+                    prepared_sets.append(config_data)
+                else:
+                    if attempts <= 4:
+                        addresses.append(address) #put at end for retry after defined set
+                    else:
+                        usable_leds = max(min(32, 128 - leds_claimed), 0) #claim 32 or whatever is left, never less than 0
+                        leds_claimed += usable_leds
+                        prepared_sets.append({'normalized_port': address, 'led_count': usable_leds})
+
+            led_offset = 0
+            sorted_configs = sorted(prepared_sets, key = lambda x: x['normalized_port'])
+            for port_configuration in sorted_configs:
+                number = port_configuration['normalized_port']
+                type = '0'
+                start = led_offset
+                count = port_configuration['led_count']
+                led_offset += count
+                message = f'ER@{self.address}:{number},{type},{Util.int_to_hex_string(start)},{Util.int_to_hex_string(count)}'
+                if start < 128: # start at 128 for 0 lights is a possible case that we skip
+                    self.log.info(message)
+                    self.communicator.send_with_confirmation(message, 'ER:P')
+                    msg2 = f'RA@{self.address}:ffffff'
+                    self.log.info(msg2)
+                    self.communicator.send_and_forget(msg2)
 
     def create_breakout(self, config: dict) -> None:
         """Define a breakout board within an EXP board."""

--- a/mpf/platforms/fast/fast_exp_board.py
+++ b/mpf/platforms/fast/fast_exp_board.py
@@ -18,7 +18,8 @@ class FastExpansionBoard:
 
     # pylint: disable-msg=too-many-instance-attributes
     __slots__ = ["name", "communicator", "config", "platform", "log", "address", "model", "features", "breakouts",
-                 "breakouts_with_leds", "firmware_version", "hw_verified", "led_fade_rate",  "led_ports" , "led_port_configurations"]
+                 "breakouts_with_leds", "firmware_version", "hw_verified", "led_fade_rate",
+                 "led_ports", "led_port_configurations"]
 
     def __init__(self, name: str, communicator, address: str, config: dict) -> None:
         """Initializes a FAST Expansion Board.
@@ -52,6 +53,7 @@ class FastExpansionBoard:
         self.features = EXPANSION_BOARD_FEATURES[self.model]  # ([local model numbers,], num of remotes) tuple
         self.breakouts = dict()
         self.breakouts_with_leds = list()
+        self.led_port_configurations = list()
 
         if self.config['led_hz'] > 31.25:
             self.config['led_hz'] = 31.25
@@ -69,7 +71,6 @@ class FastExpansionBoard:
             self.create_breakout(brk)
 
     # pylint: disable-msg=too-many-locals
-    # pylint: disable-msg=line-too-long
     def create_led_ports(self):
         """Parse the LED port overrides and create port configurations."""
         led_port_configurations = [[], []]  # grouped into breakout 0 and 1
@@ -133,16 +134,13 @@ class FastExpansionBoard:
                 start = led_offset
                 count = port_configuration['led_count']
                 led_offset += count
-                if start < 129:  # start at 128 for 0 lights is a possible case
+                if start <= 128:  # start at 128 for 0 lights is a possible case
                     hex_start = Util.int_to_hex_string(start)
                     hex_count = Util.int_to_hex_string(count)
                     breakout_address = f'{self.address}{breakout_led_group_number}'
                     message = f'ER@{breakout_address}:{number},{chain_type},{hex_start},{hex_count}'
                     self.log.info(message)
                     self.communicator.send_with_confirmation(message, 'ER:P')
-                    # msg2 = f'RA@{self.address}:ffffff'
-                    # self.log.info(msg2)
-                    # self.communicator.send_and_forget(msg2)
             final_configurations.append(prepared_sets)
         self.led_port_configurations = final_configurations
 
@@ -251,8 +249,6 @@ class FastExpansionBoard:
                     msg += f'{led_num[3:]}{color}'
 
                 log_msg = f'RD@{breakout_address}:{msg}'  # pretty version of the message for the log
-
-                self.log.warning(log_msg)
                 try:
                     self.communicator.send_bytes(b16decode(f'{msg_header}{msg}'), log_msg)
                 except binasciiError as e:

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -14,11 +14,11 @@ fast:
             model: FP-BRK-0001
           - port: 2
             model: FP-DRV-0800
-        led_ports:
-          - port: 1
-            leds: 32
-          - port: 2
-            leds: 32
+        # led_ports:
+        #   - port: 1
+        #     leds: 32
+        #   - port: 2
+        #     leds: 32
         led_hz: 30
       aaron:
         model: FP-EXP-0091-2  # test hw revision number included
@@ -27,18 +27,18 @@ fast:
         breakouts:
           - port: 2
             model: FP-BRK-0001
-        led_ports:
-          - port: 1
-            leds: 32
-          - port: 2
-            leds: 32
+        # led_ports:
+        #   - port: 1
+        #     leds: 32
+        #   - port: 2
+        #     leds: 32
       dave:
         model: FP-EXP-0071
-        led_ports:
-          - port: 1
-            leds: 32
-          - port: 2
-            leds: 32
+        # led_ports:
+        #   - port: 1
+        #     leds: 32
+        #   - port: 2
+        #     leds: 32
       eli:
         model: FP-EXP-0081-1  # test including hw revision number
         led_ports:
@@ -46,15 +46,13 @@ fast:
             leds: 16 #give up 16
           - port: 2
             leds: 50 #take 16 from 1 and 2 from 3
-          # port 3 left as default to prove automatic gapping works
+          # port 3 left as default to prove automatic gapping works, should have 8
           - port: 4
-            leds: 72 #take 30 from 3
+            leds: 54 #take 22 from 3
 
-          - port: 5
-            leds: 0 #give up all
           - port: 6
             leds: 64 #take 32 from 1
-          - port: 7  #give up all 32
+          - port: 7
             leds: 64 #take 32 from 8
       neuron:
         model: FP-EXP-2000

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -47,6 +47,21 @@ fast:
             type: apa-102
       eli:
         model: FP-EXP-0081-1  # test including hw revision number
+        led_ports:
+          - port: 1
+            leds: 16 #give up 16
+          - port: 2
+            leds: 50 #take 16 from 1 and 2 from 3
+          # port 3 left as default to prove automatic gapping works
+          - port: 4
+            leds: 72 #take 30 from 3
+
+          - port: 5
+            leds: 0 #give up all
+          - port: 6
+            leds: 64 #take 32 from 1
+          - port: 7  #give up all 32
+            leds: 64 #take 32 from 8
       neuron:
         model: FP-EXP-2000
         breakouts:
@@ -105,13 +120,13 @@ lights:
   led23:  # previous numbering, RGB LED
     previous: led22  # 48003-0, 48003-1, 48003-2
     type: rgb
-  led24:  # start channel, RGBW LED
+  led24:  # start channel, RGBW LED using only RGB channels
     start_channel: neuron-1-5-0  #48004-0, 48004-1, 48004-2, 48005-0
     type: rgbw
-  led25:  # start channel, RGBW LED
+  led25:  # start channel, RGBW LED using only RGB channels
     start_channel: neuron-1-6-1  # 48005-1, 48005-2, 48006-0, 48006-1
     type: rgbw
-  led26:  # previous numbering, RGBW LED
+  led26:  # previous numbering, RGBW LED using only RGB channels
     previous: led25  # 48006-2, 48007-0, 48007-1, 48007-2
     type: rgbw
   led27:  # make sure we can get back to normal

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -17,10 +17,8 @@ fast:
         led_ports:
           - port: 1
             leds: 32
-            type: ws2812
           - port: 2
             leds: 32
-            type: apa-102
         led_hz: 30
       aaron:
         model: FP-EXP-0091-2  # test hw revision number included
@@ -32,19 +30,15 @@ fast:
         led_ports:
           - port: 1
             leds: 32
-            type: ws2812
           - port: 2
             leds: 32
-            type: apa-102
       dave:
         model: FP-EXP-0071
         led_ports:
           - port: 1
             leds: 32
-            type: ws2812
           - port: 2
             leds: 32
-            type: apa-102
       eli:
         model: FP-EXP-0081-1  # test including hw revision number
         led_ports:

--- a/mpf/tests/machine_files/fast/config/exp.yaml
+++ b/mpf/tests/machine_files/fast/config/exp.yaml
@@ -101,7 +101,7 @@ lights:
   led18:
     number: dave-4-11
   led19:
-    number: eli-8-1  # 84160
+    number: eli-7-64  # 8417f
   led20:
     number: neuron-1-1
   led21:

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -17,7 +17,7 @@ class TestFastExp(TestFastBase):
         # These are all the defaults based on the config file for this test.
         # Individual tests can override / add as needed
 
-        self.serial_connections['exp'].expected_commands = {'RA@880:000000': '',
+        self.serial_connections['exp'].expected_commands = {'RA@880:000000': '', #RA=set all on breakout to color
                                                             'RA@881:000000': '',
                                                             'RA@882:000000': '',
                                                             'RA@890:000000': '',
@@ -28,13 +28,14 @@ class TestFastExp(TestFastBase):
                                                             'RA@480:000000': '',
                                                             'RA@481:000000': '',
                                                             'RA@482:000000': '',
-                                                            'RF@89:5DC': '',
-                                                            'EM@B40:0,1,7D0,1F4,9C4,5DC': '',
+                                                            'RF@89:5DC': '',     #RF=set default fade rate
+                                                            'EM@B40:0,1,7D0,1F4,9C4,5DC': '',  #EM=configure motor
                                                             'EM@B40:1,1,7D0,3E8,7D0,5DC': '',
                                                             'EM@882:7,1,7D0,3E8,7D0,5DC': '',
-                                                            'MP@B40:0,7F,7D0': '',
+                                                            'MP@B40:0,7F,7D0': '', #MP=set motor position
                                                             'MP@B40:1,7F,7D0': '',
-                                                            'MP@882:7,7F,7D0': '',}
+                                                            'MP@882:7,7F,7D0': '',
+                                                            }
 
     def test_servo(self):
         # go to min position
@@ -133,7 +134,7 @@ class TestFastExp(TestFastBase):
     def _test_led_colors(self):
 
         self.exp_cpu.expected_commands = {
-            'RD@880:0201ff123402121212': '',
+            'RD@880:0201ff123402121212': '', #RD=set individual leds by binary
             'RD@881:0100ffffff': '',
             'RD@841:0160ffffff': ','}
 

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -17,30 +17,31 @@ class TestFastExp(TestFastBase):
         # These are all the defaults based on the config file for this test.
         # Individual tests can override / add as needed
 
-        self.serial_connections['exp'].expected_commands = {'RA@880:000000': '', #RA=set all on breakout to color
-                                                            'RA@881:000000': '',
-                                                            'RA@882:000000': '',
-                                                            'RA@890:000000': '',
-                                                            'RA@892:000000': '',
-                                                            'RA@B40:000000': '',
-                                                            'RA@840:000000': '',
-                                                            'RA@841:000000': '',
-                                                            'RA@480:000000': '',
-                                                            'RA@481:000000': '',
-                                                            'RA@482:000000': '',
-                                                            'RF@89:5DC': '',     #RF=set default fade rate
-                                                            'EM@B40:0,1,7D0,1F4,9C4,5DC': '',  #EM=configure motor
-                                                            'EM@B40:1,1,7D0,3E8,7D0,5DC': '',
-                                                            'EM@882:7,1,7D0,3E8,7D0,5DC': '',
-                                                            'MP@B40:0,7F,7D0': '', #MP=set motor position
-                                                            'MP@B40:1,7F,7D0': '',
-                                                            'MP@882:7,7F,7D0': '',
-                                                            }
+        self.serial_connections['exp'].expected_commands = {
+            'RA@880:000000': '',                #RA=set all on breakout to color
+            'RA@881:000000': '',
+            'RA@882:000000': '',
+            'RA@890:000000': '',
+            'RA@892:000000': '',
+            'RA@B40:000000': '',
+            'RA@840:000000': '',
+            'RA@841:000000': '',
+            'RA@480:000000': '',
+            'RA@481:000000': '',
+            'RA@482:000000': '',
+            'RF@89:5DC': '',                    #RF=set default fade rate
+            'EM@B40:0,1,7D0,1F4,9C4,5DC': '',   #EM=configure motor
+            'EM@B40:1,1,7D0,3E8,7D0,5DC': '',
+            'EM@882:7,1,7D0,3E8,7D0,5DC': '',
+            'MP@B40:0,7F,7D0': '',              #MP=set motor position
+            'MP@B40:1,7F,7D0': '',
+            'MP@882:7,7F,7D0': '',
+        }
 
     def test_servo(self):
         # go to min position
         self.exp_cpu.expected_commands = {
-                "MP@B40:0,00,7D0": ""                    # MP:<INDEX>,<POSITION>,<TIME_MS><CR>
+            "MP@B40:0,00,7D0": "" # MP:<INDEX>,<POSITION>,<TIME_MS><CR>
         }
         self.machine.servos["servo1"].go_to_position(0)
         self.advance_time_and_run(1)
@@ -136,7 +137,8 @@ class TestFastExp(TestFastBase):
         self.exp_cpu.expected_commands = {
             'RD@880:0201ff123402121212': '', #RD=set individual leds by binary
             'RD@881:0100ffffff': '',
-            'RD@841:0160ffffff': ','}
+            'RD@841:0160ffffff': ','
+        }
 
         self.led1.on()
         self.led2.color("ff1234")
@@ -173,7 +175,8 @@ class TestFastExp(TestFastBase):
         self.exp_cpu.expected_commands = {
             'RD@881:0100ff1234': '',
             'RD@880:0102467fff': '',
-            'RD@B40:016a6a6a6a': '',}
+            'RD@B40:016a6a6a6a': '',
+        }
 
         self.led1.color("ff1234")
         self.led3.color("467fff")
@@ -219,11 +222,13 @@ class TestFastExp(TestFastBase):
 
     def _test_led_software_fade(self):
 
-        self.exp_cpu.expected_commands = {'RD@B40:0169151515': '',
-                                          'RD@B40:01692b2b2b': '',
-                                          'RD@B40:0169424242': '',
-                                          'RD@B40:0169585858': '',
-                                          'RD@B40:0169646464': '',}
+        self.exp_cpu.expected_commands = {
+            'RD@B40:0169151515': '',
+            'RD@B40:01692b2b2b': '',
+            'RD@B40:0169424242': '',
+            'RD@B40:0169585858': '',
+            'RD@B40:0169646464': '',
+        }
 
         self.led17.color(RGBColor((100, 100, 100)), fade_ms=150)
         self.advance_time_and_run(.04)

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -155,7 +155,7 @@ class TestFastExp(TestFastBase):
         self.exp_cpu.expected_commands = {
             'RD@880:0201ff123402121212': '', #RD=set individual leds by binary
             'RD@881:0100ffffff': '',
-            'RD@841:0160ffffff': ','
+            'RD@841:017fffffff': ','
         }
 
         self.led1.on()

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -20,14 +20,14 @@ class TestFastExp(TestFastBase):
         self.serial_connections['exp'].expected_commands = {
             # ER=configure non-default headers
             # ER:<port>,<type>,<start>,<count><CR>
-            'ER@84:0,0,00,10': '', #16 on port 1
-            'ER@84:1,0,10,32': '', #50 on port 2
-            'ER@84:2,0,42,08': '', # 8 on port 3
-            'ER@84:3,0,4A,36': '', #54 on port 4
-            'ER@84:4,0,00,00': '', # 0 on port 5
-            'ER@84:5,0,00,40': '', #64 on port 6
-            'ER@84:6,0,40,40': '', #64 on port 7
-            'ER@84:7,0,80,00': '', # 0 on port 8
+            'ER@840:0,0,00,10': '', #16 on port 1
+            'ER@840:1,0,10,32': '', #50 on port 2
+            'ER@840:2,0,42,08': '', # 8 on port 3
+            'ER@840:3,0,4A,36': '', #54 on port 4
+            'ER@841:0,0,00,00': '', # 0 on port 5
+            'ER@841:1,0,00,40': '', #64 on port 6
+            'ER@841:2,0,40,40': '', #64 on port 7
+            'ER@841:3,0,80,00': '', # 0 on port 8
 
             #RA=set all on breakout to color
             'RA@880:000000': '',

--- a/mpf/tests/test_Fast_Exp.py
+++ b/mpf/tests/test_Fast_Exp.py
@@ -18,7 +18,19 @@ class TestFastExp(TestFastBase):
         # Individual tests can override / add as needed
 
         self.serial_connections['exp'].expected_commands = {
-            'RA@880:000000': '',                #RA=set all on breakout to color
+            # ER=configure non-default headers
+            # ER:<port>,<type>,<start>,<count><CR>
+            'ER@84:0,0,00,10': '', #16 on port 1
+            'ER@84:1,0,10,32': '', #50 on port 2
+            'ER@84:2,0,42,08': '', # 8 on port 3
+            'ER@84:3,0,4A,36': '', #54 on port 4
+            'ER@84:4,0,00,00': '', # 0 on port 5
+            'ER@84:5,0,00,40': '', #64 on port 6
+            'ER@84:6,0,40,40': '', #64 on port 7
+            'ER@84:7,0,80,00': '', # 0 on port 8
+
+            #RA=set all on breakout to color
+            'RA@880:000000': '',
             'RA@881:000000': '',
             'RA@882:000000': '',
             'RA@890:000000': '',
@@ -29,11 +41,17 @@ class TestFastExp(TestFastBase):
             'RA@480:000000': '',
             'RA@481:000000': '',
             'RA@482:000000': '',
-            'RF@89:5DC': '',                    #RF=set default fade rate
-            'EM@B40:0,1,7D0,1F4,9C4,5DC': '',   #EM=configure motor
+
+            #RF=set default fade rate
+            'RF@89:5DC': '',
+
+            #EM=configure motor
+            'EM@B40:0,1,7D0,1F4,9C4,5DC': '',
             'EM@B40:1,1,7D0,3E8,7D0,5DC': '',
             'EM@882:7,1,7D0,3E8,7D0,5DC': '',
-            'MP@B40:0,7F,7D0': '',              #MP=set motor position
+
+            #MP=set motor position
+            'MP@B40:0,7F,7D0': '',
             'MP@B40:1,7F,7D0': '',
             'MP@882:7,7F,7D0': '',
         }


### PR DESCRIPTION
Work in progress - MPF now can accept a custom count per header and send the ER commands necessary to make it happen

Notes: BR will reset the board state, so ER must be done after it
Tests should generally work, but no test exists to check that >128 errors

Addressing of the LEDs uses the old numbering, which is a little confusing. EG if you configure port 1 to have 1 light, and port 2 to take the other 31 (so it has 63), then exp_board-1-1 is the first light on the first string, then exp_board-1-2 is the first light on the second string. exp_board-2-1 would actually be the 32nd light on the second string, because all of the port 1 lights would have been pushed in front of it. This can be fixed in fast.py configure_light/port_idx_to_hex/parse_light_number_to_channels but it may be a surprisingly wide area we need to fix up to support this. It also somewhat requires the lights-per-header details to be resolved before any lights can be registered. Maybe that setup order dependency is already satisfied though