### PR TITLE
Implement chimes enable/disable functionality

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1478,6 +1478,8 @@ score_reel_groups:
     __type__: device
     reels: list|machine(score_reels)|
     chimes: list|machine(coils)|None
+    enable_chimes_events: event_handler|event_handler:ms|ball_started
+    disable_chimes_events: event_handler|event_handler:ms|game_ended
     lights_tag: single|str|None
 segment_displays:
     __valid_in__: machine

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -73,11 +73,10 @@ class ScoreReelGroup(SystemWideDevice):
                                                 handler=self.chime,
                                                 chime=self.config['chimes'][i])
 
-    @classmethod
-    def chime(cls, chime, **kwargs):
+    def chime(self, chime, **kwargs):
         """Pulse chime if chimes are enabled."""
         del kwargs
-        if cls.chimes_enabled:
+        if self.chimes_enabled:
             chime.pulse()
 
     @event_handler(1)

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -5,6 +5,7 @@ from mpf.core.system_wide_device import SystemWideDevice
 from mpf.devices.score_reel_controller import ScoreReelController
 from mpf.core.events import event_handler
 
+
 class ScoreReelGroup(SystemWideDevice):
 
     """Represents a logical grouping of score reels in a pinball machine.
@@ -72,21 +73,23 @@ class ScoreReelGroup(SystemWideDevice):
                                                 handler=self.chime,
                                                 chime=self.config['chimes'][i])
 
-    def chime(cls, chime, **kwargs):
+    def chime(self, chime, **kwargs):
         """Pulse chime if chimes are enabled."""
         del kwargs
-        if cls.chimes_enabled:
+        if self.chimes_enabled:
             chime.pulse()
 
     @event_handler(1)
     def event_enable_chimes(self, **kwargs):
         """Event handler to enable chimes."""
+        del kwargs
         self.chimes_enabled = True
         self.log.info('Chimes enabled.')
 
     @event_handler(2)
     def event_disable_chimes(self, **kwargs):
         """Event handler to disable chimes."""
+        del kwargs
         self.chimes_enabled = False
         self.log.info('Chimes disabled.')
 

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -52,7 +52,7 @@ class ScoreReelGroup(SystemWideDevice):
         self.jump_in_progress = False
         # Boolean attribute that is True when a jump advance is in progress.
 
-        self.chimes_enabled = False 
+        self.chimes_enabled = False
         # Boolean attribute that is True when chimes should play when reels advance.
 
         self._tick_task = None
@@ -85,7 +85,7 @@ class ScoreReelGroup(SystemWideDevice):
     def enable_chimes(self, **kwargs):
         self.chimes_enabled = True
         self.machine.events.post('========== CHIMES ENABLED ==========')
-    
+
     def disable_chimes(self, **kwargs):
         self.chimes_enabled = False
         self.machine.events.post('========== CHIMES DISABLED =========')

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -73,10 +73,11 @@ class ScoreReelGroup(SystemWideDevice):
                                                 handler=self.chime,
                                                 chime=self.config['chimes'][i])
 
-    def chime(self, chime, **kwargs):
+    @classmethod
+    def chime(cls, chime, **kwargs):
         """Pulse chime if chimes are enabled."""
         del kwargs
-        if self.chimes_enabled:
+        if cls.chimes_enabled:
             chime.pulse()
 
     @event_handler(1)

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -3,7 +3,7 @@ from collections import deque
 
 from mpf.core.system_wide_device import SystemWideDevice
 from mpf.devices.score_reel_controller import ScoreReelController
-
+from mpf.core.events import event_handler
 
 class ScoreReelGroup(SystemWideDevice):
 
@@ -62,9 +62,6 @@ class ScoreReelGroup(SystemWideDevice):
         self.reels = self.config['reels']
         self.reels.reverse()  # We want our smallest digit in the 0th element
 
-        self.machine.events.add_handler(event='ball_started', handler=self.enable_chimes)
-        self.machine.events.add_handler(event='game_ended', handler=self.disable_chimes)
-
         self.config['chimes'].reverse()
         for i in range(len(self.config['chimes'])):
 
@@ -75,18 +72,21 @@ class ScoreReelGroup(SystemWideDevice):
                                                 handler=self.chime,
                                                 chime=self.config['chimes'][i])
 
-    @classmethod
-    def chime(self, chime, **kwargs):
+    def chime(cls, chime, **kwargs):
         """Pulse chime if chimes are enabled."""
         del kwargs
-        if self.chimes_enabled:
+        if cls.chimes_enabled:
             chime.pulse()
 
-    def enable_chimes(self, **kwargs):
+    @event_handler(1)
+    def event_enable_chimes(self, **kwargs):
+        """Event handler to enable chimes."""
         self.chimes_enabled = True
         self.log.info('Chimes enabled.')
 
-    def disable_chimes(self, **kwargs):
+    @event_handler(2)
+    def event_disable_chimes(self, **kwargs):
+        """Event handler to disable chimes."""
         self.chimes_enabled = False
         self.log.info('Chimes disabled.')
 

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -84,11 +84,11 @@ class ScoreReelGroup(SystemWideDevice):
 
     def enable_chimes(self, **kwargs):
         self.chimes_enabled = True
-        self.machine.events.post('========== CHIMES ENABLED ==========')
+        self.log.info('Chimes enabled.')
 
     def disable_chimes(self, **kwargs):
         self.chimes_enabled = False
-        self.machine.events.post('========== CHIMES DISABLED =========')
+        self.log.info('Chimes disabled.')
 
     def set_value(self, value):
         """Reset the score reel group to display the value passed.

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -52,12 +52,18 @@ class ScoreReelGroup(SystemWideDevice):
         self.jump_in_progress = False
         # Boolean attribute that is True when a jump advance is in progress.
 
+        self.chimes_enabled = False 
+        # Boolean attribute that is True when chimes should play when reels advance.
+
         self._tick_task = None
 
     async def _initialize(self):
         await super()._initialize()
         self.reels = self.config['reels']
         self.reels.reverse()  # We want our smallest digit in the 0th element
+
+        self.machine.events.add_handler(event='ball_started', handler=self.enable_chimes)
+        self.machine.events.add_handler(event='game_ended', handler=self.disable_chimes)
 
         self.config['chimes'].reverse()
         for i in range(len(self.config['chimes'])):
@@ -70,10 +76,19 @@ class ScoreReelGroup(SystemWideDevice):
                                                 chime=self.config['chimes'][i])
 
     @classmethod
-    def chime(cls, chime, **kwargs):
-        """Pulse chime."""
+    def chime(self, chime, **kwargs):
+        """Pulse chime if chimes are enabled."""
         del kwargs
-        chime.pulse()
+        if self.chimes_enabled:
+            chime.pulse()
+
+    def enable_chimes(self, **kwargs):
+        self.chimes_enabled = True
+        self.machine.events.post('========== CHIMES ENABLED ==========')
+    
+    def disable_chimes(self, **kwargs):
+        self.chimes_enabled = False
+        self.machine.events.post('========== CHIMES DISABLED =========')
 
     def set_value(self, value):
         """Reset the score reel group to display the value passed.


### PR DESCRIPTION
Added functionality to only enable chimes fired by score reel advances during gameplay, using ball_started and game_ended events.