### PR TITLE
Fast 1313 Shaker Support

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -811,6 +811,7 @@ hardware:
     accelerometers: list|str|default
     i2c: list|str|default
     stepper_controllers: list|str|default
+    shaker_controllers: list|str|default
     hardware_sound_system: list|str|default
 hardware_sound_systems:
     __valid_in__: machine
@@ -1966,6 +1967,18 @@ steppers:
 stepper_position_settings:
     event: single|str|
     speed: single|int|None
+shakers:
+    __valid_in__: machine
+    __type__: device
+    default_power: single|float|0.0
+    number: single|str|
+    control_events: dict|str:subconfig(shaker_pulse_settings)|None
+    platform: single|str|None
+    platform_settings: single|dict|None
+shaker_pulse_settings:
+    action: single|enum(pulse,stop)|pulse
+    power: single|float|None
+    duration: single|template_secs|None
 spike_stepper_settings:
     homing_speed: single|int|10
     speed: single|int|20

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -61,6 +61,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.digital_output import DigitalOutput    # pylint: disable-msg=cyclic-import,unused-import
     from logging import Logger  # noqa
     from mpf.devices.autofire import AutofireCoil   # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.devices.shaker import Shaker   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.stepper import Stepper     # pylint: disable-msg=cyclic-import,unused-import
     from mpf.config_players.show_player import ShowPlayer   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.dmd import Dmd     # pylint: disable-msg=cyclic-import,unused-import
@@ -167,6 +168,7 @@ class MachineController(LogMixin):
             self.autofire_coils = {}                    # type: Dict[str, AutofireCoil]
             self.motors = {}                            # type: Dict[str, Motor]
             self.digital_outputs = {}                   # type: Dict[str, DigitalOutput]
+            self.shakers = {}                           # type: Dict[str, Shaker]
             self.shows = {}                             # type: Dict[str, Show]
             self.shots = {}                             # type: Dict[str, Shot]
             self.shot_groups = {}                       # type: Dict[str, ShotGroup]

--- a/mpf/core/platform.py
+++ b/mpf/core/platform.py
@@ -12,6 +12,7 @@ from mpf.core.utility_functions import Util
 
 MYPY = False
 if MYPY:   # pragma: no cover
+    from mpf.devices.shaker import Shaker   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.switch import Switch   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.stepper import Stepper     # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.servo import Servo     # pylint: disable-msg=cyclic-import,unused-import

--- a/mpf/core/platform.py
+++ b/mpf/core/platform.py
@@ -19,6 +19,7 @@ if MYPY:   # pragma: no cover
     from mpf.platforms.interfaces.switch_platform_interface import SwitchPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
+    from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.segment_display_platform_interface import SegmentDisplayPlatformInterface     # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.hardware_sound_platform_interface import HardwareSoundPlatformInterface   # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.stepper_platform_interface import StepperPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
@@ -60,6 +61,7 @@ class BasePlatform(LogMixin, metaclass=abc.ABCMeta):
         self.features['has_segment_displays'] = False
         self.features['has_hardware_sound_systems'] = True
         self.features['has_steppers'] = False
+        self.features['has_shakers'] = False
         self.features['allow_empty_numbers'] = False
         self.features['hardware_eos_repulse'] = False
 
@@ -400,6 +402,53 @@ class StepperPlatform(BasePlatform, metaclass=abc.ABCMeta):
         ----
             number: Number of the smart servo
             config: Config for this stepper.
+        """
+        raise NotImplementedError
+
+
+class ShakerPlatform(BasePlatform, metaclass=abc.ABCMeta):
+
+    """Baseclass for shaker platforms in MPF."""
+
+    __slots__ = []  # type: List[str]
+
+    def __init__(self, machine):
+        """Add shaker feature."""
+        super().__init__(machine)
+        self.features['has_shakers'] = True
+
+    @classmethod
+    def get_stepper_config_section(cls) -> Optional[str]:
+        """Return config section for additional stepper config items."""
+        return None
+
+    def validate_shaker_section(self, shaker: "Shaker", config: dict) -> dict:
+        """Validate a shaker config for platform.
+
+        Args:
+        ----
+            shaker: Shaker to validate.
+            config: Config to validate.
+
+        Returns: Validated config.
+        """
+        if self.get_shaker_config_section():
+            spec = self.get_shaker_config_section()    # pylint: disable-msg=assignment-from-none
+            config = shaker.machine.config_validator.validate_config(spec, config, shaker.name)
+        elif config:
+            raise AssertionError("No platform_config supported but not empty {} for shaker {}".
+                                 format(config, shaker.name))
+
+        return config
+
+    @abc.abstractmethod
+    async def configure_shaker(self, number: str, config: dict) -> "ShakerPlatformInterface":
+        """Configure a shaker device in platform.
+
+        Args:
+        ----
+            number: Number of the shaker
+            config: Config for this shaker.
         """
         raise NotImplementedError
 

--- a/mpf/devices/shaker.py
+++ b/mpf/devices/shaker.py
@@ -1,0 +1,170 @@
+"""A digital output on either a light or driver platform."""
+from typing import Union, Optional
+
+from mpf.core.delays import DelayManager
+from mpf.core.events import event_handler
+
+from mpf.core.machine import MachineController
+from mpf.core.platform import DriverConfig, LightConfig, LightConfigColors
+from mpf.core.system_wide_device import SystemWideDevice
+from mpf.platforms.interfaces.driver_platform_interface import PulseSettings, HoldSettings
+
+MYPY = False
+if MYPY:    # pragma: no cover
+    from mpf.core.platform import DriverPlatform, LightsPlatform    # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; # noqa
+    from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
+
+INVALID_TYPE_ERROR = "Invalid type {}"
+
+
+class DigitalOutput(SystemWideDevice):
+
+    """A digital output on either a light or driver platform."""
+
+    config_section = 'digital_outputs'
+    collection = 'digital_outputs'
+    class_label = 'digital_output'
+
+    __slots__ = ["hw_driver", "type", "__dict__"]
+
+    def __init__(self, machine: MachineController, name: str) -> None:
+        """Initialize digital output."""
+        self.hw_driver = None           # type: Optional[Union[DriverPlatformInterface, LightPlatformInterface]]
+        self.platform = None            # type: Optional[Union[DriverPlatform, LightsPlatform]]
+        self.type = None                # type: Optional[str]
+        super().__init__(machine, name)
+        self.delay = DelayManager(self.machine)
+
+    async def _initialize(self):
+        """Initialize the hardware driver for this digital output."""
+        await super()._initialize()
+        if self.config['type'] == "driver":
+            self._initialize_driver()
+        elif self.config['type'] == "light":
+            self._initialize_light()
+        else:
+            raise AssertionError(INVALID_TYPE_ERROR.format(self.config['type']))
+
+    def _initialize_light(self):
+        """Configure a light as digital output."""
+        self.platform = self.machine.get_platform_sections('lights', self.config['platform'])
+        self.platform.assert_has_feature("lights")
+        self.type = "light"
+
+        if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:
+            self.raise_config_error("Digital Output must have a number.", 1)
+
+        config = LightConfig(
+            name=self.name,
+            color=LightConfigColors.NONE
+        )
+
+        try:
+            self.hw_driver = self.platform.configure_light(self.config['number'], self.config['light_subtype'],
+                                                           config, {})
+        except AssertionError as e:
+            raise AssertionError("Failed to configure light {} in platform. See error above".format(self.name)) from e
+
+    def validate_and_parse_config(self, config: dict, is_mode_config: bool, debug_prefix: str = None) -> dict:
+        """Return the parsed and validated config.
+
+        Args:
+        ----
+            config: Config of device
+            is_mode_config: Whether this device is loaded in a mode or system-wide
+            debug_prefix: Prefix to use when logging.
+
+        Returns: Validated config
+        """
+        config = super().validate_and_parse_config(config, is_mode_config, debug_prefix)
+        if config['type'] == "driver":
+            platform = self.machine.get_platform_sections('coils', getattr(config, "platform", None))
+            platform.assert_has_feature("drivers")
+            config['platform_settings'] = platform.validate_coil_section(self, config.get('platform_settings', None))
+        elif config['type'] == "light":
+            platform = self.machine.get_platform_sections('coils', getattr(config, "platform", None))
+            platform.assert_has_feature("lights")
+        else:
+            raise AssertionError(INVALID_TYPE_ERROR.format(config['type']))
+        return config
+
+    def _initialize_driver(self):
+        """Configure a driver as digital output."""
+        self.platform = self.machine.get_platform_sections('coils', self.config['platform'])
+        self.platform.assert_has_feature("drivers")
+        self.type = "driver"
+
+        config = DriverConfig(
+            name=self.name,
+            default_pulse_ms=255,
+            default_pulse_power=1.0,
+            default_timed_enable_ms=None,
+            default_hold_power=1.0,
+            default_recycle=False,
+            max_pulse_ms=255,
+            max_pulse_power=1.0,
+            max_hold_power=1.0)
+
+        if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:
+            self.raise_config_error("Digital Output must have a number.", 2)
+
+        try:
+            self.hw_driver = self.platform.configure_driver(config, self.config['number'],
+                                                            self.config['platform_settings'])
+        except AssertionError as e:
+            raise AssertionError("Failed to configure driver {} in platform. See error above".format(self.name)) from e
+
+    @event_handler(3)
+    def event_pulse(self, pulse_ms, **kwargs):
+        """Handle pulse control event."""
+        del kwargs
+        self.pulse(pulse_ms)
+
+    def pulse(self, pulse_ms):
+        """Pulse digital output."""
+        if self.type == "driver":
+            self.hw_driver.pulse(PulseSettings(power=1.0, duration=pulse_ms))
+        elif self.type == "light":
+            self.hw_driver.set_fade(1.0, -1, 1.0, -1)
+            self.platform.light_sync()
+            self.delay.reset(name='timed_disable',
+                             ms=pulse_ms,
+                             callback=self.disable)
+        else:
+            raise AssertionError(INVALID_TYPE_ERROR.format(self.type))
+
+    @event_handler(2)
+    def event_enable(self, **kwargs):
+        """Handle enable control event."""
+        del kwargs
+        self.enable()
+
+    def enable(self):
+        """Enable digital output."""
+        if self.type == "driver":
+            self.hw_driver.enable(PulseSettings(power=1.0, duration=0),
+                                  HoldSettings(power=1.0, duration=None))
+        elif self.type == "light":
+            self.hw_driver.set_fade(1.0, -1, 1.0, -1)
+            self.platform.light_sync()
+            self.delay.remove(name='timed_disable')
+        else:
+            raise AssertionError(INVALID_TYPE_ERROR.format(self.type))
+
+    @event_handler(1)
+    def event_disable(self, **kwargs):
+        """Handle disable control event."""
+        del kwargs
+        self.disable()
+
+    def disable(self):
+        """Disable digital output."""
+        if self.type == "driver":
+            self.hw_driver.disable()
+        elif self.type == "light":
+            self.hw_driver.set_fade(0.0, -1, 0.0, -1)
+            self.platform.light_sync()
+            self.delay.remove(name='timed_disable')
+        else:
+            raise AssertionError(INVALID_TYPE_ERROR.format(self.type))

--- a/mpf/devices/shaker.py
+++ b/mpf/devices/shaker.py
@@ -15,16 +15,14 @@ if MYPY:    # pragma: no cover
     from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
 
-INVALID_TYPE_ERROR = "Invalid type {}"
 
-
-class DigitalOutput(SystemWideDevice):
+class Shaker(SystemWideDevice):
 
     """A digital output on either a light or driver platform."""
 
-    config_section = 'digital_outputs'
-    collection = 'digital_outputs'
-    class_label = 'digital_output'
+    config_section = 'shakers'
+    collection = 'shakers'
+    class_label = 'shaker'
 
     __slots__ = ["hw_driver", "type", "__dict__"]
 
@@ -32,139 +30,29 @@ class DigitalOutput(SystemWideDevice):
         """Initialize digital output."""
         self.hw_driver = None           # type: Optional[Union[DriverPlatformInterface, LightPlatformInterface]]
         self.platform = None            # type: Optional[Union[DriverPlatform, LightsPlatform]]
-        self.type = None                # type: Optional[str]
         super().__init__(machine, name)
         self.delay = DelayManager(self.machine)
 
     async def _initialize(self):
-        """Initialize the hardware driver for this digital output."""
         await super()._initialize()
-        if self.config['type'] == "driver":
-            self._initialize_driver()
-        elif self.config['type'] == "light":
-            self._initialize_light()
-        else:
-            raise AssertionError(INVALID_TYPE_ERROR.format(self.config['type']))
-
-    def _initialize_light(self):
-        """Configure a light as digital output."""
-        self.platform = self.machine.get_platform_sections('lights', self.config['platform'])
-        self.platform.assert_has_feature("lights")
-        self.type = "light"
-
-        if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:
-            self.raise_config_error("Digital Output must have a number.", 1)
-
-        config = LightConfig(
-            name=self.name,
-            color=LightConfigColors.NONE
-        )
-
-        try:
-            self.hw_driver = self.platform.configure_light(self.config['number'], self.config['light_subtype'],
-                                                           config, {})
-        except AssertionError as e:
-            raise AssertionError("Failed to configure light {} in platform. See error above".format(self.name)) from e
-
-    def validate_and_parse_config(self, config: dict, is_mode_config: bool, debug_prefix: str = None) -> dict:
-        """Return the parsed and validated config.
-
-        Args:
-        ----
-            config: Config of device
-            is_mode_config: Whether this device is loaded in a mode or system-wide
-            debug_prefix: Prefix to use when logging.
-
-        Returns: Validated config
-        """
-        config = super().validate_and_parse_config(config, is_mode_config, debug_prefix)
-        if config['type'] == "driver":
-            platform = self.machine.get_platform_sections('coils', getattr(config, "platform", None))
-            platform.assert_has_feature("drivers")
-            config['platform_settings'] = platform.validate_coil_section(self, config.get('platform_settings', None))
-        elif config['type'] == "light":
-            platform = self.machine.get_platform_sections('coils', getattr(config, "platform", None))
-            platform.assert_has_feature("lights")
-        else:
-            raise AssertionError(INVALID_TYPE_ERROR.format(config['type']))
-        return config
-
-    def _initialize_driver(self):
-        """Configure a driver as digital output."""
-        self.platform = self.machine.get_platform_sections('coils', self.config['platform'])
-        self.platform.assert_has_feature("drivers")
-        self.type = "driver"
-
-        config = DriverConfig(
-            name=self.name,
-            default_pulse_ms=255,
-            default_pulse_power=1.0,
-            default_timed_enable_ms=None,
-            default_hold_power=1.0,
-            default_recycle=False,
-            max_pulse_ms=255,
-            max_pulse_power=1.0,
-            max_hold_power=1.0)
-
-        if not self.platform.features['allow_empty_numbers'] and self.config['number'] is None:
-            self.raise_config_error("Digital Output must have a number.", 2)
-
-        try:
-            self.hw_driver = self.platform.configure_driver(config, self.config['number'],
-                                                            self.config['platform_settings'])
-        except AssertionError as e:
-            raise AssertionError("Failed to configure driver {} in platform. See error above".format(self.name)) from e
-
-    @event_handler(3)
-    def event_pulse(self, pulse_ms, **kwargs):
-        """Handle pulse control event."""
-        del kwargs
-        self.pulse(pulse_ms)
-
-    def pulse(self, pulse_ms):
-        """Pulse digital output."""
-        if self.type == "driver":
-            self.hw_driver.pulse(PulseSettings(power=1.0, duration=pulse_ms))
-        elif self.type == "light":
-            self.hw_driver.set_fade(1.0, -1, 1.0, -1)
-            self.platform.light_sync()
-            self.delay.reset(name='timed_disable',
-                             ms=pulse_ms,
-                             callback=self.disable)
-        else:
-            raise AssertionError(INVALID_TYPE_ERROR.format(self.type))
+        self.platform = self.machine.get_platform_sections('stepper_controllers', self.config['platform'])
+        self.platform.assert_has_feature("shakers")
+        for event, config in self.config['pulse_events'].items():
+            self.machine.events.add_handler(event,
+                                            self.event_pulse,
+                                            power=config.get('power'),
+                                            duration=config['duration'])
 
     @event_handler(2)
-    def event_enable(self, **kwargs):
-        """Handle enable control event."""
+    def event_pulse(self, power=None, duration=None, **kwargs):
+        """Handle pulse control event."""
         del kwargs
-        self.enable()
+        self.pulse(power, duration)
 
-    def enable(self):
-        """Enable digital output."""
-        if self.type == "driver":
-            self.hw_driver.enable(PulseSettings(power=1.0, duration=0),
-                                  HoldSettings(power=1.0, duration=None))
-        elif self.type == "light":
-            self.hw_driver.set_fade(1.0, -1, 1.0, -1)
-            self.platform.light_sync()
-            self.delay.remove(name='timed_disable')
-        else:
-            raise AssertionError(INVALID_TYPE_ERROR.format(self.type))
+    def pulse(self, power=None, duration=None):
+        if not power:
+            power = self.config['default_power']
+        if not duration:
+            raise AssertionError("Shaker pulse called with no duration value")
+        self.hw_driver.pulse(power, duration)
 
-    @event_handler(1)
-    def event_disable(self, **kwargs):
-        """Handle disable control event."""
-        del kwargs
-        self.disable()
-
-    def disable(self):
-        """Disable digital output."""
-        if self.type == "driver":
-            self.hw_driver.disable()
-        elif self.type == "light":
-            self.hw_driver.set_fade(0.0, -1, 0.0, -1)
-            self.platform.light_sync()
-            self.delay.remove(name='timed_disable')
-        else:
-            raise AssertionError(INVALID_TYPE_ERROR.format(self.type))

--- a/mpf/devices/shaker.py
+++ b/mpf/devices/shaker.py
@@ -1,18 +1,17 @@
 """A digital output on either a light or driver platform."""
-from typing import Union, Optional
+from typing import Optional
 
 from mpf.core.delays import DelayManager
 from mpf.core.events import event_handler
 
 from mpf.core.machine import MachineController
-from mpf.core.platform import DriverConfig, LightConfig, LightConfigColors
 from mpf.core.system_wide_device import SystemWideDevice
-from mpf.platforms.interfaces.driver_platform_interface import PulseSettings, HoldSettings
 
 MYPY = False
 if MYPY:    # pragma: no cover
     from mpf.core.platform import ShakerPlatform    # pylint: disable-msg=cyclic-import,unused-import
-    from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; #noqa
+
 
 class Shaker(SystemWideDevice):
 
@@ -47,10 +46,12 @@ class Shaker(SystemWideDevice):
 
     @event_handler(1)
     def event_pulse(self, duration=None, power=None, **kwargs):
+        """Event handler for triggering a pulse."""
         del kwargs
         self.pulse(duration, power)
 
     def pulse(self, duration=None, power=None):
+        """Pulse the shaker for the given duration and power level."""
         if power is None:
             power = self.config['default_power']
         if not duration:
@@ -59,8 +60,10 @@ class Shaker(SystemWideDevice):
 
     @event_handler(2)
     def event_stop(self, **kwargs):
+        """Event handler for stopping the shaker."""
         del kwargs
         self.stop()
 
     def stop(self):
+        """Stop the shaker."""
         self.hw_shaker.stop()

--- a/mpf/devices/shaker.py
+++ b/mpf/devices/shaker.py
@@ -11,10 +11,8 @@ from mpf.platforms.interfaces.driver_platform_interface import PulseSettings, Ho
 
 MYPY = False
 if MYPY:    # pragma: no cover
-    from mpf.core.platform import DriverPlatform, LightsPlatform    # pylint: disable-msg=cyclic-import,unused-import
-    from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; # noqa
-    from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
-
+    from mpf.core.platform import ShakerPlatform    # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import
 
 class Shaker(SystemWideDevice):
 
@@ -24,35 +22,45 @@ class Shaker(SystemWideDevice):
     collection = 'shakers'
     class_label = 'shaker'
 
-    __slots__ = ["hw_driver", "type", "__dict__"]
+    __slots__ = ["hw_shaker", "type", "__dict__"]
 
     def __init__(self, machine: MachineController, name: str) -> None:
         """Initialize digital output."""
-        self.hw_driver = None           # type: Optional[Union[DriverPlatformInterface, LightPlatformInterface]]
-        self.platform = None            # type: Optional[Union[DriverPlatform, LightsPlatform]]
+        self.hw_shaker = None           # type: Optional[ShakerPlatformInterface]
+        self.platform = None            # type: Optional[ShakerPlatform]
         super().__init__(machine, name)
         self.delay = DelayManager(self.machine)
 
     async def _initialize(self):
         await super()._initialize()
-        self.platform = self.machine.get_platform_sections('stepper_controllers', self.config['platform'])
+        self.platform = self.machine.get_platform_sections('shaker_controllers', self.config['platform'])
         self.platform.assert_has_feature("shakers")
-        for event, config in self.config['pulse_events'].items():
+        self.hw_shaker = await self.platform.configure_shaker(self.config['number'], self.config['platform_settings'])
+        for event, config in self.config['control_events'].items():
+            if config.get('action') == 'stop':
+                self.machine.events.add_handler(event, self.event_stop)
+                continue
             self.machine.events.add_handler(event,
                                             self.event_pulse,
                                             power=config.get('power'),
-                                            duration=config['duration'])
+                                            duration=config['duration'].evaluate({}))
 
-    @event_handler(2)
-    def event_pulse(self, power=None, duration=None, **kwargs):
-        """Handle pulse control event."""
+    @event_handler(1)
+    def event_pulse(self, duration=None, power=None, **kwargs):
         del kwargs
-        self.pulse(power, duration)
+        self.pulse(duration, power)
 
-    def pulse(self, power=None, duration=None):
-        if not power:
+    def pulse(self, duration=None, power=None):
+        if power is None:
             power = self.config['default_power']
         if not duration:
             raise AssertionError("Shaker pulse called with no duration value")
-        self.hw_driver.pulse(power, duration)
+        self.hw_shaker.pulse(duration, power)
 
+    @event_handler(2)
+    def event_stop(self, **kwargs):
+        del kwargs
+        self.stop()
+
+    def stop(self):
+        self.hw_shaker.stop()

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -85,6 +85,7 @@ mpf:
         timers: mpf.devices.timer.Timer
         segment_displays: mpf.devices.segment_display.segment_display.SegmentDisplay
         sequence_shots: mpf.devices.sequence_shot.SequenceShot
+        shakers: mpf.devices.shaker.Shaker
         speedometers: mpf.devices.speedometer.Speedometer
         hardware_sound_systems: mpf.devices.hardware_sound_system.HardwareSoundSystem
         steppers: mpf.devices.stepper.Stepper
@@ -441,6 +442,7 @@ hardware:
   accelerometers: default
   servo_controllers: default
   i2c: default
+  shaker_controllers: default
   stepper_controllers: default
 
 combo_switches:

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -8,7 +8,7 @@ from serial import SerialException
 from mpf.core.platform import (RgbDmdPlatform, DriverConfig, DriverSettings,
                                LightsPlatform, RepulseSettings,
                                SegmentDisplayPlatform, ServoPlatform,
-                               StepperPlatform,
+                               StepperPlatform, ShakerPlatform,
                                SwitchConfig, SwitchSettings)
 from mpf.core.utility_functions import Util
 from mpf.exceptions.config_file_error import ConfigFileError
@@ -25,6 +25,7 @@ from mpf.platforms.fast.fast_light import FASTMatrixLight
 from mpf.platforms.fast.fast_port_detector import FastPortDetector
 from mpf.platforms.fast.fast_segment_display import FASTSegmentDisplay
 from mpf.platforms.fast.fast_servo import FastServo
+from mpf.platforms.fast.fast_shaker import FastShaker
 from mpf.platforms.fast.fast_stepper import FastStepper
 from mpf.platforms.fast.fast_switch import FASTSwitch
 # pylint: disable-msg=too-many-instance-attributes
@@ -34,7 +35,7 @@ from mpf.platforms.system11 import System11OverlayPlatform
 
 class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                            SegmentDisplayPlatform, StepperPlatform,
-                           System11OverlayPlatform):
+                           ShakerPlatform, System11OverlayPlatform):
 
     """Platform class for the FAST Pinball hardware."""
 
@@ -492,6 +493,35 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                                  f"Switch value {switch} is not valid.")
 
         return Util.int_to_hex_string(board.start_switch + switch)
+
+    async def configure_shaker(self, number: str, config: Dict):
+        """Configure a shaker.
+
+        Args:
+        ----
+            number: Number of shaker
+            config: Dict of config settings.
+
+        Returns: Stepper object.
+        """
+        # TODO consolidate with similar code in configure_light()
+        number = number.lower()
+        parts = number.split("-")
+
+        exp_board = self.exp_boards_by_name[parts[0]]
+
+        try:
+            _, port = parts
+            breakout_id = '0'
+        except ValueError:
+            _, breakout_id, port = parts
+            breakout_id = breakout_id.strip('b')
+
+        brk_board = exp_board.breakouts[breakout_id]
+
+        # verify this board support servos
+        assert int(port) <= int(brk_board.features['shaker_ports'])  # TODO should this be stored as an int?
+        return FastShaker(brk_board, port, config)
 
     def configure_switch(self, number: str, config: SwitchConfig, platform_config: dict) -> FASTSwitch:
         """Configure the switch object for a FAST Pinball controller.

--- a/mpf/platforms/fast/fast_defines.py
+++ b/mpf/platforms/fast/fast_defines.py
@@ -27,6 +27,18 @@ VALID_IO_BOARDS = (
 )
 
 EXPANSION_BOARD_FEATURES = {
+    'FP-EXP-1313': {
+        'min_fw': '0.28',
+        'local_breakouts': ['FP-EXP-1313'],
+        'breakout_ports': 0,
+        'default_address': '30'
+    },
+    'FP-EXP-0051': {
+        'min_fw': '0.31',
+        'local_breakouts': ['FP-EXP-0051'],
+        'breakout_ports': 0,
+        'default_address': 'D0'
+    },
     'FP-EXP-0061': {
         'min_fw': '0.31',
         'local_breakouts': ['FP-EXP-0061'],
@@ -60,6 +72,10 @@ EXPANSION_BOARD_FEATURES = {
 }
 
 BREAKOUT_FEATURES = {
+    'FP-EXP-1313': {
+        'min_fw': '0.44',
+        'shaker_ports': 1
+    },
     'FP-EXP-0061': {
         'min_fw': '0.33',
         'led_ports': 4,

--- a/mpf/platforms/fast/fast_shaker.py
+++ b/mpf/platforms/fast/fast_shaker.py
@@ -1,9 +1,6 @@
 """Fast shaker implementation."""
 
-import asyncio
-
 from mpf.core.utility_functions import Util
-from mpf.exceptions.config_file_error import ConfigFileError
 from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInterface
 
 

--- a/mpf/platforms/fast/fast_shaker.py
+++ b/mpf/platforms/fast/fast_shaker.py
@@ -1,0 +1,48 @@
+"""Fast shaker implementation."""
+
+import asyncio
+
+from mpf.core.utility_functions import Util
+from mpf.exceptions.config_file_error import ConfigFileError
+from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInterface
+
+
+class FastShaker(ShakerPlatformInterface):
+
+    """A shaker in the FAST platform connected to a FAST Expansion Board."""
+
+    __slots__ = ["base_address", "config", "exp_connection", "log", "shaker_index",
+                 "_is_moving", "_default_speed"]
+
+    def __init__(self, breakout_board, port, config):
+        """Initialize servo."""
+        self.config = config
+        self.exp_connection = breakout_board.communicator
+
+        self.shaker_index = Util.int_to_hex_string(int(port) - 1)  # Steppers are 0-indexed
+        self.base_address = breakout_board.address
+        self.log = breakout_board.log
+
+        #self.exp_connection.register_processor('MS:', self.base_address, self.shaker_index, self._process_ms)
+
+    def pulse(self, duration, power):
+        """Pulse the shaker at the specified power for the specified duration."""
+        if not power or not duration:
+            return
+
+        base_command = "MF"
+        hex_power = Util.int_to_hex_string(power, True)
+        hex_duration = Util.int_to_hex_string(duration, True)
+        self.log.info("Pulsing shaker index %s: for %sms with power %s", self.shaker_index, duration, power)
+
+        self._send_command(base_command, [hex_duration, hex_power])
+
+    def stop(self):
+        """Called during shutdown."""
+        self._send_command("MC")
+
+    def _send_command(self, base_command, payload=None):
+        if not payload:
+            payload = []
+        self.exp_connection.send_and_forget(','.join([
+            f'{base_command}@{self.base_address}:{self.shaker_index}', *payload]))

--- a/mpf/platforms/fast/fast_shaker.py
+++ b/mpf/platforms/fast/fast_shaker.py
@@ -25,20 +25,22 @@ class FastShaker(ShakerPlatformInterface):
 
         #self.exp_connection.register_processor('MS:', self.base_address, self.shaker_index, self._process_ms)
 
-    def pulse(self, duration, power):
+    def pulse(self, duration_secs, power):
         """Pulse the shaker at the specified power for the specified duration."""
-        if not power or not duration:
+        if not power or not duration_secs:
+            self.log.debug("Shaker pulse called with no power or duration, will not shake.")
             return
 
         base_command = "MF"
-        hex_power = Util.int_to_hex_string(power, True)
-        hex_duration = Util.int_to_hex_string(duration, True)
-        self.log.info("Pulsing shaker index %s: for %sms with power %s", self.shaker_index, duration, power)
+        hex_power = Util.float_to_hex(power)
+        hex_duration = Util.int_to_hex_string(duration_secs * 1000, True)
+        self.log.debug("Pulsing shaker index %s: for %s seconds with power %s", self.shaker_index, duration_secs, power)
 
         self._send_command(base_command, [hex_duration, hex_power])
 
     def stop(self):
         """Called during shutdown."""
+        self.log.debug("Stopping shaker")
         self._send_command("MC")
 
     def _send_command(self, base_command, payload=None):

--- a/mpf/platforms/interfaces/shaker_platform_interface.py
+++ b/mpf/platforms/interfaces/shaker_platform_interface.py
@@ -1,0 +1,29 @@
+"""Platform interface for shakers."""
+from typing import List
+
+import abc
+
+
+class ShakerPlatformInterface(metaclass=abc.ABCMeta):
+
+    """Interface for shakers in hardware platforms.
+
+    ShakerPlatformInterface is an abstract base class that should be overridden for all
+    shaker interface classes on supported platforms.  This class ensures the proper required
+    methods are implemented to support shaker operations in MPF.
+    """
+
+    __slots__ = []  # type: List[str]
+
+    @abc.abstractmethod
+    def enable(self, duration_ms=None, power=None):
+        """Enable the shaker for specified duration and power level."""
+        raise NotImplementedError
+
+    @abc
+    def disable(self):
+        """Stop this shaker.
+
+        This should disable the output or home the servo.
+        """
+        raise NotImplementedError

--- a/mpf/platforms/interfaces/shaker_platform_interface.py
+++ b/mpf/platforms/interfaces/shaker_platform_interface.py
@@ -16,7 +16,7 @@ class ShakerPlatformInterface(metaclass=abc.ABCMeta):
     __slots__ = []  # type: List[str]
 
     @abc.abstractmethod
-    def pulse(self, duration_secs=None, power=None):
+    def pulse(self, duration_secs, power):
         """Enable the shaker for specified duration and power level."""
         raise NotImplementedError
 

--- a/mpf/platforms/interfaces/shaker_platform_interface.py
+++ b/mpf/platforms/interfaces/shaker_platform_interface.py
@@ -16,14 +16,14 @@ class ShakerPlatformInterface(metaclass=abc.ABCMeta):
     __slots__ = []  # type: List[str]
 
     @abc.abstractmethod
-    def enable(self, duration_ms=None, power=None):
+    def pulse(self, duration_secs=None, power=None):
         """Enable the shaker for specified duration and power level."""
         raise NotImplementedError
 
-    @abc
-    def disable(self):
+    @abc.abstractmethod
+    def stop(self):
         """Stop this shaker.
 
-        This should disable the output or home the servo.
+        This should stop the output and end shaking
         """
         raise NotImplementedError


### PR DESCRIPTION
This PR introduces support for the FAST 1313 Shaker Board, hurray!

It's the same code that was merged into 0.80 by https://github.com/missionpinball/mpf/pull/1916, now here merging into dev for 0.57. It's tested by me to work as much as I could think to do, but I'm sure it has things that could be improved once it hits real-world scenarios.

```

fast:
  exp:
    port: /dev/tty.usbserial-3103
    boards:
      shakerboard:
        model: FP-EXP-1313

shakers:
  main_shaker:
    number: shakerboard-1
    default_power: 0.5
    control_events:
      test_one:
        power: 0.1
        duration: 10s
      test_two:
        action: stop
```

![shake it!](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExYXh5MG45bGx3d2RqMTJ1dW5rd2c3dGdkbHJmMmh1Mmx3c21uY2FjdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EK8WiEFxlR7iPDKpHj/giphy.gif)