### PR TITLE
Dev10 needs gmc 0.1.6 due to breaking event name changes

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -19,7 +19,7 @@ __short_version__ = '0.80'
 __bcp_version__ = '1.1'
 '''The version of BCP this build of MPF uses.'''
 
-__gmc_version__ = '0.1.5'
+__gmc_version__ = '0.1.6'
 '''The version of GMC this build of MPF requires.'''
 
 __config_version__ = '6'


### PR DESCRIPTION
We should rerelease dev10 with the gmc dependency upped from this change. I’ve helped one user who ran into this issue already, luckily it seems that most other gmc users who have upgraded in the last days just use dev branch instead of numbered gmc releases