### PR TITLE
Light numbering bug using "previous"

### DIFF
--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -197,7 +197,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
 
     def _load_hw_driver_sequentially(self, next_channel):
         if self.config['number'] or self.config['channels']:
-            self.raise_config_error("Cannot use start_channel/previous and number or channels.", 3)
+            self.raise_config_error("Cannot use start_channel/previous with either number or channels.", 3)
         if not self.config['type']:
             self.raise_config_error("Cannot use previous or start_channel without type. "
                                     "Add a type setting to your light.", 2)

--- a/mpf/tests/machine_files/virtual_pinball/config/config.yaml
+++ b/mpf/tests/machine_files/virtual_pinball/config/config.yaml
@@ -49,6 +49,29 @@ lights:
     number: 1-0
   test_led2:
     number: 1-1
+  virtual_led3:
+    channels:
+      red:
+        - number: 7
+      green:
+        - number: 8
+      blue:
+        - number: 9
+      white:
+        - number: 10
+
+  virtual_led4:
+    previous: virtual_led3
+    type: rgbw
+  virtual_led5:
+    previous: virtual_led4
+    type: rgbw
+  virtual_led6:
+    previous: virtual_led5
+    type: rgbw
+  virtual_led7:
+    previous: virtual_led6
+    type: rgbw
 
 autofire_coils:
     ac_slingshot_test:


### PR DESCRIPTION
@borgdog reported an issue with the following minimal configuration (and I replicated):

```yaml
#config_version=6

mpf:
    report_crashes: never

lights:
    l_plans_3:
        type: grbw
        start_channel: 0-0-0

    l_pf_gi1:
        type: grbw
        previous: l_plans_3

    l_pf_gi15:
        type: grbw
        previous: l_pf_gi1

    l_plans_2:
        type: grbw
        previous: l_pf_gi15
```

Crash is:
```
2025-10-06 16:11:38,849 : INFO : EventManager : Event: ======'init_phase_4'====== Args={}
2025-10-06 16:11:38,849 : ERROR : asyncio : Exception in callback EventManager._queue_task_done(<Task finishe....l_plans_2>")>)
handle: <Handle EventManager._queue_task_done(<Task finishe....l_plans_2>")>)>
Traceback (most recent call last):
  File "C:\Python\Python311\Lib\asyncio\events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
  File "C:\Python\Python311\Lib\site-packages\mpf\core\events.py", line 795, in _queue_task_done
    future.result()
  File "C:\Python\Python311\Lib\site-packages\mpf\core\events.py", line 708, in _run_handlers_sequential
    handler.callback(queue=queue, **merged_kwargs)
  File "C:\Python\Python311\Lib\site-packages\mpf\devices\light.py", line 136, in _check_duplicate_light_numbers
    raise ConfigFileError(f"Duplicate number {type(driver)} {driver.number} for light {light}",
mpf.exceptions.config_file_error.ConfigFileError: Config File Error in light: Duplicate number <class 'mpf.platforms.virtual.VirtualLight'> led-0-0-0+10 for light <light.l_plans_2> Context: (None, 'led-0-0-0+10', <class 'mpf.platforms.virtual.VirtualLight'>) Error Code: CFE-light-10 (https://missionpinball.org/logs)
2025-10-06 16:11:38,849 : INFO : Machine : Starting the main run loop with active modes: []
2025-10-06 16:11:38,849 : WARNING : Machine : Attract mode is not active, game will not be playable. Please check your attract mode configuration.
2025-10-06 16:11:38,849 : INFO : Machine : Shutting down...
2025-10-06 16:11:38,849 : INFO : EventManager : Event: ======'shutdown'====== Args={}
2025-10-06 16:11:39,837 : ERROR : Machine : Runtime Exception
Traceback (most recent call last):
  File "C:\Python\Python311\Lib\site-packages\mpf\core\machine.py", line 808, in _run_loop
    raise self._exception['exception']
  File "C:\Python\Python311\Lib\asyncio\events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
  File "C:\Python\Python311\Lib\site-packages\mpf\core\events.py", line 795, in _queue_task_done
    future.result()
  File "C:\Python\Python311\Lib\site-packages\mpf\core\events.py", line 708, in _run_handlers_sequential
    handler.callback(queue=queue, **merged_kwargs)
  File "C:\Python\Python311\Lib\site-packages\mpf\devices\light.py", line 136, in _check_duplicate_light_numbers
    raise ConfigFileError(f"Duplicate number {type(driver)} {driver.number} for light {light}",
```


Turns out when you print the calls to `light.get_successor_number`, it shows the multi-channel lights each requesting 4 next channels, as expected - but when a light contains the channels (for some prefix "x") "x-10" and "x-9"; the 10 is sorted before 9 due to 1 sorting before 0 in alpha-sort. This leads to the next light, if using `previous:` to think that x-9 is the last used channel, and thus it adds one and tries to use `x-10` again