### PR TITLE
FAST: mute_unconfigured_switches config option

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -643,6 +643,7 @@ fast_net:
     default_quick_debounce_close: single|ms|2
     default_normal_debounce_open: single|ms|4
     default_normal_debounce_close: single|ms|4
+    mute_unconfigured_switches: single|bool|false
     gi_hz: single|int|30
     lamp_hz: single|int|30
 fast_io_loop:

--- a/mpf/platforms/fast/fast_switch.py
+++ b/mpf/platforms/fast/fast_switch.py
@@ -41,7 +41,7 @@ class FASTSwitch:
         default_mode = '00' if self.platform.config['net']['mute_unconfigured_switches'] or \
             self.platform.machine.options["production"] else '01'
         self.baseline_switch_config = FastSwitchConfig(number=self.hw_number, mode=default_mode,
-                                                        debounce_close='00', debounce_open='00')
+                                                       debounce_close='00', debounce_open='00')
         self.current_hw_config = self.baseline_switch_config
 
     def set_initial_config(self, mpf_config, platform_settings):

--- a/mpf/platforms/fast/fast_switch.py
+++ b/mpf/platforms/fast/fast_switch.py
@@ -34,8 +34,14 @@ class FASTSwitch:
         self.hw_number = Util.int_to_hex_string(hw_number)  # hex version the FAST hw actually uses
         self.platform = communicator.platform  # Needed by the SwitchController
 
-        self.baseline_switch_config = FastSwitchConfig(number=self.hw_number, mode='00', debounce_close='00',
-                                                       debounce_open='00')
+        # Mode 01 is normal: report active when closed, report inactive when open
+        # Mode 00 mutes switches: do not report this switch from hardware ever
+        # The default mode will be overridden by config file switches, so this value only applies
+        # to switch numbers not defined in config files. Mute for production mode, or if specified.
+        default_mode = '00' if self.platform.config['net']['mute_unconfigured_switches'] or \
+            self.platform.machine.options["production"] else '01'
+        self.baseline_switch_config = FastSwitchConfig(number=self.hw_number, mode=default_mode,
+                                                        debounce_close='00', debounce_open='00')
         self.current_hw_config = self.baseline_switch_config
 
     def set_initial_config(self, mpf_config, platform_settings):

--- a/mpf/tests/machine_files/fast/config/nano.yaml
+++ b/mpf/tests/machine_files/fast/config/nano.yaml
@@ -12,6 +12,7 @@ fast:
     net:
         port: com6
         controller: nano
+        mute_unconfigured_switches: true  # Until tests are updated
         io_loop:
             3208:
                 model: FP-I/O-3208

--- a/mpf/tests/machine_files/fast/config/neuron.yaml
+++ b/mpf/tests/machine_files/fast/config/neuron.yaml
@@ -19,6 +19,7 @@ fast:
     net:
         port: com3
         controller: neuron
+        mute_unconfigured_switches: true  # Until tests are updated
         io_loop:
             io3208:  # drivers 0-8 (0x00-0x08), switches 0-31 (0x00-0x1F)
                 model: FP-I/O-3208

--- a/mpf/tests/machine_files/fast/config/retro.yaml
+++ b/mpf/tests/machine_files/fast/config/retro.yaml
@@ -13,6 +13,7 @@ fast:
         port: com3
         debug: true
         controller: wpc95
+        mute_unconfigured_switches: true  # Until tests are updated
 
 switches:
     s_baseline:  # Starts active via SA:


### PR DESCRIPTION
This PR introduces a new config file option `mute_unconfigured_switches` to the FAST platform, with a default value of `false`.

The FAST platform offers a special switch mode `00` which silences the switch at the hardware level, so no activity of the switch is reported by the platform via serial. This may be designed as a performance optimization, but it's unclear exactly why this would be done. However, by default MPF sets all switches to mode `00` and then reconfigures them to `01` (normal) or `02` (inverted) based on the MPF switch configs.

What this means is that any switch not explicitly defined in the MPF configs will be muted.

This is fine behavior for a finished machine, but during development it often occurs that a switch is not wired to the expected address. The muting behavior of mode `00` makes this difficult to debug, because the switch appears to be nonfunctional.

This PR changes the MPF behavior so that all switch addresses are mode `01` by default during dev mode, and only `00` by default in production mode. With the `mute_unconfigured_switches` option, though, a developer can choose to mute the switches in dev mode as well.

![silence](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExODA3ZzI5NHJ6d2d1bWJ5ODAzYXgyNXF4dWZpdjhuMWlxc3NiNXRkcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/snrDtXJBEiZwY/giphy.gif)