### PR TITLE
Borgdog score reel group enable chimes

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1478,6 +1478,8 @@ score_reel_groups:
     __type__: device
     reels: list|machine(score_reels)|
     chimes: list|machine(coils)|None
+    enable_chimes_events: event_handler|event_handler:ms|ball_started
+    disable_chimes_events: event_handler|event_handler:ms|game_ended
     lights_tag: single|str|None
 segment_displays:
     __valid_in__: machine

--- a/mpf/devices/score_reel_group.py
+++ b/mpf/devices/score_reel_group.py
@@ -3,6 +3,7 @@ from collections import deque
 
 from mpf.core.system_wide_device import SystemWideDevice
 from mpf.devices.score_reel_controller import ScoreReelController
+from mpf.core.events import event_handler
 
 
 class ScoreReelGroup(SystemWideDevice):
@@ -52,6 +53,9 @@ class ScoreReelGroup(SystemWideDevice):
         self.jump_in_progress = False
         # Boolean attribute that is True when a jump advance is in progress.
 
+        self.chimes_enabled = False
+        # Boolean attribute that is True when chimes should play when reels advance.
+
         self._tick_task = None
 
     async def _initialize(self):
@@ -69,11 +73,25 @@ class ScoreReelGroup(SystemWideDevice):
                                                 handler=self.chime,
                                                 chime=self.config['chimes'][i])
 
-    @classmethod
-    def chime(cls, chime, **kwargs):
-        """Pulse chime."""
+    def chime(self, chime, **kwargs):
+        """Pulse chime if chimes are enabled."""
         del kwargs
-        chime.pulse()
+        if self.chimes_enabled:
+            chime.pulse()
+
+    @event_handler(1)
+    def event_enable_chimes(self, **kwargs):
+        """Event handler to enable chimes."""
+        del kwargs
+        self.chimes_enabled = True
+        self.log.info('Chimes enabled.')
+
+    @event_handler(2)
+    def event_disable_chimes(self, **kwargs):
+        """Event handler to disable chimes."""
+        del kwargs
+        self.chimes_enabled = False
+        self.log.info('Chimes disabled.')
 
     def set_value(self, value):
         """Reset the score reel group to display the value passed.

--- a/mpf/tests/machine_files/score_reels/config/config.yaml
+++ b/mpf/tests/machine_files/score_reels/config/config.yaml
@@ -94,6 +94,8 @@ score_reel_groups:
         chimes: None, chime1, chime2, chime3, None
         lights_tag: player1
         debug: True
+        enable_chimes_events: enable_srg_player1_chimes, ball_started
+        disable_chimes_events: disable_srg_player1_chimes, game_ended
     player2:
         reels: score_2p_10, None
         tags: player2

--- a/mpf/tests/test_ScoreReels.py
+++ b/mpf/tests/test_ScoreReels.py
@@ -213,7 +213,7 @@ class TestScoreReels(MpfFakeGameTestCase):
         self.assertEqual(10, player1_10.pulse.call_count)
         self.assertEqual(1, chime1.pulse.call_count)
 
-    def testAdvanceingFailure(self):
+    def testAdvancingFailure(self):
         player1_10k = self.machine.coils["player1_10k"].hw_driver
         player1_1k = self.machine.coils["player1_1k"].hw_driver
         player1_100 = self.machine.coils["player1_100"].hw_driver
@@ -256,6 +256,89 @@ class TestScoreReels(MpfFakeGameTestCase):
         self.assertEqual(0, player1_1k.pulse.call_count)
         self.assertEqual(3, player1_100.pulse.call_count)
         self.assertEqual(1, player1_10.pulse.call_count)
+
+    def testEnableDisableChimes(self):
+        player1_10k = self.machine.coils["player1_10k"].hw_driver
+        player1_1k = self.machine.coils["player1_1k"].hw_driver
+        player1_100 = self.machine.coils["player1_100"].hw_driver
+        player1_10 = self.machine.coils["player1_10"].hw_driver
+        chime1 = self.machine.coils["chime1"].hw_driver
+        chime2 = self.machine.coils["chime2"].hw_driver
+        chime3 = self.machine.coils["chime3"].hw_driver
+        player1_10k.pulse = MagicMock(return_value=10)
+        player1_1k.pulse = MagicMock(return_value=10)
+        player1_100.pulse = MagicMock(return_value=10)
+        player1_10.pulse = MagicMock(return_value=10)
+        chime1.pulse = MagicMock(return_value=10)
+        chime2.pulse = MagicMock(return_value=10)
+        chime3.pulse = MagicMock(return_value=10)
+        self.start_game()
+        self.assertEqual(0, self.machine.game.player.score)
+
+        self._synchronise_to_reel()
+
+        self.machine.game.player.score += 110
+        self.hit_switch_and_run("score_1p_10k_0", 0)
+        self.hit_switch_and_run("score_1p_1k_0", 0)
+        self.release_switch_and_run("score_1p_100_0", 0)
+        self.release_switch_and_run("score_1p_10_0", 0)
+        self.advance_time_and_run(10)
+
+        self.assertEqual(0, player1_10k.pulse.call_count)
+        self.assertEqual(0, player1_1k.pulse.call_count)
+        self.assertEqual(1, player1_100.pulse.call_count)
+        self.assertEqual(1, player1_10.pulse.call_count)
+        self.assertEqual(0, chime1.pulse.call_count)
+        self.assertEqual(1, chime2.pulse.call_count)
+        self.assertEqual(1, chime3.pulse.call_count)
+
+        self.machine.game.player.score += 100
+        self.release_switch_and_run("score_1p_100_0", 0)
+        self.advance_time_and_run(10)
+        self.assertEqual(0, player1_10k.pulse.call_count)
+        self.assertEqual(0, player1_1k.pulse.call_count)
+        self.assertEqual(2, player1_100.pulse.call_count)
+        self.assertEqual(1, player1_10.pulse.call_count)
+        self.assertEqual(0, chime1.pulse.call_count)
+        self.assertEqual(2, chime2.pulse.call_count)
+        self.assertEqual(1, chime3.pulse.call_count)
+
+        self.machine.game.player.score += 1000
+        self.release_switch_and_run("score_1p_1k_0", 0)
+        self.advance_time_and_run(10)
+        self.assertEqual(0, player1_10k.pulse.call_count)
+        self.assertEqual(1, player1_1k.pulse.call_count)
+        self.assertEqual(2, player1_100.pulse.call_count)
+        self.assertEqual(1, player1_10.pulse.call_count)
+        self.assertEqual(1, chime1.pulse.call_count)
+        self.assertEqual(2, chime2.pulse.call_count)
+        self.assertEqual(1, chime3.pulse.call_count)
+
+        self.post_event("disable_srg_player1_chimes")
+        self.machine.game.player.score += 1100
+        self.release_switch_and_run("score_1p_1k_0", 0)
+        self.release_switch_and_run("score_1p_100_0", 0)
+        self.advance_time_and_run(10)
+        self.assertEqual(0, player1_10k.pulse.call_count)
+        self.assertEqual(2, player1_1k.pulse.call_count)
+        self.assertEqual(3, player1_100.pulse.call_count)
+        self.assertEqual(1, player1_10.pulse.call_count)
+        self.assertEqual(1, chime1.pulse.call_count)
+        self.assertEqual(2, chime2.pulse.call_count)
+        self.assertEqual(1, chime3.pulse.call_count)
+
+        self.post_event("enable_srg_player1_chimes")
+        self.machine.game.player.score += 1100
+        self.release_switch_and_run("score_1p_1k_0", 0)
+        self.release_switch_and_run("score_1p_100_0", 0)
+        self.advance_time_and_run(10)
+        self.assertEqual(0, player1_10k.pulse.call_count)
+        self.assertEqual(3, player1_1k.pulse.call_count)
+        self.assertEqual(4, player1_100.pulse.call_count)
+        self.assertEqual(1, player1_10.pulse.call_count)
+        self.assertEqual(2, chime1.pulse.call_count)
+        self.assertEqual(3, chime2.pulse.call_count)
+        self.assertEqual(1, chime3.pulse.call_count)
 
     def testThreePlayers(self):
         player1_10k = self.machine.coils["player1_10k"].hw_driver


### PR DESCRIPTION
Replaces https://github.com/missionpinball/mpf/pull/1970

Original:
```
Added functionality to only enable chimes fired by score reel advances during gameplay, using ball_started and game_ended events as defaults.
```