### PR TITLE
asyncio.TimeoutError => builtin TimeoutError with Python 3.11

### DIFF
--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -294,10 +294,11 @@ class FastSerialCommunicator(LogMixin):
 
         while max_retries == -1 or retries <= max_retries:
             try:
-                await asyncio.wait_for(self.send_and_wait_for_response(msg, pause_sending_until,
-                                                                       log_msg), timeout=timeout)
+                await asyncio.wait_for(
+                    self.send_and_wait_for_response(msg, pause_sending_until, log_msg),
+                    timeout=timeout)
                 break
-            except asyncio.TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 self.log.error("Timeout waiting for response to %s. Retrying...", msg)
                 retries += 1
 


### PR DESCRIPTION
Eh just wait until dev versions for 59/82 where we drop python 3.10 support. 3.10 is EOL in under two months, so we'll just let one more MPF release be the bridge, then cut support with the first release _after_