### PR TITLE
Disable crash reporter by default

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1121,7 +1121,7 @@ mpf:
     plugins: ignore
     platforms: ignore
     paths: ignore
-    report_crashes: single|enum(ask,never,always)|ask
+    report_crashes: single|enum(ask,never,always)|never
     rgbw_white_behavior: single|enum(white_only,min_rgb,duck_rgb)|duck_rgb
 mpf-mc:
     __valid_in__: machine                           # todo add to validator


### PR DESCRIPTION
Quiet the crash reporter by default because the service does not exist.

Could go further and remove the feature entirely if not desired, but at least this stops asking users to do something that will just add more error lines to their log.
