### PR TITLE
High score event refactor

### DIFF
--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -6,6 +6,7 @@ from mpf.core.async_mode import AsyncMode
 from mpf.core.player import Player
 
 
+# pylint: disable-msg=line-too-long
 class HighScore(AsyncMode):
 
     """High score mode.
@@ -31,9 +32,7 @@ class HighScore(AsyncMode):
         self.high_scores = self.data_manager.get_data()
 
         self.high_score_config = self.machine.config_validator.validate_config(
-            config_spec='high_score',
-            source=self.config.get('high_score', {}),
-            section_name='high_score')
+            config_spec='high_score', source=self.config.get('high_score', {}), section_name='high_score')
 
         # if data is invalid. do not use it
         if self.high_scores and not self._validate_data(self.high_scores):
@@ -85,8 +84,7 @@ class HighScore(AsyncMode):
                         return False
                 if len(data[category]) != len(self.config['high_score']['defaults'][category]):
                     self.log.warning("High Score Category %s contains %s entries while defaults contain %s",
-                                     category, len(data[category]),
-                                     len(self.config['high_score']['defaults'][category]))
+                                     category, len(data[category]), len(self.config['high_score']['defaults'][category]))
                     return False
 
         except TypeError:
@@ -101,61 +99,48 @@ class HighScore(AsyncMode):
         """
         for category, entries in self.high_score_config['categories'].items():
             try:
-                for position, (label, (name, value, *hs_vars)) in (
-                        enumerate(zip(entries,
-                                      self.high_scores[category]))):
-
+                for position, (label, (name, value, *hs_vars)) in (enumerate(zip(entries, self.high_scores[category]))):
                     self.machine.variables.set_machine_var(
-                        name=category + str(position + 1) + '_label',
-                        value=label)
+                        name=category + str(position + 1) + '_label', value=label)
 
                     '''machine_var: (high_score_category)(position)_label
-
                     desc: The "label" of the high score for that specific
                     score category and position. For example,
                     ``score1_label`` holds the label for the #1 position
                     of the "score" player variable (which might be "GRAND
                     CHAMPION").
-
                     '''
 
                     self.machine.variables.set_machine_var(
-                        name=category + str(position + 1) + '_name',
-                        value=name)
+                        name=category + str(position + 1) + '_name', value=name)
 
                     '''machine_var: (high_score_category)(position)_name
-
-                    desc: Holds the player's name (or initials) for the
-                    high score for that category and position.
-
+                    desc: Holds the player's name (or initials) for the high score for that category and position.
                     '''
 
                     self.machine.variables.set_machine_var(
-                        name=category + str(position + 1) + '_value',
-                        value=value)
+                        name=category + str(position + 1) + '_value', value=value)
 
                     '''machine_var: (high_score_category)(position)_value
-
                     desc: Holds the numeric value for the high score
                     for that category and position.
-
                     '''
 
                     if len(hs_vars) > 0:
                         for k, v in hs_vars[0].items():
                             self.machine.variables.set_machine_var(
-                                name=category + str(position + 1) + '_' + str(k),
-                                value=v)
+                                name=category + str(position + 1) + '_' + str(k), value=v)
 
                     '''machine_var: (high_score_category)(position)_(variable)
-
                     desc: Holds the player or machine variable(s) for the high
                     score for that category and position.
-
                     '''
 
             except KeyError:
                 self.high_scores[category] = list()
+
+    def _get_players(self):
+        return self.machine.game.player_list
 
     # pylint: disable-msg=too-many-nested-blocks
     async def _run(self) -> None:
@@ -178,7 +163,7 @@ class HighScore(AsyncMode):
                     new_list.append(category_high_scores)
 
             # add the players scores from this game to the list
-            for player in self.machine.game.player_list:
+            for player in self._get_players():
                 # if the player var is 0, don't add it. This prevents
                 # values of 0 being added to blank high score lists
                 if player[category_name]:
@@ -196,8 +181,7 @@ class HighScore(AsyncMode):
                     # ask player for initials if we do not know them
                     if not player.initials:
                         try:
-                            player.initials = await self._ask_player_for_initials(player, award_names[i],
-                                                                                  value, category_name)
+                            player.initials = await self._ask_player_for_initials(player, award_names[i], value, category_name)
                         except asyncio.TimeoutError:
                             del new_list[i]
                             # no entry when the player missed the timeout
@@ -205,8 +189,8 @@ class HighScore(AsyncMode):
                     # get vars from config
                     self._load_vars()
                     if category_name in self.vars:
-                        var_dict = self._assign_vars(category_name, player.number - 1)
-                        # add high score with variables
+                        var_dict = self._gather_var_values(category_name, player)
+                        # add high score with resolved variable structure
                         new_list[i] = [player.initials, value, var_dict]
                     else:
                         # add high score without variables
@@ -225,21 +209,23 @@ class HighScore(AsyncMode):
         self._write_scores_to_disk()
         self._create_machine_vars()
 
-    def _assign_vars(self, category_name, player_num_index):
+    def _gather_var_values(self, category_name, player):
         """Define all vars that are for the given category, and assign their values."""
         # create dictionary of the variable name and its value, then load it for the category
-        category_entries = self.vars[category_name]
+        var_config_for_category = self.vars[category_name]
         var_dict = dict()
         j = 0
-        while j < len(category_entries) and bool(self.vars[category_name]):
-            entry = category_entries[j]
-            entry_name = entry[0]
-            entry_score = entry[1]
-            var_dict_key = entry_name + '_' + entry_score
-            if 'player' in entry_name:
-                var_dict[var_dict_key] = self.machine.game.player_list[player_num_index][entry_score]
+        while j < len(var_config_for_category) and bool(var_config_for_category):
+            entry = var_config_for_category[j]
+            var_type = entry[0]  # machine or player
+            var_key = entry[1]  # the property name
+            out_key = var_type + '_' + var_key
+            if 'player' in var_type:
+                var_dict[out_key] = player[var_key]
+            elif 'machine' in var_type:
+                var_dict[out_key] = self.machine.variables.get_machine_var(var_key)
             else:
-                var_dict[var_dict_key] = self.machine.variables.get_machine_var(entry_score)
+                self.warning_log(f"High score could not process var with type {var_type}. Skipping {var_key}.")
             j += 1
         # return the dictionary of items for this specific player and category entry
         return var_dict
@@ -247,13 +233,9 @@ class HighScore(AsyncMode):
     # pylint: disable-msg=too-many-arguments
     async def _ask_player_for_initials(self, player: Player, award_label: str, value: int, category_name: str) -> str:
         """Show text widget to ask player for initials."""
-        self.info_log("New high score. Player: %s, award_label: %s"
-                      ", Value: %s", player, award_label, value)
+        self.info_log("New high score. Player: %s, award_label: %s" ", Value: %s", player, award_label, value)
 
-        self.machine.events.post('high_score_enter_initials',
-                                 award=award_label,
-                                 player_num=player.number,
-                                 value=value)
+        self.machine.events.post('high_score_enter_initials', award=award_label, player_num=player.number, value=value)
 
         event_result = await asyncio.wait_for(
             self.machine.events.wait_for_event("text_input_high_score_complete"),
@@ -278,23 +260,9 @@ class HighScore(AsyncMode):
         if not self.high_score_config['award_slide_display_time']:
             return
 
-        self.machine.events.post(
-            'high_score_award_display',
-            player_name=player_name,
-            award=award,
-            value=value)
-        self.machine.events.post(
-            '{}_award_display'.format(award),
-            player_name=player_name,
-            award=award,
-            value=value)
-        self.machine.events.post(
-            '{}_award_display'.format(category_name),
-            player_num=player_num,
-            player_name=player_name,
-            category_name=category_name,
-            award=award,
-            value=value)
+        self.machine.events.post('high_score_award_display', player_name=player_name, award=award, value=value)
+        self.machine.events.post('{}_award_display'.format(award), player_name=player_name, award=award, value=value)
+        self.machine.events.post('{}_award_display'.format(category_name), player_num=player_num, player_name=player_name, category_name=category_name, award=award, value=value)
         await asyncio.sleep(self.high_score_config['award_slide_display_time'] / 1000)
 
     def _write_scores_to_disk(self) -> None:

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -205,7 +205,7 @@ class HighScore(AsyncMode):
                     # get vars from config
                     self._load_vars()
                     if category_name in self.vars:
-                        var_dict = self._assign_vars(category_name, player)
+                        var_dict = self._assign_vars(category_name, player.number - 1)
                         # add high score with variables
                         new_list[i] = [player.initials, value, var_dict]
                     else:
@@ -225,19 +225,21 @@ class HighScore(AsyncMode):
         self._write_scores_to_disk()
         self._create_machine_vars()
 
-    def _assign_vars(self, category_name, player):
+    def _assign_vars(self, category_name, player_num_index):
         """Define all vars that are for the given category, and assign their values."""
         # create dictionary of the variable name and its value, then load it for the category
-        player_num_index = player.number - 1
+        category_entries = self.vars[category_name]
         var_dict = dict()
         j = 0
-        while j < len(self.vars[category_name]) and bool(self.vars[category_name]):
-            if 'player' in self.vars[category_name][j][0]:
-                var_dict[self.vars[category_name][j][0] + '_' + self.vars[category_name][j][1]] \
-                    = self.machine.game.player_list[player_num_index][self.vars[category_name][j][1]]
+        while j < len(category_entries) and bool(self.vars[category_name]):
+            entry = category_entries[j]
+            entry_name = entry[0]
+            entry_score = entry[1]
+            var_dict_key = entry_name + '_' + entry_score
+            if 'player' in entry_name:
+                var_dict[var_dict_key] = self.machine.game.player_list[player_num_index][entry_score]
             else:
-                var_dict[self.vars[category_name][j][0] + '_' + self.vars[category_name][j][1]] \
-                    = self.machine.variables.get_machine_var(self.vars[category_name][j][1])
+                var_dict[var_dict_key] = self.machine.variables.get_machine_var(entry_score)
             j += 1
         # return the dictionary of items for this specific player and category entry
         return var_dict

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -235,7 +235,16 @@ class HighScore(AsyncMode):
         """Show text widget to ask player for initials."""
         self.info_log("New high score. Player: %s, award_label: %s" ", Value: %s", player, award_label, value)
 
-        self.machine.events.post('high_score_enter_initials', award=award_label, player_num=player.number, value=value)
+        self.machine.events.post('high_score_enter_initials',
+                                 award=award_label, player_num=player.number, value=value, category_name=category_name)
+        '''event high_score_enter_initials
+            desc: A high score has been submitted and the award slide can be displayed.
+            args:
+               player_num: The player number of the player being prompted for a name (counts from 1)
+               category_name: The category name of the award (e.g. "score")
+               award: The name of the award, based on the ordered set of rank names in the category (e.g. "GRAND CHAMPION")
+               value: The numerical value the player achieved
+        '''
 
         event_result = await asyncio.wait_for(
             self.machine.events.wait_for_event("text_input_high_score_complete"),
@@ -260,9 +269,20 @@ class HighScore(AsyncMode):
         if not self.high_score_config['award_slide_display_time']:
             return
 
-        self.machine.events.post('high_score_award_display', player_name=player_name, award=award, value=value)
-        self.machine.events.post('{}_award_display'.format(award), player_name=player_name, award=award, value=value)
-        self.machine.events.post('{}_award_display'.format(category_name), player_num=player_num, player_name=player_name, category_name=category_name, award=award, value=value)
+        self.machine.events.post('high_score_award_display',
+            player_name=player_name, award=award, value=value,
+            player_num=player_num, category_name=category_name)
+
+        '''event high_score_award_display
+            desc: A high score has been submitted and the award slide can be displayed.
+            args:
+               player_name: The text name of the player being awarded.
+               player_num: The player number of the player being awarded (counts from 1)
+               category_name: The category name of the award (e.g. "score")
+               award: The name of the award, based on the ordered set of rank names in the category (e.g. "GRAND CHAMPION")
+               value: The numerical value the player achieved
+        '''
+
         await asyncio.sleep(self.high_score_config['award_slide_display_time'] / 1000)
 
     def _write_scores_to_disk(self) -> None:

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -82,9 +82,11 @@ class HighScore(AsyncMode):
                     if not isinstance(entry[0], str) or not isinstance(entry[1], (int, float)):
                         self.log.warning("Found invalid data type in high score entry.")
                         return False
-                if len(data[category]) != len(self.config['high_score']['defaults'][category]):
+
+                category_default_scores = self.config['high_score']['defaults'][category]
+                if len(data[category]) != len(category_default_scores):
                     self.log.warning("High Score Category %s contains %s entries while defaults contain %s",
-                                     category, len(data[category]), len(self.config['high_score']['defaults'][category]))
+                                     category, len(data[category]), len(category_default_scores))
                     return False
 
         except TypeError:
@@ -181,7 +183,8 @@ class HighScore(AsyncMode):
                     # ask player for initials if we do not know them
                     if not player.initials:
                         try:
-                            player.initials = await self._ask_player_for_initials(player, award_names[i], value, category_name)
+                            text = await self._ask_player_for_initials(player, award_names[i], value, category_name)
+                            player.initials = text
                         except asyncio.TimeoutError:
                             del new_list[i]
                             # no entry when the player missed the timeout
@@ -233,7 +236,7 @@ class HighScore(AsyncMode):
     # pylint: disable-msg=too-many-arguments
     async def _ask_player_for_initials(self, player: Player, award_label: str, value: int, category_name: str) -> str:
         """Show text widget to ask player for initials."""
-        self.info_log("New high score. Player: %s, award_label: %s" ", Value: %s", player, award_label, value)
+        self.info_log("New high score. Player: %s, award_label: %s, Value: %s", player, award_label, value)
 
         self.machine.events.post('high_score_enter_initials',
                                  award=award_label, player_num=player.number, value=value, category_name=category_name)
@@ -242,7 +245,7 @@ class HighScore(AsyncMode):
             args:
                player_num: The player number of the player being prompted for a name (counts from 1)
                category_name: The category name of the award (e.g. "score")
-               award: The name of the award, based on the ordered set of rank names in the category (e.g. "GRAND CHAMPION")
+               award: The award name, based on the ordered set of rank names in the category (e.g. "GRAND CHAMPION")
                value: The numerical value the player achieved
         '''
 
@@ -270,8 +273,8 @@ class HighScore(AsyncMode):
             return
 
         self.machine.events.post('high_score_award_display',
-            player_name=player_name, award=award, value=value,
-            player_num=player_num, category_name=category_name)
+                                 player_name=player_name, award=award, value=value,
+                                 player_num=player_num, category_name=category_name)
 
         '''event high_score_award_display
             desc: A high score has been submitted and the award slide can be displayed.
@@ -279,7 +282,7 @@ class HighScore(AsyncMode):
                player_name: The text name of the player being awarded.
                player_num: The player number of the player being awarded (counts from 1)
                category_name: The category name of the award (e.g. "score")
-               award: The name of the award, based on the ordered set of rank names in the category (e.g. "GRAND CHAMPION")
+               award: The award name, based on the ordered set of rank names in the category (e.g. "GRAND CHAMPION")
                value: The numerical value the player achieved
         '''
 

--- a/mpf/modes/high_score/config/high_score.yaml
+++ b/mpf/modes/high_score/config/high_score.yaml
@@ -42,24 +42,11 @@ slide_player:
   high_score_enter_initials:
     high_score:
         action: play
-  #   high_score_award_display:
-  #       action: remove
-  #   #Make sure to remove any slides you add under this high_score_enter_initials slide, or it will continue to
-  #   #show the award slide instead of initials for another player that also earned a high score.
-  #   score_award_display:
+  # TODO: slide not yet available, but comment section was updated per event name changes
+  #   high_score_award:
   #       action: remove
   # high_score_award_display:
-  #   high_score_award_display:
+  #   high_score_award:
   #       action: play
-  #   high_score_enter_initials:
-  #       action: remove
-  # #This is used to show the slide for a specific award and show additional parameters.  This can include any
-  # #static lables as well as dynamic player and machine variables.
-  # #You will need to generate this block again and swap the name for any subsequent categories that you want
-  # #to show unique additional values.
-  # score_award_display:
-  #   score_award_display:
-  #       action: play
-  #       priority: 1
   #   high_score_enter_initials:
   #       action: remove

--- a/mpf/modes/high_score/config/high_score.yaml
+++ b/mpf/modes/high_score/config/high_score.yaml
@@ -48,5 +48,5 @@ slide_player:
   # high_score_award_display:
   #   high_score_award:
   #       action: play
-  #   high_score_enter_initials:
+  #   high_score:
   #       action: remove

--- a/mpf/tests/test_HighScoreMode.py
+++ b/mpf/tests/test_HighScoreMode.py
@@ -359,7 +359,8 @@ class TestHighScoreMode(MpfBcpTestCase):
         self.assertTrue(self.machine.modes["high_score"].active)
 
         # GC
-        self.assertEventCalledWith('high_score_enter_initials', award='GRAND CHAMPION', player_num=2, value=10000000)
+        self.assertEventCalledWith('high_score_enter_initials',
+            award='GRAND CHAMPION', player_num=2, value=10000000, category_name='score')
         self.mock_event("high_score_enter_initials")
         # wait for timeout
         self.advance_time_and_run(20)
@@ -367,12 +368,13 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         # Player 2 did not react. Player 1 will be GC
         # no further slide in between
-        self.assertEventCalledWith('high_score_enter_initials', award='GRAND CHAMPION', player_num=1, value=8000000)
+        self.assertEventCalledWith('high_score_enter_initials',
+            award='GRAND CHAMPION', player_num=1, value=8000000, category_name='score')
 
-        self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='P2')))
+        self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='P1')))
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='GRAND CHAMPION', player_name='P2', value=8000000)
+        self.assertEventCalledWith("high_score_award_display", player_num=1,
+                                   award='GRAND CHAMPION', player_name='P1', value=8000000, category_name='score')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
@@ -382,7 +384,7 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         # verify the data is accurate
         new_score_data = dict()
-        new_score_data['score'] = [['P2', 8000000],
+        new_score_data['score'] = [['P1', 8000000],
                                    ['BRI', 7050550],
                                    ['GHK', 93060],
                                    ['JK', 87890],
@@ -497,8 +499,8 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='GRAND CHAMPION', player_name='NEW', value=10000000)
+        self.assertEventCalledWith("high_score_award_display", player_num=2,
+                                   award='GRAND CHAMPION', player_name='NEW', value=10000000, category_name='score')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
@@ -508,16 +510,16 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='P1')))
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='HIGH SCORE 1', player_name='P1', value=8000000)
+        self.assertEventCalledWith("high_score_award_display", player_num=1,
+                                   award='HIGH SCORE 1', player_name='P1', value=8000000, category_name='score')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
         # Loops champ should not ask again but show a slide
         self.assertTrue(self.machine.modes["high_score"].active)
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='LOOP CHAMP', player_name='P1', value=50)
+        self.assertEventCalledWith("high_score_award_display", player_num=1,
+                                   award='LOOP CHAMP', player_name='P1', value=50, category_name='loops')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
@@ -537,8 +539,7 @@ class TestHighScoreMode(MpfBcpTestCase):
         # only ask every player once
         self.assertEqual(2, self._events['high_score_enter_initials'])
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)
 
     def test_score_from_nonexistent_player_var(self):
@@ -563,8 +564,7 @@ class TestHighScoreMode(MpfBcpTestCase):
                                     ['MPF', 1000]]
         new_score_data['loops'] = []
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)
 
     def _get_mock_data(self):

--- a/mpf/tests/test_HighScoreModeWithVars.py
+++ b/mpf/tests/test_HighScoreModeWithVars.py
@@ -27,7 +27,7 @@ class TestHighScoreMode(MpfBcpTestCase):
     def test_high_score_one_var(self):
         self.advance_time_and_run()
         self.mock_event("high_score_enter_initials")
-        self.mock_event("loops_award_display")
+        self.mock_event("high_score_award_display")
         # tests loop award with additional variables
         self.machine.modes["high_score"].high_scores = dict()
         self.machine.modes["high_score"].high_scores['loops'] = [('BIL', 2)]
@@ -45,7 +45,7 @@ class TestHighScoreMode(MpfBcpTestCase):
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
         self.advance_time_and_run(.5)
 
-        self.assertEventCalledWith("loops_award_display", award='LOOP CHAMP', player_name='NEW', value=50,
+        self.assertEventCalledWith("high_score_award_display", award='LOOP CHAMP', player_name='NEW', value=50,
                                    player_num=1, category_name='loops')
         self.advance_time_and_run(4)
 
@@ -56,14 +56,13 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         new_score_data = {'score': [], 'loops': [['NEW', 50, {'player_number': 1}]], 'hits': []}
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)
 
     def test_high_score_multiple_vars(self):
         self.advance_time_and_run()
         self.mock_event("high_score_enter_initials")
-        self.mock_event("hits_award_display")
+        self.mock_event("high_score_award_display")
         # tests loop award with additional variables
         self.machine.modes["high_score"].high_scores = dict()
         self.machine.modes["high_score"].high_scores['hits'] = [['AAA', 2]]
@@ -81,7 +80,7 @@ class TestHighScoreMode(MpfBcpTestCase):
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
         self.advance_time_and_run(.5)
 
-        self.assertEventCalledWith("hits_award_display", award='MOST HITS', player_name='NEW', value=50,
+        self.assertEventCalledWith("high_score_award_display", award='MOST HITS', player_name='NEW', value=50,
                                    player_num=1, category_name='hits')
         self.advance_time_and_run(4)
 
@@ -94,6 +93,5 @@ class TestHighScoreMode(MpfBcpTestCase):
                           'loops': [],
                           'hits': [['NEW', 50, {'player_number': 1, 'machine_credits_string': 'FREE PLAY'}]]}
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)


### PR DESCRIPTION
This changes from sending three events on high score submission to just one, `high_score_award_display`, which has all the params of the previous two included, so a dev can filter and hook onto whatever they need.

This branch includes two cherry-picks from https://github.com/missionpinball/mpf/pull/1906 and for a cleaner history will be rebased once dev and 0.80 have that branch merged in.