### PR TITLE
Fix shot#persist_enable=false

### DIFF
--- a/mpf/tests/machine_files/shots/config/test_shots.yaml
+++ b/mpf/tests/machine_files/shots/config/test_shots.yaml
@@ -6,6 +6,7 @@ modes:
   - mode1
   - mode2
   - mode3
+  - mode_test_persist_enable
 
 switches:
   switch_1:
@@ -59,6 +60,8 @@ switches:
   switch_27:
     number:
   switch_28:
+    number:
+  switch_29:
     number:
 
 lights:

--- a/mpf/tests/machine_files/shots/modes/mode_test_persist_enable/config/mode_test_persist_enable.yaml
+++ b/mpf/tests/machine_files/shots/modes/mode_test_persist_enable/config/mode_test_persist_enable.yaml
@@ -1,0 +1,31 @@
+#config_version=6
+
+mode:
+  priority: 100
+
+shot_profiles:
+  pe_profile:
+    advance_on_hit: false
+    states:
+      - name: pe_state_1
+      - name: pe_state_2
+
+shots:
+  pe_test_default:
+    switch: switch_29
+    # persist_enable: default
+    profile: pe_profile
+    disable_events: pe_test_disable_all_shots
+    enable_events: pe_test_enable_all_shots
+  pe_test_property_enabled:
+    switch: switch_29
+    persist_enable: true
+    profile: pe_profile
+    disable_events: pe_test_disable_all_shots
+    enable_events: pe_test_enable_all_shots
+  pe_test_property_disabled:
+    switch: switch_29
+    persist_enable: false
+    profile: pe_profile
+    disable_events: pe_test_disable_all_shots
+    enable_events: pe_test_enable_all_shots

--- a/mpf/tests/machine_files/shots/modes/mode_test_persist_enable/config/mode_test_persist_enable.yaml
+++ b/mpf/tests/machine_files/shots/modes/mode_test_persist_enable/config/mode_test_persist_enable.yaml
@@ -11,21 +11,31 @@ shot_profiles:
       - name: pe_state_2
 
 shots:
+  pe_test_property_disabled:
+    profile: pe_profile
+    switch: switch_29
+    start_enabled: false
+    persist_enable: false #field under test
+    disable_events: pe_test_disable_all_shots
+    enable_events: pe_test_enable_all_shots
   pe_test_default:
     switch: switch_29
-    # persist_enable: default
     profile: pe_profile
+    start_enabled: false
+    # persist_enable: default is true #field under test
     disable_events: pe_test_disable_all_shots
     enable_events: pe_test_enable_all_shots
   pe_test_property_enabled:
     switch: switch_29
-    persist_enable: true
     profile: pe_profile
+    start_enabled: false
+    persist_enable: true #field under test
     disable_events: pe_test_disable_all_shots
     enable_events: pe_test_enable_all_shots
-  pe_test_property_disabled:
+  pe_test_property_enabled_default_enabled:
     switch: switch_29
-    persist_enable: false
     profile: pe_profile
+    start_enabled: true #field under test
+    persist_enable: true #field under test
     disable_events: pe_test_disable_all_shots
     enable_events: pe_test_enable_all_shots

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -1028,36 +1028,52 @@ class TestShots(MpfTestCase):
         test_mode = self.machine.modes["mode_test_persist_enable"]
         test_mode.start()
 
+        shot_pe_test_property_disabled = self.machine.shots["pe_test_property_disabled"]
         shot_pe_test_default = self.machine.shots["pe_test_default"]
         shot_pe_test_property_enabled = self.machine.shots["pe_test_property_enabled"]
-        shot_pe_test_property_disabled = self.machine.shots["pe_test_property_disabled"]
+        shot_pe_test_property_enabled_default_enabled = self.machine.shots["pe_test_property_enabled_default_enabled"]
 
+        # Check the configs
+        self.assertFalse(shot_pe_test_property_disabled.config['persist_enable'])
+        self.assertTrue(shot_pe_test_default.config['persist_enable'])
+        self.assertTrue(shot_pe_test_property_enabled.config['persist_enable'])
+        self.assertTrue(shot_pe_test_property_enabled_default_enabled.config['persist_enable'])
+
+        # Test clean start values - all are start_enabled: false
+        self.assertFalse(shot_pe_test_property_disabled.enabled)
         self.assertFalse(shot_pe_test_default.enabled)
         self.assertFalse(shot_pe_test_property_enabled.enabled)
-        self.assertFalse(shot_pe_test_property_disabled.enabled)
+        self.assertTrue(shot_pe_test_property_enabled_default_enabled.enabled)
 
         self.post_event("pe_test_enable_all_shots")
 
-        self.assertTrue(shot_pe_test_default.enabled)
-        self.assertTrue(shot_pe_test_property_enabled.enabled)
+        # Everything uses the same enable event
         self.assertTrue(shot_pe_test_property_disabled.enabled)
-
-        test_mode.stop()
-        test_mode.start()
-
         self.assertTrue(shot_pe_test_default.enabled)
         self.assertTrue(shot_pe_test_property_enabled.enabled)
-        self.assertFalse(shot_pe_test_property_disabled.enabled)
-
-        self.post_event("pe_test_enable_all_shots")
-
-        self.assertFalse(shot_pe_test_default.enabled)
-        self.assertFalse(shot_pe_test_property_enabled.enabled)
-        self.assertFalse(shot_pe_test_property_disabled.enabled)
+        self.assertTrue(shot_pe_test_property_enabled_default_enabled.enabled)
 
         test_mode.stop()
         test_mode.start()
 
+        # Default and true should preserve the enable, false should start false again
+        # self.assertFalse(shot_pe_test_property_disabled.enabled) #TODO this is failing
+        self.assertTrue(shot_pe_test_default.enabled)
+        self.assertTrue(shot_pe_test_property_enabled.enabled)
+        self.assertTrue(shot_pe_test_property_enabled_default_enabled.enabled)
+
+        self.post_event("pe_test_disable_all_shots")
+
+        # Everything uses the same disable event
+        self.assertFalse(shot_pe_test_property_disabled.enabled)
         self.assertFalse(shot_pe_test_default.enabled)
         self.assertFalse(shot_pe_test_property_enabled.enabled)
+        self.assertFalse(shot_pe_test_property_enabled_default_enabled.enabled)
+
+        test_mode.stop()
+        test_mode.start()
+
         self.assertFalse(shot_pe_test_property_disabled.enabled)
+        self.assertFalse(shot_pe_test_default.enabled)
+        self.assertFalse(shot_pe_test_property_enabled.enabled)
+        self.assertFalse(shot_pe_test_property_enabled_default_enabled.enabled)

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -1057,7 +1057,7 @@ class TestShots(MpfTestCase):
         test_mode.start()
 
         # Default and true should preserve the enable, false should start false again
-        # self.assertFalse(shot_pe_test_property_disabled.enabled) #TODO this is failing
+        self.assertFalse(shot_pe_test_property_disabled.enabled) #TODO this is failing
         self.assertTrue(shot_pe_test_default.enabled)
         self.assertTrue(shot_pe_test_property_enabled.enabled)
         self.assertTrue(shot_pe_test_property_enabled_default_enabled.enabled)

--- a/mpf/tests/test_Shots.py
+++ b/mpf/tests/test_Shots.py
@@ -1021,3 +1021,43 @@ class TestShots(MpfTestCase):
         self.advance_time_and_run()
         self.post_event("state_event2")
         self.assertEqual("None", shot2.state_name)
+
+    def test_persist_enable(self):
+        """Test shot#persist_enable functionality"""
+        self.start_game()
+        test_mode = self.machine.modes["mode_test_persist_enable"]
+        test_mode.start()
+
+        shot_pe_test_default = self.machine.shots["pe_test_default"]
+        shot_pe_test_property_enabled = self.machine.shots["pe_test_property_enabled"]
+        shot_pe_test_property_disabled = self.machine.shots["pe_test_property_disabled"]
+
+        self.assertFalse(shot_pe_test_default.enabled)
+        self.assertFalse(shot_pe_test_property_enabled.enabled)
+        self.assertFalse(shot_pe_test_property_disabled.enabled)
+
+        self.post_event("pe_test_enable_all_shots")
+
+        self.assertTrue(shot_pe_test_default.enabled)
+        self.assertTrue(shot_pe_test_property_enabled.enabled)
+        self.assertTrue(shot_pe_test_property_disabled.enabled)
+
+        test_mode.stop()
+        test_mode.start()
+
+        self.assertTrue(shot_pe_test_default.enabled)
+        self.assertTrue(shot_pe_test_property_enabled.enabled)
+        self.assertFalse(shot_pe_test_property_disabled.enabled)
+
+        self.post_event("pe_test_enable_all_shots")
+
+        self.assertFalse(shot_pe_test_default.enabled)
+        self.assertFalse(shot_pe_test_property_enabled.enabled)
+        self.assertFalse(shot_pe_test_property_disabled.enabled)
+
+        test_mode.stop()
+        test_mode.start()
+
+        self.assertFalse(shot_pe_test_default.enabled)
+        self.assertFalse(shot_pe_test_property_enabled.enabled)
+        self.assertFalse(shot_pe_test_property_disabled.enabled)


### PR DESCRIPTION
It seems that the enabled status is persisted whether you like it or not. I have a test case that passes for other property combinations, but not this one. Need to still figure out the root cause/fix