### PR TITLE
support template_ms for diverter activation_time config

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -449,7 +449,7 @@ diverters:
     __type__: device
     activate_events: event_handler|event_handler:ms|None
     activation_coil: single|machine(coils)|None
-    activation_time: single|ms|0
+    activation_time: single|template_ms|None
     activation_switches: list|machine(switches)|None
     allow_multiple_concurrent_ejects_to_same_side: single|bool|true
     cool_down_time: single|ms|0

--- a/mpf/devices/diverter.py
+++ b/mpf/devices/diverter.py
@@ -258,7 +258,7 @@ class Diverter(SystemWideDevice):
     def schedule_deactivation(self):
         """Schedule a delay to deactivate this diverter."""
         if self.config['activation_time']:
-            self.delay.add(name='deactivate_timed', ms=self.config['activation_time'],
+            self.delay.add(name='deactivate_timed', ms=self.config['activation_time'].evaluate({}),
                            callback=self.deactivate)
 
     def _enable_switches(self):

--- a/mpf/tests/machine_files/diverter/config/test_hold_activation_time_template.yaml
+++ b/mpf/tests/machine_files/diverter/config/test_hold_activation_time_template.yaml
@@ -1,0 +1,24 @@
+#config_version=6
+
+config:
+- config.yaml
+
+diverters:
+    d_test_activation_time_template:
+        activation_coil: c_diverter
+        activation_switches: s_diverter
+        type: hold
+        feeder_devices: test_trough
+        targets_when_active: playfield
+        targets_when_inactive: test_target
+        activation_time: settings.d_test_activation_time
+        debug: True
+
+settings:
+    d_test_activation_time:
+        sort: 1212
+        label: Diverter test activation time
+        key_type: int
+        default: 12000
+        values:
+            12000: '12s'

--- a/mpf/tests/test_Diverter.py
+++ b/mpf/tests/test_Diverter.py
@@ -175,6 +175,55 @@ class TestDiverter(MpfTestCase):
         self.advance_time_and_run(4)
         assert not self.machine.coils["c_diverter"].enable.called
 
+    @test_config("test_hold_activation_time_template.yaml")
+    def test_activation_time_template(self):
+        diverter = self.machine.diverters["d_test_activation_time_template"]
+
+        self.machine.coils["c_diverter"].enable = MagicMock()
+        self.machine.coils["c_diverter"].disable = MagicMock()
+
+        self.assertFalse(diverter.enabled)
+        self.assertFalse(diverter.active)
+
+        self.machine.playfield.config['default_source_device'] = self.machine.ball_devices["test_trough"]
+        self.machine.playfield.add_ball()
+
+        self.advance_time_and_run(1)
+        self.assertTrue(diverter.enabled)
+        self.assertFalse(diverter.active)
+
+        self.hit_and_release_switch("s_diverter")
+        self.advance_time_and_run(0.5)
+        self.assertTrue(diverter.enabled)
+        self.assertTrue(diverter.active)
+        self.machine.coils["c_diverter"].enable.assert_called_once_with()
+        self.machine.coils["c_diverter"].enable = MagicMock()
+        assert not self.machine.coils["c_diverter"].disable.called
+
+        self.advance_time_and_run(12)
+        self.machine.coils["c_diverter"].disable.assert_called_once_with()
+        assert not self.machine.coils["c_diverter"].enable.called
+
+        self.hit_and_release_switch("s_playfield")
+        self.machine_run()
+        self.assertFalse(diverter.active)
+
+        self.hit_switch_and_run("s_ball_switch1", 1)
+        self.machine.playfield.config['default_source_device'] = self.machine.ball_devices["test_target"]
+        self.machine.playfield.add_ball()
+
+        self.advance_time_and_run(3)
+        self.assertFalse(diverter.enabled)
+        self.assertFalse(diverter.active)
+
+        self.hit_and_release_switch("s_diverter")
+        self.advance_time_and_run(0.5)
+        self.assertFalse(diverter.enabled)
+        self.assertFalse(diverter.active)
+
+        self.advance_time_and_run(4)
+        assert not self.machine.coils["c_diverter"].enable.called
+
     @test_config("test_hold_no_activation_time.yaml")
     def test_hold_no_activation_time(self):
         diverter = self.machine.diverters["d_test_hold"]


### PR DESCRIPTION
Had to change the default to None instead of 0 so that the existing behaviors that checked for falsy/unset config would continue to skip appropriately