### PR TITLE
MPF .57 supports Python 3.13

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Install MPF
         run: |
+          sudo apt-get update
+          sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libjpeg-dev
+          sudo apt-get install -y qt6-base-dev
           pip install --upgrade pip setuptools wheel build
           pip install -e .
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,6 +20,8 @@ jobs:
           python-version: 3.11
         - os: windows-latest
           python-version: 3.12
+        - os: windows-latest
+          python-version: 3.13
         - os: ubuntu-latest
           python-version: 3.8
         - os: ubuntu-latest
@@ -28,7 +30,10 @@ jobs:
           python-version: "3.10"
         - os: ubuntu-latest
           python-version: 3.11
-        # Ubuntu can't run 3.12 because Pillow dependencies.
+        - os: ubuntu-latest
+          python-version: 3.12
+        - os: ubuntu-latest
+          python-version: 3.13
         - os: macos-latest
           python-version: 3.8
         - os: macos-latest
@@ -39,6 +44,8 @@ jobs:
           python-version: 3.11
         - os: macos-latest
           python-version: 3.12
+        - os: macos-latest
+          python-version: 3.13
 
     steps:
       - name: Checkout MPF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mpf"
 description = "The Mission Pinball Framework (MPF)"
 readme = "README.md"
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 license = {text = "MIT"}
 authors = [{ name = "The Mission Pinball Framework Team", email = "brian@missionpinball.org"}]
 keywords = ["pinball"]
@@ -15,6 +15,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -33,7 +34,7 @@ dependencies = [
     "setuptools ~= 72.2.0",  # Nov 16, 2024,
     "sortedcontainers == 2.4.0",  # Oct 4 2023, used by platform batch light system
     "terminaltables == 3.1.10",  # Oct 4 2023, used for the service CLI
-    "Pillow == 9.5.0"  # Nov 4 2023. Asciimatics needs Pillow > 2.7, but latest 10.x breaks kivy for now (fix due in 2.3), so we pin to latest working Pillow for now.
+    "Pillow == 10.4.0"  # Dec 7, 2025. Upgrading past broken versions
     ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Turns out we can get .57 working with Python 3.13! And add ubuntu coverage for 3.12 that was missing as well!