### PR TITLE
enable python 3.13 builds and upgrade pillow to avoid setuptools incompatibility

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,10 +11,6 @@ jobs:
       matrix:
         include:
         - os: windows-latest
-          python-version: 3.8
-        - os: windows-latest
-          python-version: 3.9
-        - os: windows-latest
           python-version: "3.10"
         - os: windows-latest
           python-version: 3.11
@@ -24,10 +20,6 @@ jobs:
           python-version: 3.13
 
         - os: ubuntu-latest
-          python-version: 3.8
-        - os: ubuntu-latest
-          python-version: 3.9
-        - os: ubuntu-latest
           python-version: "3.10"
         - os: ubuntu-latest
           python-version: 3.11
@@ -36,10 +28,6 @@ jobs:
         - os: ubuntu-latest
           python-version: 3.13
 
-        - os: macos-latest
-          python-version: 3.8
-        - os: macos-latest
-          python-version: 3.9
         - os: macos-latest
           python-version: "3.10"
         - os: macos-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,6 +20,9 @@ jobs:
           python-version: 3.11
         - os: windows-latest
           python-version: 3.12
+        - os: windows-latest
+          python-version: 3.13
+
         - os: ubuntu-latest
           python-version: 3.8
         - os: ubuntu-latest
@@ -28,7 +31,11 @@ jobs:
           python-version: "3.10"
         - os: ubuntu-latest
           python-version: 3.11
-        # Ubuntu can't run 3.12 because Pillow dependencies.
+        - os: ubuntu-latest
+          python-version: 3.12
+        - os: ubuntu-latest
+          python-version: 3.13
+
         - os: macos-latest
           python-version: 3.8
         - os: macos-latest
@@ -39,6 +46,8 @@ jobs:
           python-version: 3.11
         - os: macos-latest
           python-version: 3.12
+        - os: macos-latest
+          python-version: 3.13
 
     steps:
       - name: Checkout MPF

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -444,9 +444,9 @@ class MachineController(LogMixin):
         """
         python_version_info = sys.version_info
 
-        # if not (python_version_info[0] == 3 and python_version_info[1] in (5, 6, 7, 8, 9)):
+        # if not (python_version_info[0] == 3 and python_version_info[1] in (10, 11, 12, 13)):
         #     raise AssertionError("Incorrect Python version. MPF requires "
-        #                          "Python 3.5, 3.6, 3.7, 3.8 or 3.9. You have Python {}.{}.{}."
+        #                          "Python 3.10, 3.11, 3.12 or 3.13. You have Python {}.{}.{}."
         #                          .format(python_version_info[0], python_version_info[1],
         #                                  python_version_info[2]))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mpf"
 description = "The Mission Pinball Framework (MPF)"
 readme = "README.md"
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 license = {text = "MIT"}
 authors = [{ name = "The Mission Pinball Framework Team", email = "brian@missionpinball.org"}]
 keywords = ["pinball"]
@@ -15,6 +15,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -33,6 +34,7 @@ dependencies = [
     "setuptools ~= 72.2.0",  # Nov 16, 2024,
     "sortedcontainers == 2.4.0",  # Oct 4 2023, used by platform batch light system
     "terminaltables == 3.1.10",  # Oct 4 2023, used for the service CLI
+    "Pillow == 10.4.0"  # Early 10.x had issues installing, mid 10.x may have had issues with kivy
     ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mpf"
 description = "The Mission Pinball Framework (MPF)"
 readme = "README.md"
-requires-python = ">=3.8,<3.14"
+requires-python = ">=3.10,<3.14"
 license = {text = "MIT"}
 authors = [{ name = "The Mission Pinball Framework Team", email = "brian@missionpinball.org"}]
 keywords = ["pinball"]
@@ -10,8 +10,6 @@ classifiers=[
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Looks like python 13 setuptools had an issue with pillow < 10.1 or so (nested execs when establishing the __version__ info? No matter!)

There was a note that 10.x broke Kivy somehow, but no tests seem to be failing, not sure if there's something else I need to check.