### PR TITLE
Asyncio `get_``event_loop` to `new_`

### DIFF
--- a/mpf/core/clock.py
+++ b/mpf/core/clock.py
@@ -64,21 +64,27 @@ class ClockBase(LogMixin):
 
         self.debug_log("Starting tickless clock")
         if not loop:
-            self.loop = self._create_event_loop()   # type: asyncio.AbstractEventLoop
+            self.loop = self._get_or_create_loop()  # type: asyncio.AbstractEventLoop
         else:
             self.loop = loop                        # type: asyncio.AbstractEventLoop
 
         asyncio.set_event_loop(self.loop)
 
-    def _create_event_loop(self):
+    def _get_or_create_loop(self):
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError:
+            return self._create_loop()
+
+    def _create_loop(self):
         try:
             # pylint: disable-msg=import-outside-toplevel
             import uvloop
         except ImportError:
             pass
         else:
-            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-        return asyncio.get_event_loop()
+            return uvloop.new_event_loop()
+        return asyncio.new_event_loop()
 
     def run(self, stop_future):
         """Run the clock."""

--- a/mpf/tests/MpfTestCase.py
+++ b/mpf/tests/MpfTestCase.py
@@ -133,7 +133,7 @@ class TestMachineController(MachineController):
         return self._test_clock
 
     def __del__(self):
-        if self._test_clock:
+        if self._test_clock and self._test_clock.loop.is_running():
             self._test_clock.loop.close()
 
     def _register_plugin_config_players(self):


### PR DESCRIPTION
Python 3.14 deprecates the behavior of asyncio_get_event_loop creating one when one is not found.
Python 3.16 will deprecate how uvloop hooks in (via policy management)

So really, this mostly makes sense for 0.80.x, but the change seems to be viable for older versions as well, so I'd rather target dev.

It appears to me that the changed code may not actually be executed in test, so I think I should find some testers on .57 and Python 3.9 (8 if someone is so bold)