### PR TITLE
randomizer will pick last item in options set when faced with all-false conditional options and no defined fallback

### DIFF
--- a/mpf/core/randomizer.py
+++ b/mpf/core/randomizer.py
@@ -128,7 +128,7 @@ class Randomizer:
                 found_it = True
                 break
 
-        if not found_it:
+        if not found_it and self.fallback_value:
             self.data['current_item'] = self.fallback_value
             self.data['current_item_index'] = 0
             return self.fallback_value

--- a/mpf/tests/test_Randomizer.py
+++ b/mpf/tests/test_Randomizer.py
@@ -233,6 +233,22 @@ class TestRandomizer(MpfTestCase):
         self.assertEqual(0, results.count('2'))
         self.assertEqual(10, results.count('foo'))
 
+        # last item is used when all conditional items are false and no fallback is given
+        r = Randomizer([
+                '1{False}',
+                '2{False}',
+                '3{False}',
+            ], self.machine)
+        r.disable_random = True
+
+        results = list()
+        for x in range(10):
+            results.append(next(r))
+
+        self.assertEqual(0, results.count('1'))
+        self.assertEqual(0, results.count('2'))
+        self.assertEqual(10, results.count('3'))
+
     def test_conditionals_dynamic_updating_no_random(self):
         # conditionals should loop properly when conditional values change between draws
         r = Randomizer([


### PR DESCRIPTION
When using a randomizer,
- with all conditional events,
- with all conditions resolving false,
- and with the fallback_value not set
the current code results in None, which seems reasonable, but may result in odd behavior down the line.

Probably the more right thing to do is to not post any event, but I don't think it's worth spending too much time on these edge cases while randomization is being rewritten.

In any case, if a developer is using all-conditional event sets and can end up with all being false-dropped, its really on them to provide a fallback (even if they want a noop response) to avoid unwanted undefined behaviors (the posting of the last event or none etc).