### PR TITLE
Update item highlighted event comment

### DIFF
--- a/mpf/modes/carousel/code/carousel.py
+++ b/mpf/modes/carousel/code/carousel.py
@@ -101,10 +101,12 @@ class Carousel(Mode):
                                  carousel=self.name,
                                  direction=direction,
                                  item=self._get_highlighted_item())
-        '''event (carousel_name)_(item)_highlighted
+        '''event item_highlighted
             desc: Player highlighted an item in a carousel. Mostly used to play shows or trigger slides.
             args:
+               carousel: The name of the carousel that posted this event.
                direction: The direction the carousel is moving. Either forwards or backwards. None on mode start.
+               item: The name of the item that is now highlighted.
             '''
 
     def _get_available_items(self):


### PR DESCRIPTION
Note: Comment-only change.

Noticed this while helping Ernie debug his new game.

0.57 called this (carousel)_(item)_highlighted but .80 changed to the static name "item_highlighted" so that GMC could interpret it cleanly (see: https://github.com/missionpinball/mpf-gmc/blob/43170784272f4e89c754288532b874a5f11efb99/addons/mpf-gmc/scripts/bcp_server.gd#L349 )

I'm pretty radical, but I think that no device names nor custom field values should be in event names, preferring everything in event params instead, partly because it would make mapping other events into the GMC handler trivial. OTOH I haven't had any need to map any more events either. Could be fun for a 1.0 overhaul something though when we all win the lottery :P