### PR TITLE
randomizer nonrandom fallback fix

### DIFF
--- a/mpf/core/randomizer.py
+++ b/mpf/core/randomizer.py
@@ -109,6 +109,7 @@ class Randomizer:
     def _next_not_random(self, conditional_args):
         total_items = len(self.items)
         current_item_index = self.data['current_item_index']
+
         if current_item_index >= total_items:
             if not self.loop:
                 raise StopIteration
@@ -118,12 +119,19 @@ class Randomizer:
         next_item_index = current_item_index
 
         rotated_option_list = self.items[next_item_index:] + self.items[:next_item_index]
+        found_it = False
         while len(rotated_option_list):
             next_item = rotated_option_list.pop(0)
             next_item_index += 1
             event = next_item[0]
             if not event.condition or (self._template_type and event.condition.evaluate(conditional_args)):
+                found_it = True
                 break
+
+        if not found_it:
+            self.data['current_item'] = self.fallback_value
+            self.data['current_item_index'] = 0
+            return self.fallback_value
 
         self.data['current_item'] = next_item
         self.data['current_item_index'] = next_item_index

--- a/mpf/tests/test_Randomizer.py
+++ b/mpf/tests/test_Randomizer.py
@@ -216,6 +216,58 @@ class TestRandomizer(MpfTestCase):
         self.assertEqual(50, results.count('2'))
         self.assertEqual(0, results.count('foo'))
 
+    def test_fallback_value_nonrandom(self):
+        # when condition for all items is false, always fall back
+        r = Randomizer([
+                '1{False}',
+                '2{False}',
+            ], self.machine)
+        r.fallback_value = "foo"
+        r.disable_random = True
+
+        results = list()
+        for x in range(10):
+            results.append(next(r))
+
+        self.assertEqual(0, results.count('1'))
+        self.assertEqual(0, results.count('2'))
+        self.assertEqual(10, results.count('foo'))
+
+    def test_conditionals_dynamic_updating_no_random(self):
+        # conditionals should loop properly when conditional values change between draws
+        r = Randomizer([
+                '1{machine.foo == 0}',
+                '2{machine.foo == 0}',
+            ],
+                self.machine,
+                template_type="event"
+        )
+        r.fallback_value = "bar"
+        r.disable_random = True
+
+        self.machine.variables.set_machine_var('foo', 0)
+        for i in range(10):
+            self.assertEqual(next(r), '1')
+            self.assertEqual(next(r), '2')
+
+        self.machine.variables.set_machine_var('foo', 1)
+        for i in range(10):
+            self.assertEqual(next(r), 'bar')
+
+        self.machine.variables.set_machine_var('foo', 0)
+        for i in range(10):
+            self.assertEqual(next(r), '1')
+            self.assertEqual(next(r), '2')
+
+        self.machine.variables.set_machine_var('foo', 1)
+        for i in range(10):
+            self.assertEqual(next(r), 'bar')
+
+        self.machine.variables.set_machine_var('foo', 0)
+        for i in range(10):
+            self.assertEqual(next(r), '1')
+            self.assertEqual(next(r), '2')
+
     def test_weights(self):
         # Case 1 - double-weight to one option skews true random draws
         items = [


### PR DESCRIPTION
Turns out if you use a bunch of randomizer features together it didnt behave as expected:
- disable_random
- fallback_value
- events that all use conditionals and all happen to be false when trying to generate a value

Put that all together and previously you would always get the last event from the event list out even with the false condition, and thus the fallback would also never be used.

This commit properly falls back to the fallback value when all are false and should return to items from the list when conditions become true again.