### PR TITLE
release version 0.57.5

### DIFF
--- a/mpf/_version.py
+++ b/mpf/_version.py
@@ -10,7 +10,7 @@ PyPI.
 
 """
 
-__version__ = '0.57.5.dev3'  # Also consider whether MPF-MC pyproject.toml should be updated
+__version__ = '0.57.5'  # Also consider whether MPF-MC pyproject.toml should be updated
 '''The full version of MPF.'''
 
 __short_version__ = '0.57'


### PR DESCRIPTION
This version is the baseline for the 0.80.0 first full release version.

In the future, it is likely that 0.57.6 will be the baseline for the parallel changes between 0.80.0 and 0.81.0, but 80->81 may include changes to core MPF functionality that will not be backported to 0.57 series