### PR TITLE
Reset available_balls count on eject timeouts

### DIFF
--- a/mpf/core/ball_controller.py
+++ b/mpf/core/ball_controller.py
@@ -188,6 +188,15 @@ class BallController(MpfController):
         while True:
             found_balls = False
             for playfield in playfields:
+                # Reconcile inconsistent playfield state: available_balls may
+                # sometimes be left >0 due to eject/timeout race conditions.
+                # Use the authoritative `balls` count and keep `available_balls`
+                # in sync to avoid waiting forever on stale state.
+                if playfield.available_balls != playfield.balls:
+                    self.debug_log('Reconciling %s: available_balls=%s, balls=%s',
+                                   playfield.name, playfield.available_balls, playfield.balls)
+                    playfield.available_balls = playfield.balls
+
                 if playfield.available_balls > 0:
                     self.info_log('Found %s ball(s) on %s.', playfield.available_balls, playfield.name)
                     found_balls = True

--- a/mpf/devices/ball_device/outgoing_balls_handler.py
+++ b/mpf/devices/ball_device/outgoing_balls_handler.py
@@ -357,12 +357,12 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
             else:
                 self.debug_log('No available_balls to decrement on %s (value: %s)',
                                target.name, getattr(target, 'available_balls', None))
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             # Don't let cleanup raise an exception
             try:
                 self.exception_log('Error while reconciling available_balls on failed eject for %s',
-                                    eject_request.target)
-            except Exception:
+                                   eject_request.target)
+            except Exception:  # pylint: disable=broad-exception-caught
                 pass
 
     async def _post_ejecting_event(self, eject_request: OutgoingBall, eject_try: int):
@@ -388,6 +388,7 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
         num_attempts: How many eject attempts have been tried so far.
         '''
 
+    # pylint: disable-msg=too-many-statements
     async def _eject_ball(self, eject_request: OutgoingBall, eject_try: int) -> bool:
         # inform the counter that we are ejecting now
         self.info_log("Ejecting ball to %s", eject_request.target)
@@ -440,11 +441,11 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
                         self.debug_log('Decrementing available_balls on %s due to eject timeout (was %s)',
                                        target.name, target.available_balls)
                         target.available_balls -= 1
-                except Exception:
+                except Exception:  # pylint: disable=broad-exception-caught
                     try:
                         self.exception_log('Error while reconciling available_balls after eject timeout for %s',
-                                            eject_request.target)
-                    except Exception:
+                                           eject_request.target)
+                    except Exception:  # pylint: disable=broad-exception-caught
                         pass
                 return False
 

--- a/mpf/devices/ball_device/outgoing_balls_handler.py
+++ b/mpf/devices/ball_device/outgoing_balls_handler.py
@@ -344,6 +344,27 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
                 (or balls).
         '''
 
+        # Defensive reconciliation: if an eject failed, the target may have
+        # had its `available_balls` incremented earlier when the eject was
+        # scheduled. Ensure we decrement it to avoid stale counts that block
+        # end-of-game logic.
+        try:
+            target = eject_request.target
+            if hasattr(target, 'available_balls') and target.available_balls > 0:
+                self.debug_log('Decrementing available_balls on %s due to failed eject (was %s)',
+                               target.name, target.available_balls)
+                target.available_balls -= 1
+            else:
+                self.debug_log('No available_balls to decrement on %s (value: %s)',
+                               target.name, getattr(target, 'available_balls', None))
+        except Exception:
+            # Don't let cleanup raise an exception
+            try:
+                self.exception_log('Error while reconciling available_balls on failed eject for %s',
+                                    eject_request.target)
+            except Exception:
+                pass
+
     async def _post_ejecting_event(self, eject_request: OutgoingBall, eject_try: int):
         await self.machine.events.post_async(
             'balldevice_{}_ejecting_ball'.format(self.ball_device.name),
@@ -410,6 +431,21 @@ class OutgoingBallsHandler(BallDeviceStateHandler):
             except asyncio.TimeoutError:
                 # timeout. ball did not leave. failed
                 await self.ball_device.ball_count_handler.end_eject(ball_eject_process, False)
+                # Reconcile target.available_balls if it was incremented when the
+                # eject was scheduled. This prevents stale available_balls from
+                # persisting after timeouts.
+                try:
+                    target = eject_request.target
+                    if hasattr(target, 'available_balls') and target.available_balls > 0:
+                        self.debug_log('Decrementing available_balls on %s due to eject timeout (was %s)',
+                                       target.name, target.available_balls)
+                        target.available_balls -= 1
+                except Exception:
+                    try:
+                        self.exception_log('Error while reconciling available_balls after eject timeout for %s',
+                                            eject_request.target)
+                    except Exception:
+                        pass
                 return False
 
             if (trigger and trigger.done()) or (tilt and tilt.done()):

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -189,7 +189,7 @@ class TestBallDevice(MpfTestCase):
         target = self.machine.ball_devices['test_target1']
 
         # Ensure clean start
-        target.balls = 0
+        target.ball_count_handler._set_ball_count(0)  # pylint: disable=protected-access
         target.available_balls = 0
 
         # Trigger an eject from the launcher

--- a/mpf/tests/test_BallDevice.py
+++ b/mpf/tests/test_BallDevice.py
@@ -181,6 +181,33 @@ class TestBallDevice(MpfTestCase):
         self.assertEqual(0, self._missing)
         self.assertEqual(1, self._captured)
 
+    def test_eject_timeout_cleans_available_balls(self):
+        """Repro: scheduling an eject increments target.available_balls; timeout should clean it."""
+        coil2 = self.machine.coils['eject_coil2']
+        coil2.pulse = MagicMock()
+
+        target = self.machine.ball_devices['test_target1']
+
+        # Ensure clean start
+        target.balls = 0
+        target.available_balls = 0
+
+        # Trigger an eject from the launcher
+        self.machine.events.add_handler('balldevice_ball_missing', self._missing_ball)
+        self.machine.switch_controller.process_switch("s_ball_switch_launcher", 1)
+        # Let eject be processed
+        self.advance_time_and_run(1)
+        self.assertTrue(coil2.pulse.called)
+
+        # After scheduling, the outgoing handler or route may increment available_balls
+        self.assertGreaterEqual(target.available_balls, 0)
+
+        # Advance time beyond eject timeout to force timeout handling
+        self.advance_time_and_run(15)
+
+        # After our defensive fixes, available_balls should match authoritative balls
+        self.assertEqual(target.available_balls, target.balls)
+
     def test_eject_retry(self):
         self.hit_switch_and_run("s_ball_switch1", 1)
         self.hit_switch_and_run("s_ball_switch2", 1)

--- a/mpf/tests/test_eject_timeout_repro.py
+++ b/mpf/tests/test_eject_timeout_repro.py
@@ -1,0 +1,49 @@
+import asyncio
+
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestEjectTimeoutRepro(MpfTestCase):
+
+    def get_config_file(self):
+        return 'null.yaml'
+
+    def test_eject_timeout_decrements_available(self):
+        # Setup: pick a source device that will schedule an eject to a target
+        trough = self.machine.ball_devices['trough']
+        # Ensure starting clean
+        trough.available_balls = 6
+        trough.balls = 6
+
+        # Choose a playfield target to receive an eject
+        playfield = list(self.machine.playfields.values())[0]
+        playfield.balls = 0
+        playfield.available_balls = 0
+
+        # Simulate a mechanical eject during idle from trough to playfield
+        # This uses the code path that increments target.available_balls
+        # and enqueues an eject via the outgoing handler.
+        # Find a device that supports mechanical eject: call handle_mechanical_eject_during_idle
+        # We'll call it on trough to schedule an eject to its default eject target.
+        trough.config['eject_targets'][0].available_balls = 0
+
+        # Call handler that increments available_balls and adds eject to queue
+        self.machine_run()
+        # Call the method directly to simulate mechanical eject scheduling
+        self.assertTrue(hasattr(trough, 'handle_mechanical_eject_during_idle'))
+        fut = asyncio.ensure_future(trough.handle_mechanical_eject_during_idle())
+        # Let the loop run so the outgoing handler processes the queue
+        self.advance_time_and_run(0)
+
+        # After scheduling, the target should have been incremented
+        target = trough.config['eject_targets'][0]
+        self.assertGreaterEqual(target.available_balls, 1)
+
+        # Now simulate the eject timing out: advance time beyond eject timeout
+        # and let the outgoing handler run its timeout path.
+        # Use a large time to ensure timeout triggers
+        self.advance_time_and_run(5)
+
+        # After the timeout and our defensive fix, available_balls should not be left > balls
+        # The playfield authoritative balls is 0, so available_balls should be 0 as well
+        self.assertEqual(playfield.available_balls, playfield.balls)

--- a/mpf/tests/test_playfield_timeout_reconcile.py
+++ b/mpf/tests/test_playfield_timeout_reconcile.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestPlayfieldTimeoutReconcile(MpfTestCase):
+
+    def get_config_file(self):
+        return 'null.yaml'
+
+    def test_reconcile_available_balls(self):
+        # Ensure the machine is initialized
+        self.assertIsNotNone(self.machine)
+
+        playfield = list(self.machine.playfields.values())[0]
+
+        # Simulate stale state: authoritative `balls` is 0 but `available_balls`
+        # is 1 (left over from an eject timeout)
+        playfield.balls = 0
+        playfield.available_balls = 1
+
+        # Start the waiter and let the test loop run briefly
+        fut = asyncio.ensure_future(self.machine.ball_controller.wait_until_playfields_are_empty())
+        self.machine_run()
+
+        # After a single run the reconciler should have fixed available_balls
+        self.assertTrue(fut.done())
+        fut.result()
+        self.assertEqual(playfield.available_balls, 0)


### PR DESCRIPTION
## Summary

This PR attempts to mitigate a bug in ball count handling where orphaned `available_balls` causes the game to soft lock.

## Description

When a ball device is the eject target of another's ejection, the `available_balls` count is incremented to allow eject chains to map a path through the available devices to the target. When the eject completes, the incoming device's `balls` count is incremented and the available balls are resolved.

There is a bug where if an eject fails, the available_balls count is not adjusted. This can lead to disparate values between `available_balls` and `balls`.

When a player's turn ends, the game waits for all balls to drain before proceeding. However it does this by counting `available_balls` and not `balls`, which can lead to a soft-lock if a previous eject failure caused the device (playfield) to have orphaned available balls.

## The Fix

This PR implements two changes:
* When an eject fails, decrement the `available_balls` of the target device. This keeps the balls and available balls in sync, and the available balls will be incremented again on the next eject attempt.
* When the playfield drains, do a safety check to align the available balls and balls. This should no longer happen with the above fix, but it's better to catch and address a mismatch than to soft-lock the game.

These fixes were build by Copilot based on analysis of my own game log wherein a multiball eject failure caused a later downstream lock. Tests were added to validate the fix.

![balls balls balls](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExb28wbXlkeWVyMWVhMW13d2RpZm1vbzV0YzE5MXR2amFtb3FiOGg1cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/6glYLqOQ3dlok/giphy.gif) 