### PR TITLE
increase default number of top player scores kept in audits

### DIFF
--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -249,7 +249,7 @@ auditor:
       -  game_started
       -  ball_ended
       -  game_ended
-    num_player_top_records: 10
+    num_player_top_records: 50
     audit:
       -  shots
       -  switches


### PR DESCRIPTION
We've been keeping only 10 scores in the audit log for over a decade. I propose the default be changed to 1000 or more. I think the default audits are good enough that most developers will not dig into customizing them for a long time, and before they ever do it would be nice to store more than just 10 scores.

I guess what I'd really rather have is a time+score audit trail rather than top score, since top will resort over time. But rather than build out yet another thing, let's start with making the default more useful.