### PR TITLE
allow FAST port detector to actually retry on timeouts

### DIFF
--- a/mpf/platforms/fast/fast_port_detector.py
+++ b/mpf/platforms/fast/fast_port_detector.py
@@ -82,7 +82,7 @@ class FastPortDetector:
                 try:
                     data = await asyncio.wait_for(reader.read(100), timeout=1.0)
                 except asyncio.TimeoutError:
-                    pass
+                    data = None
 
                 if data:
                     data = data.decode('utf-8', errors='ignore')


### PR DESCRIPTION
Using pass silences follow-on errors, and I think we're getting one (maybe data is populated with something truthy but crashy?) and never actually retrying. I'm also not certain that log lines from the async tasks are actually getting printed (even with -vV etc), so I had to resort to debugging with just `print` heh.