### PR TITLE
monitor more device enabled statuses

### DIFF
--- a/mpf/devices/ball_hold.py
+++ b/mpf/devices/ball_hold.py
@@ -9,7 +9,7 @@ from mpf.core.mode_device import ModeDevice
 from mpf.core.system_wide_device import SystemWideDevice
 
 
-@DeviceMonitor("balls_held")
+@DeviceMonitor("balls_held", "enabled")
 class BallHold(EnableDisableMixin, SystemWideDevice, ModeDevice):
 
     """Ball hold device which can be used to keep balls in ball devices and control their eject later on."""

--- a/mpf/devices/ball_routing.py
+++ b/mpf/devices/ball_routing.py
@@ -17,7 +17,7 @@ if MYPY:   # pragma: no cover
     from mpf.core.machine import MachineController   # pylint: disable-msg=cyclic-import,unused-import
 
 
-@DeviceMonitor("balls_routing")
+@DeviceMonitor("balls_routing", "enabled")
 class BallRouting(EnableDisableMixin, ModeDevice):
 
     """Route balls from one device to another when captured."""

--- a/mpf/devices/multiball.py
+++ b/mpf/devices/multiball.py
@@ -9,7 +9,7 @@ from mpf.core.placeholder_manager import NativeTypeTemplate
 from mpf.core.system_wide_device import SystemWideDevice
 
 
-@DeviceMonitor("shoot_again", "grace_period", "hurry_up", "balls_added_live", "balls_live_target")
+@DeviceMonitor("shoot_again", "grace_period", "hurry_up", "balls_added_live", "balls_live_target", "enabled")
 class Multiball(EnableDisableMixin, SystemWideDevice, ModeDevice):
 
     """Multiball device for MPF."""

--- a/mpf/devices/multiball_lock.py
+++ b/mpf/devices/multiball_lock.py
@@ -13,7 +13,7 @@ if MYPY:   # pragma: no cover
     from mpf.devices.playfield import Playfield     # pylint: disable-msg=cyclic-import,unused-import
 
 
-@DeviceMonitor("locked_balls")
+@DeviceMonitor("locked_balls", "enabled")
 class MultiballLock(EnableDisableMixin, ModeDevice):
 
     """Ball lock device which locks balls for a multiball."""

--- a/mpf/devices/shot.py
+++ b/mpf/devices/shot.py
@@ -10,7 +10,7 @@ from mpf.core.mode_device import ModeDevice
 from mpf.core.player import Player
 
 
-@DeviceMonitor("state", "state_name")
+@DeviceMonitor("state", "state_name", "enabled")
 class Shot(EnableDisableMixin, ModeDevice):
 
     """A device which represents a generic shot."""

--- a/mpf/devices/spinner.py
+++ b/mpf/devices/spinner.py
@@ -13,7 +13,7 @@ if MYPY:   # pragma: no cover
     from mpf.core.machine import MachineController  # pylint: disable-msg=cyclic-import,unused-import
 
 
-@DeviceMonitor(_active="active", _idle="idle")
+@DeviceMonitor(_active="active", _idle="idle", enabled="enabled")
 class Spinner(EnableDisableMixinSystemWideDevice, SystemWideDevice):
 
     """Represents a spinner or spinner group in a pinball machine."""


### PR DESCRIPTION
Note that `enabled` was not put in the first position on any devices. This is because the first property is used by monitor to decide when to color in a shape on the playfield display.