### PR TITLE
Fast er lights

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,10 +10,10 @@ PyPI.
 
 """
 
-__version__ = '0.57.4.dev3'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.58.0.dev1'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
-__short_version__ = '0.57'
+__short_version__ = '0.58'
 '''The major.minor version of MPF.'''
 
 __bcp_version__ = '1.1'

--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -213,13 +213,18 @@ class Light(SystemWideDevice, DevicePositionMixin):
                     tree.append(prev.name)
                     self.raise_config_error("Cyclical light chain found: {}".format(" -> ".join(tree)), 9)
 
-    def _load_hw_driver_sequentially(self, next_channel):
-        if self.config['number'] or self.config['channels']:
-            self.raise_config_error("Cannot use start_channel/previous and number or channels.", 3)
+    def _load_hw_driver_sequentially(self, first_channel):
+        if self.config['number']:
+            self.raise_config_error("Cannot use number with start_channel/previous.", 15)
+
+        if self.config['channels']:
+            self.raise_config_error("Cannot use channels list with start_channel/previous.", 16)
+
         if not self.config['type']:
             self.raise_config_error("Cannot use previous or start_channel without type. "
                                     "Add a type setting to your light.", 2)
 
+        next_channel = first_channel
         for color_letter in self.config['type']:
             full_color_name = self._color_letter_to_name(color_letter)
 
@@ -229,7 +234,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
                        'platform_settings': self.config['platform_settings'], 'number': next_channel}
             channel = self.machine.config_validator.validate_config("light_channels", channel)
             driver = self._load_hw_driver(channel, full_color_name)
-            next_channel = driver.get_successor_number()
+            next_channel = driver.get_successor_number()  # increment for the next loop
             self.hw_drivers[full_color_name].append(driver)
 
     def _load_hw_drivers(self):

--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -293,10 +293,8 @@ class Light(SystemWideDevice, DevicePositionMixin):
             channel_list[channel]['subtype'] = self.config['subtype']
             channel_list[channel]['platform'] = self.config['platform']
             channel_list[channel]['platform_settings'] = self.config['platform_settings']
-        # map channels to colors
-        return self._map_channels_to_colors(channel_list)
 
-    def _map_channels_to_colors(self, channel_list) -> dict:
+        # map channels to colors
         if self.config['type']:
             color_channels = self.config['type']
         else:
@@ -306,6 +304,8 @@ class Light(SystemWideDevice, DevicePositionMixin):
             elif len(channel_list) == 3:
                 # TODO this seems like a bug waiting to happen -- what if the channel list ISNT R G B ordered?
                 # -- the blind .pop(0) down below combined with the "for letter in 'rgb'" seems risky
+                # and the channel list order is up to the platform to provide, which doesnt seem clear in the
+                # parse_light_number_to_channels interface definition at all
 
                 # for three channels default to RGB
                 color_channels = "rgb"

--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -138,47 +138,21 @@ class Light(SystemWideDevice, DevicePositionMixin):
 
                     check_set.add(key)
 
-    def _map_channels_to_colors(self, channel_list) -> dict:
-        if self.config['type']:
-            color_channels = self.config['type']
-        else:
-            if len(channel_list) == 1:
-                # for one channel default to a white channel
-                color_channels = "w"
-            elif len(channel_list) == 3:
-                # for three channels default to RGB
-                color_channels = "rgb"
-            else:
-                self.raise_config_error("Please provide a type for light {}. No default for channels {}.".
-                                        format(self.name, channel_list), 11)
+    def _color_letter_to_name(self, letter):
+        if letter == 'r':
+            return 'red'
 
-        if len(channel_list) != len(color_channels):
-            self.raise_config_error("Type {} does not match channels {} for light {}".format(
-                color_channels, channel_list, self.name), 12)
+        if letter == 'g':
+            return 'green'
 
-        channels = {}   # type: Dict[str, List[Any]]
-        for color_name in color_channels:
-            # red channel
-            if color_name == 'r':
-                full_color_name = "red"
-            # green channel
-            elif color_name == 'g':
-                full_color_name = "green"
-            # blue channel
-            elif color_name == 'b':
-                full_color_name = "blue"
-            # simple white channel
-            elif color_name == 'w':
-                full_color_name = "white"
-            else:
-                self.raise_config_error("Invalid element {} in type {} of light {}".format(
-                    color_name, self.config['type'], self.name), 13)
+        if letter == 'b':
+            return 'blue'
 
-            if full_color_name not in channels:
-                channels[full_color_name] = []
-            channels[full_color_name].append(channel_list.pop(0))
+        if letter == 'w':
+            return 'white'
 
-        return channels
+        self.raise_config_error("Invalid element {} in type {} of light {}".format(
+                                letter, self.config['type'], self.name), 14)
 
     def wait_for_loaded(self):
         """Return future."""
@@ -194,94 +168,6 @@ class Light(SystemWideDevice, DevicePositionMixin):
             all_drivers.extend(drivers)
         sorted_channels = sorted(all_drivers)
         return sorted_channels[-1].get_successor_number()
-
-    def _load_hw_driver_sequentially(self, next_channel):
-        if self.config['number'] or self.config['channels']:
-            self.raise_config_error("Cannot use start_channel/previous and number or channels.", 3)
-        if not self.config['type']:
-            self.raise_config_error("Cannot use previous or start_channel without type. "
-                                    "Add a type setting to your light.", 2)
-
-        for color_name in self.config['type']:
-            # red channel
-            if color_name == 'r':
-                full_color_name = "red"
-            # green channel
-            elif color_name == 'g':
-                full_color_name = "green"
-            # blue channel
-            elif color_name == 'b':
-                full_color_name = "blue"
-            # simple white channel
-            elif color_name == 'w':
-                full_color_name = "white"
-            else:
-                self.raise_config_error("Invalid element {} in type {} of light {}".format(
-                    color_name, self.config['type'], self.name), 14)
-
-            if full_color_name not in self.hw_drivers:
-                self.hw_drivers[full_color_name] = []
-            channel = {'subtype': self.config['subtype'], 'platform': self.config['platform'],
-                       'platform_settings': self.config['platform_settings'], 'number': next_channel}
-            channel = self.machine.config_validator.validate_config("light_channels", channel)
-            driver = self._load_hw_driver(channel, full_color_name)
-            next_channel = driver.get_successor_number()
-            self.hw_drivers[full_color_name].append(driver)
-
-    def _load_hw_drivers(self):
-        if not self.config['channels']:
-            # get channels from number + platform
-            platform = self.machine.get_platform_sections('lights', self.config['platform'])
-            platform.assert_has_feature("lights")
-            try:
-                channel_list = platform.parse_light_number_to_channels(self.config['number'], self.config['subtype'])
-            except AssertionError as e:
-                self.raise_config_error("Failed to parse light number {} in platform. See error above".
-                                        format(self.name), 4, source_exception=e)
-
-            # copy platform and platform_settings to all channels
-            for channel, _ in enumerate(channel_list):
-                channel_list[channel]['subtype'] = self.config['subtype']
-                channel_list[channel]['platform'] = self.config['platform']
-                channel_list[channel]['platform_settings'] = self.config['platform_settings']
-            # map channels to colors
-            channels = self._map_channels_to_colors(channel_list)
-        else:
-            if self.config['number'] or self.config['platform'] or self.config['platform_settings']:
-                self.raise_config_error("Light {} cannot contain platform/platform_settings/number and channels".
-                                        format(self.name), 5)
-            # alternatively use channels from config
-            channels = self.config['channels']
-            # ensure that we got lists
-            for channel in channels:
-                if not isinstance(channels[channel], list):
-                    channels[channel] = [channels[channel]]
-
-        if not channels:
-            self.raise_config_error("Light {} has no channels.".format(self.name), 6)
-
-        for color, channel_list in channels.items():
-            self.hw_drivers[color] = []
-            for channel in channel_list:
-                channel = self.machine.config_validator.validate_config("light_channels", channel)
-                driver = self._load_hw_driver(channel, color)
-                self.hw_drivers[color].append(driver)
-
-    def _load_hw_driver(self, channel, color):
-        """Load one channel."""
-        platform = self.machine.get_platform_sections('lights', channel['platform'])
-        self.platforms.add(platform)
-
-        if not platform.features['allow_empty_numbers'] and channel['number'] is None:
-            self.raise_config_error("Light must have a number.", 1)
-
-        config = LightConfig(name=self.name, color=LightConfigColors[color.upper()])
-
-        try:
-            return platform.configure_light(channel['number'], channel['subtype'], config, channel['platform_settings'])
-        except AssertionError as e:
-            self.raise_config_error("Failed to configure light {} in platform. See error above".format(self.name), 7,
-                                    source_exception=e)
 
     async def _initialize(self):
         await super()._initialize()
@@ -327,6 +213,120 @@ class Light(SystemWideDevice, DevicePositionMixin):
                     tree.append(prev.name)
                     self.raise_config_error("Cyclical light chain found: {}".format(" -> ".join(tree)), 9)
 
+    def _load_hw_driver_sequentially(self, next_channel):
+        if self.config['number'] or self.config['channels']:
+            self.raise_config_error("Cannot use start_channel/previous and number or channels.", 3)
+        if not self.config['type']:
+            self.raise_config_error("Cannot use previous or start_channel without type. "
+                                    "Add a type setting to your light.", 2)
+
+        for color_letter in self.config['type']:
+            full_color_name = self._color_letter_to_name(color_letter)
+
+            if full_color_name not in self.hw_drivers:
+                self.hw_drivers[full_color_name] = []
+            channel = {'subtype': self.config['subtype'], 'platform': self.config['platform'],
+                       'platform_settings': self.config['platform_settings'], 'number': next_channel}
+            channel = self.machine.config_validator.validate_config("light_channels", channel)
+            driver = self._load_hw_driver(channel, full_color_name)
+            next_channel = driver.get_successor_number()
+            self.hw_drivers[full_color_name].append(driver)
+
+    def _load_hw_drivers(self):
+        if not self.config['channels']:
+            channels = self._derive_platform_channels()
+        else:
+            channels = self._prepare_config_channels()
+
+        if not channels:
+            self.raise_config_error("Light {} has no channels.".format(self.name), 6)
+
+        for color, channel_list in channels.items():
+            self.hw_drivers[color] = []
+            for channel in channel_list:
+                channel = self.machine.config_validator.validate_config("light_channels", channel)
+                driver = self._load_hw_driver(channel, color)
+                self.hw_drivers[color].append(driver)
+
+    def _load_hw_driver(self, channel, color):
+        """Load one channel."""
+        platform = self.machine.get_platform_sections('lights', channel['platform'])
+        self.platforms.add(platform)
+
+        if not platform.features['allow_empty_numbers'] and channel['number'] is None:
+            self.raise_config_error("Light must have a number.", 1)
+
+        config = LightConfig(name=self.name, color=LightConfigColors[color.upper()])
+
+        try:
+            return platform.configure_light(channel['number'], channel['subtype'], config, channel['platform_settings'])
+        except AssertionError as e:
+            self.raise_config_error("Failed to configure light {} in platform. See error above".format(self.name), 7,
+                                    source_exception=e)
+
+    def _prepare_config_channels(self):
+        if self.config['number'] or self.config['platform'] or self.config['platform_settings']:
+            self.raise_config_error("Light {} cannot contain platform/platform_settings/number and channels".
+                                    format(self.name), 5)
+        channels = self.config['channels']
+
+        # ensure that each color's channels are a list, not single value
+        for channel in channels:
+            if not isinstance(channels[channel], list):
+                channels[channel] = [channels[channel]]
+
+        return channels
+
+    def _derive_platform_channels(self):
+        # get channels from number + platform
+        platform = self.machine.get_platform_sections('lights', self.config['platform'])
+        platform.assert_has_feature("lights")
+
+        try:
+            channel_list = platform.parse_light_number_to_channels(self.config['number'], self.config['subtype'])
+        except AssertionError as e:
+            self.raise_config_error("Failed to parse light number {} in platform. See error above".
+                                    format(self.name), 4, source_exception=e)
+
+        # copy platform and platform_settings to all channels
+        for channel, _ in enumerate(channel_list):
+            channel_list[channel]['subtype'] = self.config['subtype']
+            channel_list[channel]['platform'] = self.config['platform']
+            channel_list[channel]['platform_settings'] = self.config['platform_settings']
+        # map channels to colors
+        return self._map_channels_to_colors(channel_list)
+
+    def _map_channels_to_colors(self, channel_list) -> dict:
+        if self.config['type']:
+            color_channels = self.config['type']
+        else:
+            if len(channel_list) == 1:
+                # for one channel default to a white channel
+                color_channels = "w"
+            elif len(channel_list) == 3:
+                # TODO this seems like a bug waiting to happen -- what if the channel list ISNT R G B ordered?
+                # -- the blind .pop(0) down below combined with the "for letter in 'rgb'" seems risky
+
+                # for three channels default to RGB
+                color_channels = "rgb"
+            else:
+                self.raise_config_error("Please provide a type for light {}. No default for channels {}.".
+                                        format(self.name, channel_list), 11)
+
+        if len(channel_list) != len(color_channels):
+            self.raise_config_error("Type {} does not match channels {} for light {}".format(
+                color_channels, channel_list, self.name), 12)
+
+        channels = {}   # type: Dict[str, List[Any]]
+        for color_letter in color_channels:
+            full_color_name = self._color_letter_to_name(color_letter)
+            if full_color_name not in channels:
+                channels[full_color_name] = []
+
+            channels[full_color_name].append(channel_list.pop(0))
+
+        return channels
+
     def _apply_color_correction_profile(self, profile_value):
         profile_name = self._determine_color_correction_profile(profile_value)
         if profile_name:
@@ -370,7 +370,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
 
     def _apply_rgbw_style(self):
         rgbw_all_present = all(channel in self.hw_drivers
-                    for channel in ['red', 'green', 'blue', 'white'])
+                               for channel in ['red', 'green', 'blue', 'white'])
 
         if len(self.hw_drivers) == 4 and rgbw_all_present:
             self._rbgw_style = self.machine.config['mpf']['rgbw_white_behavior']

--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -275,10 +275,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
         if not platform.features['allow_empty_numbers'] and channel['number'] is None:
             self.raise_config_error("Light must have a number.", 1)
 
-        config = LightConfig(
-            name=self.name,
-            color=LightConfigColors[color.upper()]
-        )
+        config = LightConfig(name=self.name, color=LightConfigColors[color.upper()])
 
         try:
             return platform.configure_light(channel['number'], channel['subtype'], config, channel['platform_settings'])
@@ -405,8 +402,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
         """
         if self._debug:
             self.debug_log("Received color() command. color: %s, fade_ms: %s "
-                           "priority: %s, key: %s", color, fade_ms, priority,
-                           key)
+                           "priority: %s, key: %s", color, fade_ms, priority, key)
 
         if isinstance(color, str) and color == "on":
             color = self.config['default_on_color']
@@ -453,8 +449,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
             fade_ms: duration of fade
         """
         del kwargs
-        self.color(color=self._off_color, fade_ms=fade_ms, priority=priority,
-                   key=key)
+        self.color(color=self._off_color, fade_ms=fade_ms, priority=priority, key=key)
 
     # pylint: disable-msg=too-many-arguments
     def _add_to_stack(self, color, fade_ms, priority, key, start_time):
@@ -486,12 +481,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
         if self.stack:
             self._remove_from_stack_by_key(key)
 
-        self.stack.append(LightStackEntry(priority,
-                                          key,
-                                          start_time,
-                                          color_below,
-                                          dest_time,
-                                          color))
+        self.stack.append(LightStackEntry(priority, key, start_time, color_below, dest_time, color))
 
         if len(self.stack) > 1:
             self.stack.sort(reverse=True)

--- a/mpf/devices/light.py
+++ b/mpf/devices/light.py
@@ -290,22 +290,7 @@ class Light(SystemWideDevice, DevicePositionMixin):
         await super()._initialize()
         try:
             if self.config['previous']:
-                if self.config['previous'].name == self.name:
-                    self.raise_config_error(
-                        "Failed to configure light {} in platform. 'previous' value cannot refer to itself.".
-                        format(self.name), 8)
-
-                # If we are in development mode, do a robust tree traversal to catch infinite light loops
-                if not self.machine.options['production']:
-                    tree = [self.name]
-                    prev = self.config['previous']
-                    while prev:
-                        tree.append(prev.name)
-                        prev = prev.config.get('previous')
-                        if prev is not None and prev.name in tree:
-                            tree.append(prev.name)
-                            self.raise_config_error("Cyclical light chain found: {}".format(" -> ".join(tree)), 9)
-
+                self._detect_previous_reference_loop()
                 await self.config['previous'].wait_for_loaded()
                 start_channel = self.config['previous'].get_successor_number()
                 self._load_hw_driver_sequentially(start_channel)
@@ -313,47 +298,62 @@ class Light(SystemWideDevice, DevicePositionMixin):
                 self._load_hw_driver_sequentially(self.config['start_channel'])
             else:
                 self._load_hw_drivers()
-            self._drivers_loaded.set_result(True)
 
+            self._drivers_loaded.set_result(True)
             self.config['default_on_color'] = RGBColor(self.config['default_on_color'])
 
-            if self.config['color_correction_profile'] is not None:
-                profile_name = self.config['color_correction_profile']
-            elif 'light_settings' in self.machine.config and \
-                    self.machine.config['light_settings']['default_color_correction_profile'] is not None:
-                profile_name = self.machine.config['light_settings']['default_color_correction_profile']
-            else:
-                profile_name = None
+            self._apply_color_correction_profile(self.config['color_correction_profile'])
+            self._apply_fade(self.config['fade_ms'])
+            self._apply_rgbw_style()
 
-            if profile_name:
-                if profile_name in self.machine.light_controller.light_color_correction_profiles:
-                    profile = self.machine.light_controller.light_color_correction_profiles[profile_name]
-
-                    if profile is not None:
-                        self._set_color_correction_profile(profile)
-                else:   # pragma: no cover
-                    error = "Color correction profile '{}' was specified for light '{}'"\
-                            " but the color correction profile does not exist."\
-                            .format(profile_name, self.name)
-                    self.error_log(error)
-                    raise ValueError(error)
-
-            if self.config['fade_ms'] is not None:
-                self.default_fade_ms = self.config['fade_ms']
-            else:
-                self.default_fade_ms = (self.machine.config['light_settings']
-                                        ['default_fade_ms'])
-
-            if len(self.hw_drivers) == 4 and all(channel in self.hw_drivers
-                                                 for channel in ['red', 'green', 'blue', 'white']):
-                self._rbgw_style = self.machine.config['mpf']['rgbw_white_behavior']
-
-            self.debug_log("Initializing Light. CC Profile: %s, "
-                           "Default fade: %sms", self._color_correction_profile,
+            self.debug_log("Initializing Light. CC Profile: %s, Default fade: %sms",
+                           self._color_correction_profile,
                            self.default_fade_ms)
         except Exception:
             self._drivers_loaded.cancel()
             raise
+
+    def _detect_previous_reference_loop(self):
+        if self.config['previous'].name == self.name:
+            self.raise_config_error(
+                "Failed to configure light {} in platform. 'previous' value cannot refer to itself.".
+                format(self.name), 8)
+
+        # If we are in development mode, do a robust tree traversal to catch infinite light loops
+        if not self.machine.options['production']:
+            tree = [self.name]
+            prev = self.config['previous']
+            while prev:
+                tree.append(prev.name)
+                prev = prev.config.get('previous')
+                if prev is not None and prev.name in tree:
+                    tree.append(prev.name)
+                    self.raise_config_error("Cyclical light chain found: {}".format(" -> ".join(tree)), 9)
+
+    def _apply_color_correction_profile(self, profile_value):
+        profile_name = self._determine_color_correction_profile(profile_value)
+        if profile_name:
+            if profile_name in self.machine.light_controller.light_color_correction_profiles:
+                profile = self.machine.light_controller.light_color_correction_profiles[profile_name]
+
+                if profile is not None:
+                    self._set_color_correction_profile(profile)
+            else:  # pragma: no cover
+                error = "Color correction profile '{}' was specified for light '{}'"\
+                        " but the color correction profile does not exist."\
+                        .format(profile_name, self.name)
+                self.error_log(error)
+                raise ValueError(error)
+
+    def _determine_color_correction_profile(self, profile_value):
+        if profile_value is not None:
+            return profile_value
+
+        if 'light_settings' in self.machine.config and \
+                self.machine.config['light_settings']['default_color_correction_profile'] is not None:
+            return self.machine.config['light_settings']['default_color_correction_profile']
+
+        return None
 
     def _set_color_correction_profile(self, profile):
         """Apply a color correction profile to this light.
@@ -364,6 +364,19 @@ class Light(SystemWideDevice, DevicePositionMixin):
 
         """
         self._color_correction_profile = profile
+
+    def _apply_fade(self, fade_value):
+        if fade_value is not None:
+            self.default_fade_ms = fade_value
+        else:
+            self.default_fade_ms = self.machine.config['light_settings']['default_fade_ms']
+
+    def _apply_rgbw_style(self):
+        rgbw_all_present = all(channel in self.hw_drivers
+                    for channel in ['red', 'green', 'blue', 'white'])
+
+        if len(self.hw_drivers) == 4 and rgbw_all_present:
+            self._rbgw_style = self.machine.config['mpf']['rgbw_white_behavior']
 
     # pylint: disable-msg=too-many-arguments
     def color(self, color, fade_ms=None, priority=0, key=None, start_time=None):

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -752,12 +752,13 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                     result = []
                     for i in range(3):
                         working_parts = parts.copy()
-                        if i + channel > 2:
+                        absolute_channel = channel + i
+                        if absolute_channel > 2:
                             # Channel rolls over, increment the LED number
-                            working_parts[3] = str(int(working_parts[3]) + 1)
-                            working_parts[4] = str((channel + i) % 3)
+                            working_parts[3] = str(int(working_parts[3]) + absolute_channel // 3)
+                            working_parts[4] = str(absolute_channel % 3)
                         else:
-                            working_parts[4] = str(channel + i)
+                            working_parts[4] = str(absolute_channel)
                         result.append({'number': '-'.join(working_parts)})
                     return result
                 raise AssertionError(f"Invalid LED channel: {channel}")

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -562,12 +562,10 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
             raise AssertionError("Switch needs a number")
 
         if not self.serial_connections['net']:
-            raise AssertionError("A request was made to configure a FAST "
-                                 "switch, but no connection to a NET processor"
-                                 "is available")
+            raise AssertionError("A request was made to configure a FAST switch, "
+                                 "but no connection to a NET processor is available")
 
-        if self.is_retro:
-            # translate switch num to FAST switch
+        if self.is_retro:  # translate switch num to FAST switch
             try:
                 number = fast_defines.RETRO_SWITCH_MAP[str(number).upper()]
             except KeyError:
@@ -584,7 +582,6 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
 
         return switch
 
-    # pylint: disable-msg=too-many-locals
     def configure_light(self, number, subtype, config, platform_settings) -> LightPlatformInterface:
         """Configure light in platform."""
         del platform_settings
@@ -601,80 +598,86 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
             # split into board name, breakout, port, led
             parts = parts.split('-')
 
-            if parts[0] in self.exp_boards_by_name:
-                # this is an expansion board LED in config file format
-                exp_board = self.exp_boards_by_name[parts[0]]
+            if parts[0] in self.exp_boards_by_name:  # this is an expansion board LED in config file format
+                return self._add_exp_led_with_config_format(parts, channel, config.name)
 
-                try:
-                    _, port, led = parts
-                    breakout = '0'
-                except ValueError:
-                    _, breakout, port, led = parts
-                    breakout = breakout.strip('b')
+            if int(parts[0]) > 255:  # EXP LED in int form, which is how "previous:" values are calculated
+                return self._add_exp_led_with_int_format(parts, channel)
 
-                # ports are always 1-4, but some EXP boards have more which are labeled 5-8
-                # Those are really 1-4 of the next breakout board, so if we get a port > 4
-                # then sort it out to the real internal values
-                if int(port) > 4:
-                    # assume 4 LED ports per breakout, could change to a lookup
-                    breakout = str((int(port) - 1) // 4)
-                    port = str((int(port) - 1) % 4 + 1)
+            # else it's a Nano LED
+            return self._add_nano_led(parts, channel)
 
-                try:
-                    brk_board = exp_board.breakouts[breakout]
-                except KeyError:
-                    # TODO change to mpf config exception
-                    raise AssertionError(f'Board {exp_board} does not have a config entry for Breakout {breakout}')
-
-                index = self.port_idx_to_hex(port, led, 32, config.name)
-                this_led_number = f'{brk_board.address}{index}'
-
-                # this code runs once for each channel, so it will be called 3x per LED which
-                # is why we check this here
-                if this_led_number not in self.fast_exp_leds:
-                    self.fast_exp_leds[this_led_number] = FASTExpLED(this_led_number,
-                                                                     exp_board.config['led_fade_time'], self)
-
-                fast_led_channel = FASTLEDChannel(self.fast_exp_leds[this_led_number], channel)
-                self.fast_exp_leds[this_led_number].add_channel(int(channel), fast_led_channel)
-
-            elif int(parts[0]) > 255:
-                # EXP LED in int form, which is how "previous:" values are calculated
-
-                raw_hex_string = hex(int(parts[0]))[2:]  # lowercase with 0x prefix stripped"
-                this_led_number = Util.normalize_hex_string(raw_hex_string, len(raw_hex_string))
-
-                exp_board = self.exp_boards_by_address[this_led_number[:2]]
-
-                if this_led_number not in self.fast_exp_leds:
-                    # RGBW LEDs could span multiple FAST LEDs, so make sure it exists
-                    self.fast_exp_leds[this_led_number] = FASTExpLED(this_led_number,
-                                                                     exp_board.config['led_fade_time'], self)
-
-                fast_led_channel = FASTLEDChannel(self.fast_exp_leds[this_led_number], channel)
-                self.fast_exp_leds[this_led_number].add_channel(int(channel), fast_led_channel)
-
-            else:
-                # Nano LED
-
-                try:
-                    number = self.port_idx_to_hex(parts[0], parts[1], 64)
-                except IndexError:
-                    # this is a legacy LED number as an int
-                    number = f'{int(parts[0]):02X}'
-
-                if number not in self.fast_rgb_leds:
-                    try:
-                        self.fast_rgb_leds[number] = FASTRGBLED(number, self)
-                    except KeyError:
-                        # This number is not valid
-                        raise ConfigFileError(f"Invalid LED number: {'_'.join(parts)}", 3, self.log.name)
-
-                fast_led_channel = FASTLEDChannel(self.fast_rgb_leds[number], channel)
-                self.fast_rgb_leds[number].add_channel(int(channel), fast_led_channel)
-
-            return fast_led_channel
         raise AssertionError(f"Unknown light subtype {subtype}")
+
+    def _add_exp_led_with_config_format(self, parts, channel, name):
+        exp_board = self.exp_boards_by_name[parts[0]]
+
+        try:
+            _, port, led = parts
+            breakout = '0'
+        except ValueError:
+            _, breakout, port, led = parts
+            breakout = breakout.strip('b')
+
+        # ports are always 1-4, but some EXP boards have more which are labeled 5-8
+        # Those are really 1-4 of the next breakout board, so if we get a port > 4
+        # then sort it out to the real internal values
+        if int(port) > 4:
+            # assume 4 LED ports per breakout, could change to a lookup
+            breakout = str((int(port) - 1) // 4)
+            port = str((int(port) - 1) % 4 + 1)
+
+        try:
+            brk_board = exp_board.breakouts[breakout]
+        except KeyError:
+            # TODO change to mpf config exception
+            raise AssertionError(f'Board {exp_board} does not have a config entry for Breakout {breakout}')
+
+        index = self.port_idx_to_hex(port, led, 32, name)
+        this_led_number = f'{brk_board.address}{index}'
+
+        # this code runs once for each channel, so it will be called 3x per LED which
+        # is why we check this here
+        if this_led_number not in self.fast_exp_leds:
+            self.fast_exp_leds[this_led_number] = FASTExpLED(this_led_number,
+                                                             exp_board.config['led_fade_time'], self)
+
+        fast_led_channel = FASTLEDChannel(self.fast_exp_leds[this_led_number], channel)
+        self.fast_exp_leds[this_led_number].add_channel(int(channel), fast_led_channel)
+        return fast_led_channel
+
+    def _add_exp_led_with_int_format(self, parts, channel):
+        raw_hex_string = hex(int(parts[0]))[2:]  # lowercase with 0x prefix stripped"
+        this_led_number = Util.normalize_hex_string(raw_hex_string, len(raw_hex_string))
+
+        exp_board = self.exp_boards_by_address[this_led_number[:2]]
+
+        if this_led_number not in self.fast_exp_leds:
+            # RGBW LEDs could span multiple FAST LEDs, so make sure it exists
+            self.fast_exp_leds[this_led_number] = FASTExpLED(this_led_number,
+                                                             exp_board.config['led_fade_time'], self)
+
+        fast_led_channel = FASTLEDChannel(self.fast_exp_leds[this_led_number], channel)
+        self.fast_exp_leds[this_led_number].add_channel(int(channel), fast_led_channel)
+        return fast_led_channel
+
+    def _add_nano_led(self, parts, channel):
+        try:
+            number = self.port_idx_to_hex(parts[0], parts[1], 64)
+        except IndexError:
+            # this is a legacy LED number as an int
+            number = f'{int(parts[0]):02X}'
+
+        if number not in self.fast_rgb_leds:
+            try:
+                self.fast_rgb_leds[number] = FASTRGBLED(number, self)
+            except KeyError:
+                # This number is not valid
+                raise ConfigFileError(f"Invalid LED number: {'_'.join(parts)}", 3, self.log.name)
+
+        fast_led_channel = FASTLEDChannel(self.fast_rgb_leds[number], channel)
+        self.fast_rgb_leds[number].add_channel(int(channel), fast_led_channel)
+        return fast_led_channel
 
     def port_idx_to_hex(self, port, device_num, devices_per_port, name=None):
         """Converts port number and LED index into the proper FAST hex number.

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -740,34 +740,45 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
 
         if parts[0] in self.exp_boards_by_name:
             # This is an expansion board LED
-            if not parts[1].startswith('b'):
-                # No breakout specified, so we insert a b0
-                parts.insert(1, 'b0')
+            return self._parse_expansion_board_light_number(number, parts)
 
-            if len(parts) == 4:
-                # No channel specified, so we return 3 channels 0,1,2
-                return [{'number': '-'.join(parts) + f'-{i}'} for i in range(3)]
+        # Nano LEDs do not have expansion board names
+        return self._parse_nano_light_number(number, parts)
 
-            if len(parts) == 5:
-                # We have a channel specified
-                channel = int(parts[4])
-                if 0 <= channel <= 2:
-                    result = []
-                    for i in range(3):
-                        working_parts = parts.copy()
-                        absolute_channel = channel + i
-                        if absolute_channel > 2:
-                            # Channel rolls over, increment the LED number
-                            working_parts[3] = str(int(working_parts[3]) + absolute_channel // 3)
-                            working_parts[4] = str(absolute_channel % 3)
-                        else:
-                            working_parts[4] = str(absolute_channel)
-                        result.append({'number': '-'.join(working_parts)})
-                    return result
-                raise AssertionError(f"Invalid LED channel: {channel}")
-            raise AssertionError(f"Invalid LED number: {number}")
+    def _parse_expansion_board_light_number(self, number, parts):
+        if not parts[1].startswith('b'):
+            # No breakout specified, so we insert a b0
+            parts.insert(1, 'b0')
 
-        # This is a Nano LED
+        if len(parts) == 4:
+            # No channel specified, so we return 3 channels 0,1,2
+            return [{'number': '-'.join(parts) + f'-{i}'} for i in range(3)]
+
+        if len(parts) == 5:
+            # We have a channel specified
+            channel = int(parts[4])
+            if 0 <= channel <= 2:
+                result = []
+                for i in range(3):
+                    working_parts = parts.copy()
+                    absolute_channel = channel + i
+                    if absolute_channel > 2:
+                        # Channel rolls over, increment the LED number
+                        working_parts[3] = str(int(working_parts[3]) + absolute_channel // 3)
+                        working_parts[4] = str(absolute_channel % 3)
+                    else:
+                        working_parts[4] = str(absolute_channel)
+                    result.append({'number': '-'.join(working_parts)})
+
+                return result
+
+            # channel out of bounds
+            raise AssertionError(f"Invalid LED channel: {channel}")
+
+        # wrong number of parts
+        raise AssertionError(f"Invalid LED number: {number}")
+
+    def _parse_nano_light_number(self, number, parts):
         if '-' in str(number):
             # num = list(map(int, str(number).split('-')))
             # index = num[0] * 64 + num[1]

--- a/mpf/platforms/fast/fast_defines.py
+++ b/mpf/platforms/fast/fast_defines.py
@@ -34,37 +34,37 @@ EXPANSION_BOARD_FEATURES = {
         'default_address': '30'
     },
     'FP-EXP-0051': {
-        'min_fw': '0.31',
+        'min_fw': '0.48',
         'local_breakouts': ['FP-EXP-0051'],
         'breakout_ports': 0,
         'default_address': 'D0'
     },
     'FP-EXP-0061': {
-        'min_fw': '0.31',
+        'min_fw': '0.48',
         'local_breakouts': ['FP-EXP-0061'],
         'breakout_ports': 0,
         'default_address': '90'
     },
     'FP-EXP-0071': {
-        'min_fw': '0.11',
+        'min_fw': '0.44',
         'local_breakouts': ['FP-EXP-0071'],
         'breakout_ports': 0,
         'default_address': 'B4'
     },
     'FP-EXP-0081': {
-        'min_fw': '0.12',
+        'min_fw': '0.48',
         'local_breakouts': ['FP-EXP-0081', 'FP-EXP-0081'],
         'breakout_ports': 0,
         'default_address': '84'
     },
     'FP-EXP-0091': {
-        'min_fw': '0.11',
+        'min_fw': '0.48',
         'local_breakouts': ['FP-EXP-0091'],
         'breakout_ports': 2,
         'default_address': '88'
     },
     'FP-EXP-2000': {
-        'min_fw': '0.11',
+        'min_fw': '0.44',
         'local_breakouts': ['FP-BRK-0001'],
         'breakout_ports': 3,
         'default_address': '48'
@@ -77,21 +77,21 @@ BREAKOUT_FEATURES = {
         'shaker_ports': 1
     },
     'FP-EXP-0061': {
-        'min_fw': '0.33',
+        'min_fw': '0.48',
         'led_ports': 4,
         'stepper_ports': 2
     },
     'FP-EXP-0071': {
-        'min_fw': '0.11',
+        'min_fw': '0.44',
         'led_ports': 4,
         'servo_ports': 4,
     },
     'FP-EXP-0081': {
-        'min_fw': '0.11',
+        'min_fw': '0.48',
         'led_ports': 4,
     },
     'FP-EXP-0091': {
-        'min_fw': '0.11',
+        'min_fw': '0.48',
         'led_ports': 4,
     },
     'FP-BRK-0001': {  # Neuron

--- a/mpf/platforms/fast/fast_led.py
+++ b/mpf/platforms/fast/fast_led.py
@@ -143,7 +143,11 @@ class FASTLEDChannel(LightPlatformInterface):
 
     def is_successor_of(self, other):
         """Return true if the other light has the previous number."""
-        return self.led.number_int * 3 + self.channel == other.led.number_int * 3 + other.channel + 1
+        return self.absolute_channel() == other.absolute_channel() + 1
+
+    def absolute_channel(self):
+        """Returns channel offset from 0-0 as a single number."""
+        return self.led.number_int * 3 + self.channel
 
     def get_successor_number(self):
         """Return next number. We want this in the config format."""


### PR DESCRIPTION
WIP -- IMO this is a breaking change and requires a minor version bump to .58/.81, or we even just target .81 and leave .57 series behind. This PR includes the version bump commit, which we can rebase out when the true merge point is determined.

I'm kind of in favor of this -- thinking about the upgrade steps required to move from .57 to .80, if someone really wants the ER-based features in legacy, they will move to .58 to get them. But then they no longer can upgrade directly to .80, since the ER support will disappear (leaving them with either misbehaving lights, or possibly incompatible config specification).
I suppose the steps to go between .58 and .81 would be identical to the 57->80 upgrade path, but that also then requires that .81 not have any additional breaking changes between .80 and .81 (or else the developer must solve everything at once!)

Since this is the lights system, there are existing hacks (https://github.com/missionpinball/mpf/issues/1939, where the hand-channeled example is given) to make RGBWs work on FAST without ER, and RGB and RGBW lights are among the cheapest and most substitutable electronic components in a build, I vote make this .81-only.

Most of the early commits are simple refactors, so it's possible we could backport much of this into .57.4 if desired, but
I'd rather deliver the whole package at once than risk getting some stuff merged in and other stuff languish for a long time.