### PR TITLE
Counter action in non-running mode crash fix

### DIFF
--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -427,7 +427,7 @@ class Counter(LogicBlock):
             value: Value to add to the counter.
             kwargs: Additional arguments.
         """
-        if not self.enabled:
+        if (not self.enabled):
             return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
@@ -448,7 +448,7 @@ class Counter(LogicBlock):
             value: Value to subtract from the counter.
             kwargs: Additional arguments.
         """
-        if not self.enabled:
+        if (not self.enabled):
             return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
@@ -469,7 +469,7 @@ class Counter(LogicBlock):
             value: Value to add to jump to.
             kwargs: Additional arguments.
         """
-        if not self.enabled:
+        if (not self.enabled):
             return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -427,6 +427,8 @@ class Counter(LogicBlock):
             value: Value to add to the counter.
             kwargs: Additional arguments.
         """
+        if(not self.enabled):
+           return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter add did not evaluate with args %s", value, kwargs)
@@ -446,6 +448,8 @@ class Counter(LogicBlock):
             value: Value to subtract from the counter.
             kwargs: Additional arguments.
         """
+        if(not self.enabled):
+           return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter substract did not evaluate with args %s", value, kwargs)
@@ -465,6 +469,8 @@ class Counter(LogicBlock):
             value: Value to add to jump to.
             kwargs: Additional arguments.
         """
+        if(not self.enabled):
+           return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter jump did not evaluate with args %s", value, kwargs)

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -410,6 +410,8 @@ class Counter(LogicBlock):
             value: Value to add to the counter.
             kwargs: Additional arguments.
         """
+        if(not self.enabled):
+           return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter add did not evaluate with args %s", value, kwargs)
@@ -429,6 +431,8 @@ class Counter(LogicBlock):
             value: Value to subtract from the counter.
             kwargs: Additional arguments.
         """
+        if(not self.enabled):
+           return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter substract did not evaluate with args %s", value, kwargs)
@@ -448,6 +452,8 @@ class Counter(LogicBlock):
             value: Value to add to jump to.
             kwargs: Additional arguments.
         """
+        if(not self.enabled):
+           return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter jump did not evaluate with args %s", value, kwargs)

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -427,8 +427,8 @@ class Counter(LogicBlock):
             value: Value to add to the counter.
             kwargs: Additional arguments.
         """
-        if(not self.enabled):
-           return
+        if (not self.enabled):
+            return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter add did not evaluate with args %s", value, kwargs)
@@ -448,8 +448,8 @@ class Counter(LogicBlock):
             value: Value to subtract from the counter.
             kwargs: Additional arguments.
         """
-        if(not self.enabled):
-           return
+        if (not self.enabled):
+            return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter substract did not evaluate with args %s", value, kwargs)
@@ -469,8 +469,8 @@ class Counter(LogicBlock):
             value: Value to add to jump to.
             kwargs: Additional arguments.
         """
-        if(not self.enabled):
-           return
+        if (not self.enabled):
+            return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
             self.log.warning("Placeholder %s for counter jump did not evaluate with args %s", value, kwargs)

--- a/mpf/devices/logic_blocks.py
+++ b/mpf/devices/logic_blocks.py
@@ -427,7 +427,7 @@ class Counter(LogicBlock):
             value: Value to add to the counter.
             kwargs: Additional arguments.
         """
-        if (not self.enabled):
+        if not self.enabled:
             return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
@@ -448,7 +448,7 @@ class Counter(LogicBlock):
             value: Value to subtract from the counter.
             kwargs: Additional arguments.
         """
-        if (not self.enabled):
+        if not self.enabled:
             return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:
@@ -469,7 +469,7 @@ class Counter(LogicBlock):
             value: Value to add to jump to.
             kwargs: Additional arguments.
         """
-        if (not self.enabled):
+        if not self.enabled:
             return
         evaluated_value = value.evaluate_or_none(kwargs)
         if evaluated_value is None:

--- a/mpf/tests/test_LogicBlocks.py
+++ b/mpf/tests/test_LogicBlocks.py
@@ -897,3 +897,36 @@ class TestLogicBlocks(MpfFakeGameTestCase):
         self.post_event("accrual7_step2")
         self.assertEqual(3, self._events["accrual7_complete"])
         self.assertEqual(11, self._events["accrual7_hit"])
+
+    #test for when a counter action jump is called when it shouldn't be loaded
+    def test_counter_jump_when_mode_not_loaded(self):
+        self.start_game()
+        self.mock_event("counter6_complete")
+        self.post_event("set_counter6_25")
+        self.assertEventNotCalled("counter6_complete")
+        self.post_event("start_mode4")
+        self.post_event("set_counter6_25")
+        self.assertEventCalled("counter6_complete")
+
+    #test for when a counter action add is called when it shouldn't be loaded
+    def test_counter_add_when_mode_not_loaded(self):
+        self.start_game()
+        self.mock_event("counter6_complete")
+        self.post_event("increase_counter6_5")
+        self.post_event("increase_counter6_5")
+        self.assertEventNotCalled("counter6_complete")
+        self.post_event("start_mode4")
+        self.post_event("increase_counter6_5")
+        self.post_event("increase_counter6_5")
+        self.assertEventCalled("counter6_complete")
+
+    #test for when a counter action subtract is called when it shouldn't be loaded
+    def test_counter_subtract_when_mode_not_loaded(self):
+        self.start_game()
+        self.mock_event("logicblock_counter6_updated")
+        self.post_event("reduce_counter6_5")
+        self.assertEventNotCalled("logicblock_counter6_updated")
+        self.post_event("start_mode4")
+        self.post_event("reduce_counter6_5")
+        self.assertEventCalled("logicblock_counter6_updated")
+        

--- a/mpf/tests/test_LogicBlocks.py
+++ b/mpf/tests/test_LogicBlocks.py
@@ -907,3 +907,36 @@ class TestLogicBlocks(MpfFakeGameTestCase):
         self.post_event("accrual7_step2")
         self.assertEqual(3, self._events["accrual7_complete"])
         self.assertEqual(11, self._events["accrual7_hit"])
+
+    #test for when a counter action jump is called when it shouldn't be loaded
+    def test_counter_jump_when_mode_not_loaded(self):
+        self.start_game()
+        self.mock_event("counter6_complete")
+        self.post_event("set_counter6_25")
+        self.assertEventNotCalled("counter6_complete")
+        self.post_event("start_mode4")
+        self.post_event("set_counter6_25")
+        self.assertEventCalled("counter6_complete")
+
+    #test for when a counter action add is called when it shouldn't be loaded
+    def test_counter_add_when_mode_not_loaded(self):
+        self.start_game()
+        self.mock_event("counter6_complete")
+        self.post_event("increase_counter6_5")
+        self.post_event("increase_counter6_5")
+        self.assertEventNotCalled("counter6_complete")
+        self.post_event("start_mode4")
+        self.post_event("increase_counter6_5")
+        self.post_event("increase_counter6_5")
+        self.assertEventCalled("counter6_complete")
+
+    #test for when a counter action subtract is called when it shouldn't be loaded
+    def test_counter_subtract_when_mode_not_loaded(self):
+        self.start_game()
+        self.mock_event("logicblock_counter6_updated")
+        self.post_event("reduce_counter6_5")
+        self.assertEventNotCalled("logicblock_counter6_updated")
+        self.post_event("start_mode4")
+        self.post_event("reduce_counter6_5")
+        self.assertEventCalled("logicblock_counter6_updated")
+        


### PR DESCRIPTION
Fixed issue of counter actions crashing game when mode they are defined in is not running. [https://github.com/missionpinball/mpf/issues/1933]

Added tests to duplicate issue and verify actions still function when mode is running.