### PR TITLE
Counter control event split

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1024,6 +1024,7 @@ counter_control_events:  # subconfig for mode counters
     action: single|enum(add,subtract,jump)|
     event: single|event_handler|
     value: single|template_int|None
+    priority: single|int|0
 sequences:
     __valid_in__: machine, mode
     __type__: device

--- a/mpf/core/mode_device.py
+++ b/mpf/core/mode_device.py
@@ -42,6 +42,7 @@ class ModeDevice(Device, metaclass=abc.ABCMeta):
             player: Current active player
         """
         del player
+        del mode
 
     @property
     def can_exist_outside_of_game(self) -> bool:
@@ -87,4 +88,3 @@ class ModeDevice(Device, metaclass=abc.ABCMeta):
             mode: Mode which stopped
         """
         del mode
-        self.mode = None

--- a/mpf/core/mode_device.py
+++ b/mpf/core/mode_device.py
@@ -22,7 +22,7 @@ class ModeDevice(Device, metaclass=abc.ABCMeta):
         self.mode = None    # type: Optional[Mode]
 
     async def device_added_to_mode(self, mode: Mode) -> None:
-        """Add device to a running mode.
+        """Add device to a loading mode.
 
         Args:
         ----

--- a/mpf/core/mode_device.py
+++ b/mpf/core/mode_device.py
@@ -28,7 +28,7 @@ class ModeDevice(Device, metaclass=abc.ABCMeta):
         ----
             mode: Mode which loaded the device
         """
-        del mode
+        self.mode = mode
         await self._initialize()
 
     def device_loaded_in_mode(self, mode: Mode, player: Player) -> None:
@@ -42,7 +42,6 @@ class ModeDevice(Device, metaclass=abc.ABCMeta):
             player: Current active player
         """
         del player
-        self.mode = mode
 
     @property
     def can_exist_outside_of_game(self) -> bool:

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -394,7 +394,7 @@ class Counter(LogicBlock):
         for entry in self.config['control_events']:
             if entry['action'] in ('add', 'subtract', 'jump'):
                 handler = getattr(self, "event_{}".format(entry['action']))
-                kwargs = {'value': entry['value']}
+                kwargs = {'value': entry['value'], 'priority': entry['priority']}
                 results.append((entry['event'], handler, kwargs))
             else:
                 raise AssertionError("Invalid control_event action {} in counter".format(entry['action']), self.name)

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -365,23 +365,40 @@ class Counter(LogicBlock):
 
         # Add control events if included in the config
         if self.config['control_events']:
-            self._setup_control_events(self.config['control_events'])
+            self._setup_machine_control_events()
 
     def add_control_events_in_mode(self, mode: Mode) -> None:
-        """Do not auto enable this device in modes."""
+        """Activate control events given a mode context"""
+        self._setup_mode_control_events(mode)
 
-    def _setup_control_events(self, event_list):
-        self.debug_log("Setting up control events")
+    def _setup_machine_control_events(self):
+        if self.mode:
+            self.debug_log("Not setting up machine control events for mode counter {}".format(self.name))
+            return
 
-        kwargs = {}
-        for entry in event_list:
+        self.debug_log("Setting up machine control events for counter {}".format(self.name))
+        for (event_name, handler, kwargs) in self._generate_control_event_settings():
+            self.machine.events.add_handler(event_name, handler, **kwargs)
+
+    def _setup_mode_control_events(self, mode: Mode):
+        if not self.mode == mode:
+            self.debug_log("Not setting up mode control events for machine counter {}".format(self.name))
+            return
+
+        self.debug_log("Setting up control events for counter {} in mode {}".format(self.name, mode.name))
+        for (event_name, handler, kwargs) in self._generate_control_event_settings():
+            mode.add_mode_event_handler(event_name, handler, **kwargs)
+
+    def _generate_control_event_settings(self):
+        results = []
+        for entry in self.config['control_events']:
             if entry['action'] in ('add', 'subtract', 'jump'):
                 handler = getattr(self, "event_{}".format(entry['action']))
                 kwargs = {'value': entry['value']}
+                results.append((entry['event'], handler, kwargs))
             else:
-                raise AssertionError("Invalid control_event action {} in mode".
-                                     format(entry['action']), self.name)
-            self.machine.events.add_handler(entry['event'], handler, **kwargs)
+                raise AssertionError("Invalid control_event action {} in counter".format(entry['action']), self.name)
+        return results
 
     def check_complete(self, count_complete_value=None):
         """Check if counter is completed.

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -368,7 +368,7 @@ class Counter(LogicBlock):
             self._setup_machine_control_events()
 
     def add_control_events_in_mode(self, mode: Mode) -> None:
-        """Activate control events given a mode context"""
+        """Activate control events given a mode context."""
         self._setup_mode_control_events(mode)
 
     def _setup_machine_control_events(self):

--- a/mpf/tests/test_LogicBlocks.py
+++ b/mpf/tests/test_LogicBlocks.py
@@ -380,6 +380,16 @@ class TestLogicBlocks(MpfFakeGameTestCase):
             self.mock_event("logicblock_counter7_updated")
         self.start_game()
         reset_event_mocks()
+
+        # Posting control events while mode is not started should not cause changes
+        self.assertPlaceholderEvaluates(None, "device.counters.counter6.value")
+        self.post_event("increase_counter6_3")
+        self.assertPlaceholderEvaluates(None, "device.counters.counter6.value")
+        self.post_event("counter6_count")
+        self.assertPlaceholderEvaluates(None, "device.counters.counter6.value")
+        self.post_event("set_counter6_25")
+        self.assertPlaceholderEvaluates(None, "device.counters.counter6.value")
+
         # Start mode with control events and counter6
         self.post_event("start_mode4")
         self.assertTrue("mode4" in self.machine.modes)


### PR DESCRIPTION
https://github.com/missionpinball/mpf/issues/1933

I think the code change itself is kinda gross, I'm sure there's a better way (and the commit that moves my_counter.mode=mode earlier seems like it could cause a meaningful difference elsewhere in the code (nothing fails, but it seems like there would have been a reason why mode was attached only at mode-start-time)).

Still, this solution is close enough to a real one that I figured it's worth putting up to get comments on before I go trying to figure out a good test to prove it.