### PR TITLE
use per-player score value when calculating average in audits

### DIFF
--- a/mpf/plugins/auditor.py
+++ b/mpf/plugins/auditor.py
@@ -236,17 +236,19 @@ class Auditor(MpfPlugin):
                 if item not in self.machine.game.player.vars:
                     continue
 
+                value = player[item]
+
                 self.current_audits['player'][item]['top'] = (
                     self._merge_into_top_list(
-                        player[item],
+                        value,
                         self.current_audits['player'][item]['top'],
                         self.config['num_player_top_records']))
 
-                self.current_audits['player'][item]['average'] = int(
-                    ((self.current_audits['player'][item]['total'] *
-                      self.current_audits['player'][item]['average']) +
-                     self.machine.game.player[item]) /
-                    (self.current_audits['player'][item]['total'] + 1))
+                self.current_audits['player'][item]['average'] = int((
+                    (self.current_audits['player'][item]['total']
+                        * self.current_audits['player'][item]['average'])
+                    + value
+                ) / (self.current_audits['player'][item]['total'] + 1))
 
                 self.current_audits['player'][item]['total'] += 1
         if self._autosave:

--- a/mpf/tests/test_Auditor.py
+++ b/mpf/tests/test_Auditor.py
@@ -167,3 +167,26 @@ class TestAuditor(MpfFakeGameTestCase):
         self.assertEqual(0, data_manager.written_data['switches']['s_test'])
         self.assertEqual(0, auditor.current_audits['events']['game_started'])
         self.assertEqual(0, data_manager.written_data['events']['game_started'])
+
+    def test_auditor_score_statistics(self):
+        auditor = self.machine.plugins[0]
+        self.assertIsInstance(auditor, Auditor)
+
+        self.start_two_player_game()
+        self.post_event("add_score")
+        self.post_event("add_score")
+        self.assertPlayerVarEqual(200, "score")
+        self.drain_all_balls()
+        self.assertPlayerVarEqual(0, "score")
+        self.post_event("add_score")
+        self.post_event("add_score")
+        self.post_event("add_score")
+        self.post_event("add_score")
+        self.post_event("add_score")
+        self.assertPlayerVarEqual(500, "score")
+        self.drain_all_balls()
+        self.assertGameIsNotRunning()
+
+        self.assertEqual(350, auditor.current_audits['player']['score']['average'])
+        self.assertEqual([500, 200], auditor.current_audits['player']['score']['top'])
+        self.assertEqual(2, auditor.current_audits['player']['score']['total'])


### PR DESCRIPTION
Still adding a test case for this, but this should fix average calculations in multiplayer games