### PR TITLE
GMC - Add high score award slide hooks + change to static event names only for high score

### DIFF
--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -102,12 +102,10 @@ class HighScore(AsyncMode):
         for category, entries in self.high_score_config['categories'].items():
             try:
                 for position, (label, (name, value, *hs_vars)) in (
-                        enumerate(zip(entries,
-                                      self.high_scores[category]))):
+                        enumerate(zip(entries, self.high_scores[category]))):
 
-                    self.machine.variables.set_machine_var(
-                        name=category + str(position + 1) + '_label',
-                        value=label)
+                    var_name_base = category + str(position + 1) + "_"
+                    self.machine.variables.set_machine_var(name=var_name_base + 'label', value=label)
 
                     '''machine_var: (high_score_category)(position)_label
 
@@ -119,9 +117,7 @@ class HighScore(AsyncMode):
 
                     '''
 
-                    self.machine.variables.set_machine_var(
-                        name=category + str(position + 1) + '_name',
-                        value=name)
+                    self.machine.variables.set_machine_var(name=var_name_base + 'name', value=name)
 
                     '''machine_var: (high_score_category)(position)_name
 
@@ -130,9 +126,7 @@ class HighScore(AsyncMode):
 
                     '''
 
-                    self.machine.variables.set_machine_var(
-                        name=category + str(position + 1) + '_value',
-                        value=value)
+                    self.machine.variables.set_machine_var(name=var_name_base + 'value', value=value)
 
                     '''machine_var: (high_score_category)(position)_value
 
@@ -143,9 +137,7 @@ class HighScore(AsyncMode):
 
                     if len(hs_vars) > 0:
                         for k, v in hs_vars[0].items():
-                            self.machine.variables.set_machine_var(
-                                name=category + str(position + 1) + '_' + str(k),
-                                value=v)
+                            self.machine.variables.set_machine_var(name=var_name_base + str(k), value=v)
 
                     '''machine_var: (high_score_category)(position)_(variable)
 
@@ -249,9 +241,7 @@ class HighScore(AsyncMode):
                       ", Value: %s", player, award_label, value)
 
         self.machine.events.post('high_score_enter_initials',
-                                 award=award_label,
-                                 player_num=player.number,
-                                 value=value)
+                                 award=award_label, player_num=player.number, value=value)
 
         event_result = await asyncio.wait_for(
             self.machine.events.wait_for_event("text_input_high_score_complete"),
@@ -276,23 +266,16 @@ class HighScore(AsyncMode):
         if not self.high_score_config['award_slide_display_time']:
             return
 
-        self.machine.events.post(
-            'high_score_award_display',
-            player_name=player_name,
-            award=award,
-            value=value)
-        self.machine.events.post(
-            '{}_award_display'.format(award),
-            player_name=player_name,
-            award=award,
-            value=value)
-        self.machine.events.post(
-            '{}_award_display'.format(category_name),
-            player_num=player_num,
-            player_name=player_name,
-            category_name=category_name,
-            award=award,
-            value=value)
+        self.machine.events.post('high_score_award_display',
+                                 player_name=player_name, award=award, value=value)
+
+        self.machine.events.post('{}_award_display'.format(award),
+                                 player_name=player_name, award=award, value=value)
+
+        self.machine.events.post('{}_award_display'.format(category_name),
+                                 player_name=player_name, award=award, value=value,
+                                 player_num=player_num, category_name=category_name)
+
         await asyncio.sleep(self.high_score_config['award_slide_display_time'] / 1000)
 
     def _write_scores_to_disk(self) -> None:

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -219,19 +219,21 @@ class HighScore(AsyncMode):
 
     def _assign_vars(self, category_name, player):
         """Define all vars that are for the given category, and assign their values."""
-        # create dictionary of the variable name and its value, then load it for the category
         player_num_index = player.number - 1
-        var_dict = dict()
+        var_dict = dict()  # store the results of var lookups for the player entry being saved
+
         j = 0
-        while j < len(self.vars[category_name]) and bool(self.vars[category_name]):
-            if 'player' in self.vars[category_name][j][0]:
-                var_dict[self.vars[category_name][j][0] + '_' + self.vars[category_name][j][1]] \
-                    = self.machine.game.player_list[player_num_index][self.vars[category_name][j][1]]
-            else:
-                var_dict[self.vars[category_name][j][0] + '_' + self.vars[category_name][j][1]] \
-                    = self.machine.variables.get_machine_var(self.vars[category_name][j][1])
+        category_var_configuration = self.vars[category_name]
+        while j < len(category_var_configuration) and bool(category_var_configuration):
+            variable_type = category_var_configuration[j][0]
+            variable_name = category_var_configuration[j][1]
+            dict_key = variable_type + '_' + variable_name
+            if 'player' in variable_type:
+                var_dict[dict_key] = self.machine.game.player_list[player_num_index][variable_name]
+            else:  # else is machine variable
+                var_dict[dict_key] = self.machine.variables.get_machine_var(variable_name)
             j += 1
-        # return the dictionary of items for this specific player and category entry
+
         return var_dict
 
     # pylint: disable-msg=too-many-arguments

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -10,8 +10,8 @@ class HighScore(AsyncMode):
 
     """High score mode.
 
-    Mode which runs during the game ending process to check for high scores and lets the players enter their names or
-    initials.
+    Mode which runs during the game ending process to check for high scores and lets the
+    players enter their names or initials.
     """
 
     __slots__ = ["data_manager", "high_scores", "high_score_config", "pending_award", "vars"]
@@ -83,10 +83,11 @@ class HighScore(AsyncMode):
                     if not isinstance(entry[0], str) or not isinstance(entry[1], (int, float)):
                         self.log.warning("Found invalid data type in high score entry.")
                         return False
-                if len(data[category]) != len(self.config['high_score']['defaults'][category]):
+
+                category_default_scores = self.config['high_score']['defaults'][category]
+                if len(data[category]) != len(category_default_scores):
                     self.log.warning("High Score Category %s contains %s entries while defaults contain %s",
-                                     category, len(data[category]),
-                                     len(self.config['high_score']['defaults'][category]))
+                                     category, len(data[category]), len(category_default_scores))
                     return False
 
         except TypeError:
@@ -196,8 +197,8 @@ class HighScore(AsyncMode):
                     # ask player for initials if we do not know them
                     if not player.initials:
                         try:
-                            player.initials = await self._ask_player_for_initials(player.number, award_names[i],
-                                                                                  value, category_name)
+                            player.initials = await self._ask_player_for_initials(player.number,
+                                                                                  award_names[i], value, category_name)
                         except asyncio.TimeoutError:
                             del new_list[i]
                             # no entry when the player missed the timeout
@@ -245,13 +246,24 @@ class HighScore(AsyncMode):
         return var_dict
 
     # pylint: disable-msg=too-many-arguments
-    async def _ask_player_for_initials(self, player_number: int, award_label: str, value: int, category_name: str) -> str:
+    async def _ask_player_for_initials(self,
+                                       player_number: int, award_label: str, value: int, category_name: str) -> str:
         """Show text widget to ask player for initials."""
         self.info_log("New high score. Player: %s, award_label: %s"
                       ", Value: %s", player_number, award_label, value)
 
         self.machine.events.post('high_score_enter_initials',
-                                 award=award_label, player_num=player_number, value=value)
+                                 award=award_label, player_num=player_number, value=value,
+                                 category_name=category_name)
+        '''event high_score_enter_initials
+            desc: A high score has been submitted and the award slide can be displayed.
+            args:
+               player_num: The player number of the player being prompted for a name (counts from 1)
+               category_name: The category name of the award (e.g. "score")
+               award: The award name, based on the ordered set of rank names
+                      in the category (e.g. "GRAND CHAMPION")
+               value: The numerical value the player achieved
+        '''
 
         event_result = await asyncio.wait_for(
             self.machine.events.wait_for_event("text_input_high_score_complete"),
@@ -277,14 +289,19 @@ class HighScore(AsyncMode):
             return
 
         self.machine.events.post('high_score_award_display',
-                                 player_name=player_name, award=award, value=value)
-
-        self.machine.events.post('{}_award_display'.format(award),
-                                 player_name=player_name, award=award, value=value)
-
-        self.machine.events.post('{}_award_display'.format(category_name),
                                  player_name=player_name, award=award, value=value,
                                  player_num=player_num, category_name=category_name)
+
+        '''event high_score_award_display
+            desc: A high score has been submitted and the award slide can be displayed.
+            args:
+               player_name: The text name of the player being awarded.
+               player_num: The player number of the player being awarded (counts from 1)
+               category_name: The category name of the award (e.g. "score")
+               award: The name of the award, based on the ordered set of
+                      rank names in the category (e.g. "GRAND CHAMPION")
+               value: The numerical value the player achieved
+        '''
 
         await asyncio.sleep(self.high_score_config['award_slide_display_time'] / 1000)
 

--- a/mpf/modes/high_score/code/high_score.py
+++ b/mpf/modes/high_score/code/high_score.py
@@ -149,11 +149,19 @@ class HighScore(AsyncMode):
             except KeyError:
                 self.high_scores[category] = list()
 
+    def _get_players(self):
+        return self.machine.game.player_list
+
     # pylint: disable-msg=too-many-nested-blocks
     async def _run(self) -> None:
         """Run high score mode."""
-        if not self.machine.game or not self.machine.game.player_list:
-            self.warning_log("High Score started but there was no game. Will not start.")
+        if not self.machine.game:
+            self.warning_log("High Score starting but there is no game. Mode will not start.")
+            return
+
+        players = self._get_players()
+        if not players:
+            self.warning_log("High Score starting but there are no players. Mode will not start.")
             return
 
         new_high_score_list = {}
@@ -170,7 +178,7 @@ class HighScore(AsyncMode):
                     new_list.append(category_high_scores)
 
             # add the players scores from this game to the list
-            for player in self.machine.game.player_list:
+            for player in players:
                 # if the player var is 0, don't add it. This prevents
                 # values of 0 being added to blank high score lists
                 if player[category_name]:
@@ -188,7 +196,7 @@ class HighScore(AsyncMode):
                     # ask player for initials if we do not know them
                     if not player.initials:
                         try:
-                            player.initials = await self._ask_player_for_initials(player, award_names[i],
+                            player.initials = await self._ask_player_for_initials(player.number, award_names[i],
                                                                                   value, category_name)
                         except asyncio.TimeoutError:
                             del new_list[i]
@@ -197,7 +205,7 @@ class HighScore(AsyncMode):
                     # get vars from config
                     self._load_vars()
                     if category_name in self.vars:
-                        var_dict = self._assign_vars(category_name, player)
+                        var_dict = self._assign_vars(category_name, player.number)
                         # add high score with variables
                         new_list[i] = [player.initials, value, var_dict]
                     else:
@@ -217,10 +225,10 @@ class HighScore(AsyncMode):
         self._write_scores_to_disk()
         self._create_machine_vars()
 
-    def _assign_vars(self, category_name, player):
+    def _assign_vars(self, category_name, player_number):
         """Define all vars that are for the given category, and assign their values."""
-        player_num_index = player.number - 1
         var_dict = dict()  # store the results of var lookups for the player entry being saved
+        player_index = player_number - 1
 
         j = 0
         category_var_configuration = self.vars[category_name]
@@ -229,7 +237,7 @@ class HighScore(AsyncMode):
             variable_name = category_var_configuration[j][1]
             dict_key = variable_type + '_' + variable_name
             if 'player' in variable_type:
-                var_dict[dict_key] = self.machine.game.player_list[player_num_index][variable_name]
+                var_dict[dict_key] = self._get_players()[player_index][variable_name]
             else:  # else is machine variable
                 var_dict[dict_key] = self.machine.variables.get_machine_var(variable_name)
             j += 1
@@ -237,13 +245,13 @@ class HighScore(AsyncMode):
         return var_dict
 
     # pylint: disable-msg=too-many-arguments
-    async def _ask_player_for_initials(self, player: Player, award_label: str, value: int, category_name: str) -> str:
+    async def _ask_player_for_initials(self, player_number: int, award_label: str, value: int, category_name: str) -> str:
         """Show text widget to ask player for initials."""
         self.info_log("New high score. Player: %s, award_label: %s"
-                      ", Value: %s", player, award_label, value)
+                      ", Value: %s", player_number, award_label, value)
 
         self.machine.events.post('high_score_enter_initials',
-                                 award=award_label, player_num=player.number, value=value)
+                                 award=award_label, player_num=player_number, value=value)
 
         event_result = await asyncio.wait_for(
             self.machine.events.wait_for_event("text_input_high_score_complete"),

--- a/mpf/modes/high_score/config/high_score.yaml
+++ b/mpf/modes/high_score/config/high_score.yaml
@@ -42,24 +42,11 @@ slide_player:
   high_score_enter_initials:
     high_score:
         action: play
-  #   high_score_award_display:
-  #       action: remove
-  #   #Make sure to remove any slides you add under this high_score_enter_initials slide, or it will continue to
-  #   #show the award slide instead of initials for another player that also earned a high score.
-  #   score_award_display:
+  # TODO: slide not yet available, but comment section was updated per event name changes
+  #   high_score_award:
   #       action: remove
   # high_score_award_display:
-  #   high_score_award_display:
+  #   high_score_award:
   #       action: play
-  #   high_score_enter_initials:
-  #       action: remove
-  # #This is used to show the slide for a specific award and show additional parameters.  This can include any
-  # #static lables as well as dynamic player and machine variables.
-  # #You will need to generate this block again and swap the name for any subsequent categories that you want
-  # #to show unique additional values.
-  # score_award_display:
-  #   score_award_display:
-  #       action: play
-  #       priority: 1
   #   high_score_enter_initials:
   #       action: remove

--- a/mpf/modes/high_score/config/high_score.yaml
+++ b/mpf/modes/high_score/config/high_score.yaml
@@ -42,11 +42,16 @@ slide_player:
   high_score_enter_initials:
     high_score:
         action: play
-  # TODO: slide not yet available, but comment section was updated per event name changes
-  #   high_score_award:
-  #       action: remove
-  # high_score_award_display:
-  #   high_score_award:
-  #       action: play
-  #   high_score_enter_initials:
-  #       action: remove
+    high_score_award:
+        action: remove
+  high_score_award_display:
+    high_score_award:
+        action: play
+    high_score:
+        action: remove
+
+  # When a player wins multiple awards, we only prompt for initials
+  # on the first. For the rest, we must update the award slide in place.
+  high_score_award_display.1:
+    high_score_award:
+        action: update

--- a/mpf/tests/test_HighScoreMode.py
+++ b/mpf/tests/test_HighScoreMode.py
@@ -359,7 +359,8 @@ class TestHighScoreMode(MpfBcpTestCase):
         self.assertTrue(self.machine.modes["high_score"].active)
 
         # GC
-        self.assertEventCalledWith('high_score_enter_initials', award='GRAND CHAMPION', player_num=2, value=10000000)
+        self.assertEventCalledWith('high_score_enter_initials',
+            award='GRAND CHAMPION', player_num=2, value=10000000, category_name='score')
         self.mock_event("high_score_enter_initials")
         # wait for timeout
         self.advance_time_and_run(20)
@@ -367,12 +368,13 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         # Player 2 did not react. Player 1 will be GC
         # no further slide in between
-        self.assertEventCalledWith('high_score_enter_initials', award='GRAND CHAMPION', player_num=1, value=8000000)
+        self.assertEventCalledWith('high_score_enter_initials',
+            award='GRAND CHAMPION', player_num=1, value=8000000, category_name='score')
 
-        self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='P2')))
+        self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='P1')))
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='GRAND CHAMPION', player_name='P2', value=8000000)
+        self.assertEventCalledWith("high_score_award_display", player_num=1,
+                                   award='GRAND CHAMPION', player_name='P1', value=8000000, category_name='score')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
@@ -382,7 +384,7 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         # verify the data is accurate
         new_score_data = dict()
-        new_score_data['score'] = [['P2', 8000000],
+        new_score_data['score'] = [['P1', 8000000],
                                    ['BRI', 7050550],
                                    ['GHK', 93060],
                                    ['JK', 87890],
@@ -497,8 +499,8 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='GRAND CHAMPION', player_name='NEW', value=10000000)
+        self.assertEventCalledWith("high_score_award_display", player_num=2,
+                                   award='GRAND CHAMPION', player_name='NEW', value=10000000, category_name='score')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
@@ -508,16 +510,16 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='P1')))
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='HIGH SCORE 1', player_name='P1', value=8000000)
+        self.assertEventCalledWith("high_score_award_display", player_num=1,
+                                   award='HIGH SCORE 1', player_name='P1', value=8000000, category_name='score')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
         # Loops champ should not ask again but show a slide
         self.assertTrue(self.machine.modes["high_score"].active)
         self.advance_time_and_run(.5)
-        self.assertEventCalledWith("high_score_award_display",
-                                   award='LOOP CHAMP', player_name='P1', value=50)
+        self.assertEventCalledWith("high_score_award_display", player_num=1,
+                                   award='LOOP CHAMP', player_name='P1', value=50, category_name='loops')
         self.mock_event("high_score_award_display")
         self.advance_time_and_run(4)
 
@@ -537,8 +539,7 @@ class TestHighScoreMode(MpfBcpTestCase):
         # only ask every player once
         self.assertEqual(2, self._events['high_score_enter_initials'])
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)
 
     def test_score_from_nonexistent_player_var(self):
@@ -563,8 +564,7 @@ class TestHighScoreMode(MpfBcpTestCase):
                                     ['MPF', 1000]]
         new_score_data['loops'] = []
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)
 
     def _get_mock_data(self):

--- a/mpf/tests/test_HighScoreModeWithVars.py
+++ b/mpf/tests/test_HighScoreModeWithVars.py
@@ -27,7 +27,7 @@ class TestHighScoreMode(MpfBcpTestCase):
     def test_high_score_one_var(self):
         self.advance_time_and_run()
         self.mock_event("high_score_enter_initials")
-        self.mock_event("loops_award_display")
+        self.mock_event("high_score_award_display")
         # tests loop award with additional variables
         self.machine.modes["high_score"].high_scores = dict()
         self.machine.modes["high_score"].high_scores['loops'] = [('BIL', 2)]
@@ -45,7 +45,7 @@ class TestHighScoreMode(MpfBcpTestCase):
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
         self.advance_time_and_run(.5)
 
-        self.assertEventCalledWith("loops_award_display", award='LOOP CHAMP', player_name='NEW', value=50,
+        self.assertEventCalledWith("high_score_award_display", award='LOOP CHAMP', player_name='NEW', value=50,
                                    player_num=1, category_name='loops')
         self.advance_time_and_run(4)
 
@@ -56,14 +56,13 @@ class TestHighScoreMode(MpfBcpTestCase):
 
         new_score_data = {'score': [], 'loops': [['NEW', 50, {'player_number': 1}]], 'hits': []}
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)
 
     def test_high_score_multiple_vars(self):
         self.advance_time_and_run()
         self.mock_event("high_score_enter_initials")
-        self.mock_event("hits_award_display")
+        self.mock_event("high_score_award_display")
         # tests loop award with additional variables
         self.machine.modes["high_score"].high_scores = dict()
         self.machine.modes["high_score"].high_scores['hits'] = [['AAA', 2]]
@@ -81,7 +80,7 @@ class TestHighScoreMode(MpfBcpTestCase):
         self._bcp_client.receive_queue.put_nowait(('trigger', dict(name='text_input_high_score_complete', text='NEW')))
         self.advance_time_and_run(.5)
 
-        self.assertEventCalledWith("hits_award_display", award='MOST HITS', player_name='NEW', value=50,
+        self.assertEventCalledWith("high_score_award_display", award='MOST HITS', player_name='NEW', value=50,
                                    player_num=1, category_name='hits')
         self.advance_time_and_run(4)
 
@@ -94,6 +93,5 @@ class TestHighScoreMode(MpfBcpTestCase):
                           'loops': [],
                           'hits': [['NEW', 50, {'player_number': 1, 'machine_credits_string': 'FREE PLAY'}]]}
 
-        self.assertEqual(new_score_data,
-                         self.machine.modes["high_score"].high_scores)
+        self.assertEqual(new_score_data, self.machine.modes["high_score"].high_scores)
         self.assertEqual(new_score_data, self.machine.modes["high_score"].data_manager.written_data)


### PR DESCRIPTION
Replacing https://github.com/missionpinball/mpf/pull/1908 because the changes need to go together

From previous:
This changes from sending three events on high score submission to just one, high_score_award_display, which has all the params of the previous two included, so a dev can filter and hook onto whatever they need.

This branch merges dev into 0.80.x to get the refactor commits I made so that the two versions look somewhat similar after all the other changes made in .80

Additional:
This also re-enables the default hooks for showing an award slide between each prompt for initials.
Because the slides are removed instead of stacked, the changes suggested in GMC https://github.com/missionpinball/mpf-gmc/pull/33 are not necessary. However, I think that because the class is generically Text Input, not specifically a high score slide, it's reasonable to clear and reset the input anyway. But I'm happy either way on that PR.