### PR TITLE
Breaking change -- rename carousel events to have static names

### DIFF
--- a/mpf/modes/carousel/code/carousel.py
+++ b/mpf/modes/carousel/code/carousel.py
@@ -57,11 +57,12 @@ class Carousel(Mode):
             elif not item.condition or item.condition.evaluate({}):
                 self._items.append(item.name)
         if not self._items:
-            self.machine.events.post("{}_items_empty".format(self.name))
-            '''event (carousel_name)_items_empty
+            self.machine.events.post("carousel_items_empty", carousel=self.name)
+            '''event carousel_items_empty
                 desc: A carousel's items are all conditional and all evaluated false.
-                    If this event is posted, the carousel mode will not be started.
-                '''
+                    If this event is posted, the carousel mode will also stop itself
+                    instead of continuing to start and run.
+            '''
             self.stop()
             return
 
@@ -97,17 +98,17 @@ class Carousel(Mode):
     def _update_highlighted_item(self, direction):
         self.debug_log("Highlighted item: " + self._get_highlighted_item())
 
-        self.machine.events.post("item_highlighted",
+        self.machine.events.post("carousel_item_highlighted",
                                  carousel=self.name,
                                  direction=direction,
                                  item=self._get_highlighted_item())
-        '''event item_highlighted
+        '''event carousel_item_highlighted
             desc: Player highlighted an item in a carousel. Mostly used to play shows or trigger slides.
             args:
                carousel: The name of the carousel that posted this event.
                direction: The direction the carousel is moving. Either forwards or backwards. None on mode start.
                item: The name of the item that is now highlighted.
-            '''
+        '''
 
     def _get_available_items(self):
         # Return the default items
@@ -145,13 +146,13 @@ class Carousel(Mode):
         self.debug_log("Selected mode: " + str(self._get_highlighted_item()))
         self._done = True
 
-        self.machine.events.post("{}_{}_selected".format(self.name, self._get_highlighted_item()))
-        '''event (carousel_name)_(item)_selected
-            desc: Player selected an item in a carousel. Can be used to trigger modes. '''
-        self.machine.events.post("{}_item_selected".format(self.name))
-        '''event (carousel_name)_item_selected
-            desc: Player selected any item in a carousel. Used to stop mode. '''
-
+        self.machine.events.post("carousel_item_selected", carousel=self.name, item=self._get_highlighted_item())
+        '''event carousel_item_selected
+            desc: Player selected an item in a carousel.
+            args:
+               carousel: The name of the carousel that posted this event.
+               item: The name of the item that is being selected.
+        '''
     def _block_enable(self, **kwargs):
         del kwargs
         self._is_blocking = True

--- a/mpf/tests/machine_files/carousel/modes/conditional_carousel/config/conditional_carousel.yaml
+++ b/mpf/tests/machine_files/carousel/modes/conditional_carousel/config/conditional_carousel.yaml
@@ -1,7 +1,7 @@
 #config_version=6
 mode:
   start_events: start_mode3
-  stop_events: stop_mode3, conditional_carousel_item_selected
+  stop_events: stop_mode3, carousel_item_selected{carousel==conditional_carousel}
   code: mpf.modes.carousel.code.carousel.Carousel
 
 mode_settings:

--- a/mpf/tests/test_CarouselMode.py
+++ b/mpf/tests/test_CarouselMode.py
@@ -24,17 +24,17 @@ class TestCarouselMode(MpfTestCase):
         self.assertIsNone(self.machine.game)
 
     def testBlockingCarousel(self):
-        self.mock_event("item_highlighted")
+        self.mock_event("carousel_item_highlighted")
         self.mock_event("flipper_cancel")
 
         self._start_game()
         self.post_event("start_mode4")
 
         self.assertIn(self.machine.modes["blocking_carousel"], self.machine.mode_controller.active_modes)
-        self.assertEventCalledWith("item_highlighted", carousel="blocking_carousel", item="item1", direction=None)
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="blocking_carousel", item="item1", direction=None)
         self.post_event("s_flipper_right_active")
         self.post_event("s_flipper_right_inactive")
-        self.assertEventCalledWith("item_highlighted", carousel="blocking_carousel", item="item2", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="blocking_carousel", item="item2", direction="forwards")
         self.assertEqual(0, self._events["flipper_cancel"])
         self.post_event("s_flipper_right_active")
         self.post_event("s_flipper_left_active")
@@ -44,7 +44,7 @@ class TestCarouselMode(MpfTestCase):
         self.assertEqual(1, self._events["flipper_cancel"])
         self.post_event("both_flippers_inactive")
         self.post_event("s_flipper_right_inactive")
-        self.assertEventCalledWith("item_highlighted", carousel="blocking_carousel", item="item3", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="blocking_carousel", item="item3", direction="forwards")
 
         # Restart the mode to ensure that the block is cleared
         self.post_event("flipper_cancel")
@@ -53,87 +53,87 @@ class TestCarouselMode(MpfTestCase):
         self.post_event("start_mode4")
         self.post_event("s_flipper_right_inactive")
         # item2 highlighted should be called when a blocked mode restarts
-        self.assertEventCalledWith("item_highlighted", carousel="blocking_carousel", item="item2", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="blocking_carousel", item="item2", direction="forwards")
 
     def testNoWrapCarousel(self):
 
-        self.mock_event("item_highlighted")
+        self.mock_event("carousel_item_highlighted")
         self._start_game()
         self.post_event("start_mode_nowrap_carousel")
         self.advance_time_and_run()
         #self.assertEqual(1, self._events["nowrap_carousel_item1_highlighted"])
-        self.assertEventCalledWith("item_highlighted", carousel="nowrap_carousel", item="item1", direction=None)
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="nowrap_carousel", item="item1", direction=None)
 
         # Advance forward one and back
         self.post_event("next")
         self.advance_time_and_run()
         #self.assertEqual(1, self._events["nowrap_carousel_item1_highlighted"])
         #self.assertEqual(1, self._events["nowrap_carousel_item2_highlighted"])
-        self.assertEventCalledWith("item_highlighted", carousel="nowrap_carousel", item="item2", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="nowrap_carousel", item="item2", direction="forwards")
 
         self.post_event("previous")
         self.advance_time_and_run()
 
-        self.assertEventCalledWith("item_highlighted", carousel="nowrap_carousel", item="item1", direction="backwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="nowrap_carousel", item="item1", direction="backwards")
         # Try and go back but fail
-        self.mock_event("item_highlighted")
+        self.mock_event("carousel_item_highlighted")
         self.post_event("previous")
         self.advance_time_and_run()
-        self.assertEventNotCalled("item_highlighted")
+        self.assertEventNotCalled("carousel_item_highlighted")
         self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 0)
         self.post_event("previous")
         self.advance_time_and_run()
-        self.assertEventNotCalled("item_highlighted")
+        self.assertEventNotCalled("carousel_item_highlighted")
         self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 0)
 
         # Go forward to the last item
         self.post_event("next")
         self.advance_time_and_run()
-        self.assertEventCalledWith("item_highlighted", carousel="nowrap_carousel", item="item2", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="nowrap_carousel", item="item2", direction="forwards")
         self.post_event("next")
         self.advance_time_and_run()
-        self.assertEventCalledWith("item_highlighted", carousel="nowrap_carousel", item="item3", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="nowrap_carousel", item="item3", direction="forwards")
         # Try and go forward but fail
-        self.mock_event("item_highlighted")
+        self.mock_event("carousel_item_highlighted")
         self.post_event("next")
         self.advance_time_and_run()
-        self.assertEventNotCalled("item_highlighted")
+        self.assertEventNotCalled("carousel_item_highlighted")
         self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 2)
         self.post_event("next")
         self.advance_time_and_run()
-        self.assertEventNotCalled("item_highlighted")
+        self.assertEventNotCalled("carousel_item_highlighted")
         self.assertEqual(self.machine.modes["nowrap_carousel"]._highlighted_item_index, 2)
 
     def testConditionalCarousel(self):
-        self.mock_event("item_highlighted")
+        self.mock_event("carousel_item_highlighted")
 
         self._start_game()
 
         # Start the mode without any conditions true
         self.post_event("start_mode3")
         self.assertIn(self.machine.modes["conditional_carousel"], self.machine.mode_controller.active_modes)
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item1", direction=None)
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item1", direction=None)
         self.post_event("next")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
         self.post_event("next")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
         self.post_event("stop_mode3")
 
         # Reset the count for item 1
-        self.mock_event("item_highlighted")
+        self.mock_event("carousel_item_highlighted")
         # Start the mode with a player variable condition
         self.machine.game.player["show_item4"] = True
         self.post_event("start_mode3")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item1", direction=None)
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item1", direction=None)
         self.post_event("next")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item4", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item4", direction="forwards")
         self.post_event("next")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
         self.post_event("stop_mode3")
 
         # Reset the count for items 1 and 4
@@ -143,28 +143,26 @@ class TestCarouselMode(MpfTestCase):
         self.machine.game.player["show_item4"] = False
         self.post_event("start_mode3")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item1", direction=None)
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item1", direction=None)
         self.post_event("next")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item3", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item3", direction="forwards")
         self.post_event("next")
 
-        self.assertEventCalledWith("item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="conditional_carousel", item="item1", direction="forwards")
         self.post_event("stop_mode3")
 
         # The mode shouldn't start if all conditions are false (i.e. no items)
-        self.mock_event("conditional_carousel_items_empty")
+        self.mock_event("carousel_items_empty")
         self.machine.game.player["hide_item1"] = "truthy"
         self.machine.variables.set_machine_var("player2_score", 0)
         self.post_event("start_mode3")
-        self.assertEqual(1, self._events["conditional_carousel_items_empty"])
+        self.assertEqual(1, self._events["carousel_items_empty"])
         self.assertNotIn(self.machine.modes["conditional_carousel"], self.machine.mode_controller.active_modes)
 
     def testExtraBall(self):
-        self.mock_event("item_highlighted")
-        self.mock_event("carousel_item1_selected")
-        self.mock_event("carousel_item2_selected")
-        self.mock_event("carousel_item3_selected")
+        self.mock_event("carousel_item_highlighted")
+        self.mock_event("carousel_item_selected")
 
         # start game
         self._start_game()
@@ -172,22 +170,22 @@ class TestCarouselMode(MpfTestCase):
         self.post_event("start_mode1")
         self.assertIn(self.machine.modes["carousel"], self.machine.mode_controller.active_modes)
 
-        self.assertEventCalledWith("item_highlighted", carousel="carousel", item="item1", direction=None)
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="carousel", item="item1", direction=None)
         self.post_event("next")
-        self.assertEventCalledWith("item_highlighted", carousel="carousel", item="item2", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="carousel", item="item2", direction="forwards")
         self.post_event("next")
-        self.assertEventCalledWith("item_highlighted", carousel="carousel", item="item3", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="carousel", item="item3", direction="forwards")
         self.post_event("next")
-        self.assertEventCalledWith("item_highlighted", carousel="carousel", item="item1", direction="forwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="carousel", item="item1", direction="forwards")
         self.post_event("previous2")
-        self.assertEventCalledWith("item_highlighted", carousel="carousel", item="item3", direction="backwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="carousel", item="item3", direction="backwards")
         self.post_event("previous")
-        self.assertEventCalledWith("item_highlighted", carousel="carousel", item="item2", direction="backwards")
+        self.assertEventCalledWith("carousel_item_highlighted", carousel="carousel", item="item2", direction="backwards")
 
 
+        self.assertEventNotCalled("carousel_item_selected")
         self.post_event("select")
-        self.assertEqual(0, self._events["carousel_item1_selected"])
-        self.assertEqual(1, self._events["carousel_item2_selected"])
-        self.assertEqual(0, self._events["carousel_item3_selected"])
+        self.assertEventCalled("carousel_item_selected", times=1)
+        self.assertEventCalledWith("carousel_item_selected", carousel="carousel", item="item2")
 
         self.assertNotIn(self.machine.modes["carousel"], self.machine.mode_controller.active_modes)


### PR DESCRIPTION
Name and item have been moved to event params where previously part of the name.

Note that this is a divergence from .57 and before, and will require upgrading users to revisit their carousel hooks.

GMC also will need a change (PR link in a moment) to expect the new carousel_item_highlighted event name, which also means that the GMC minimum MPF version would be the next 0.80.0.dev release, dev10 (assuming this gets in there)