### PR TITLE
Soft power down event hook and FAST button press integration

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -581,6 +581,8 @@ fast_net:
     mute_unconfigured_switches: single|bool|false
     gi_hz: single|int|30
     lamp_hz: single|int|30
+    soft_power_hold_ms: single|ms|2500
+    soft_power_powerdown_delay: single|ms|4000
 fast_io_loop:
     model: single|str|  # FP-I/O-0804, etc.
     order: single|enum(1,2,3,4,5,6,7,8,9)|
@@ -942,6 +944,7 @@ machine:
     __type__: config
     balls_installed: single|int|1
     min_balls: single|int|1
+    soft_shutdown_exit_command: single|str|None
 machine_vars:
     __valid_in__: machine
     __type__: config_dict

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -573,7 +573,7 @@ fast_net:
     console_log: single|enum(none,basic,full)|none
     file_log: single|enum(none,basic,full)|basic
     controller: single|enum(neuron,nano,sys11,wpc89,wpc95)|
-    watchdog: single|ms|1000
+    watchdog: single|ms|500
     default_quick_debounce_open: single|ms|2
     default_quick_debounce_close: single|ms|2
     default_normal_debounce_open: single|ms|4

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -2,6 +2,7 @@
 """Contains the MachineController base class."""
 import asyncio
 import logging
+import subprocess
 import sys
 import threading
 from typing import Any, Callable, Dict, List, Set, Optional, TYPE_CHECKING
@@ -106,7 +107,8 @@ class MachineController(LogMixin):
                  "stop_future", "events", "switch_controller", "mode_controller", "settings",
                  "bcp", "ball_controller", "show_controller", "placeholder_manager", "device_manager", "auditor",
                  "tui", "service", "switches", "shows", "coils", "ball_devices", "lights", "playfield", "playfields",
-                 "autofire_coils", "_crash_handlers", "__dict__", "mpf_config", "is_shutting_down"]
+                 "autofire_coils", "_crash_handlers", "__dict__", "mpf_config", "is_shutting_down",
+                 "soft_power_down_active"]
 
     # pylint: disable-msg=too-many-statements
     def __init__(self, options: dict, config: MpfConfig) -> None:
@@ -116,6 +118,7 @@ class MachineController(LogMixin):
         self.log.info("Mission Pinball Framework Core Engine v%s", __version__)
         self._crash_handlers = []   # type: List[Callable]
         self.is_shutting_down = False
+        self.soft_power_down_active = False
 
         self.log.info("Command line arguments: %s", options)
         self.options = options
@@ -396,6 +399,7 @@ class MachineController(LogMixin):
     def _register_system_events(self) -> None:
         """Register default event handlers."""
         self.events.add_handler('quit', self.stop)
+        self.events.add_handler('request_soft_shutdown', self.request_soft_shutdown)
         self.events.add_handler(self.config['mpf']['switch_tag_event'].
                                 replace('%', 'quit'), self.stop)
 
@@ -790,6 +794,56 @@ class MachineController(LogMixin):
         self.clock.loop.stop()
         self.clock.loop.run_forever()
         self.clock.loop.close()
+
+        if self.soft_power_down_active:
+            self._execute_soft_shutdown_command()
+
+    def _execute_soft_shutdown_command(self) -> None:
+        cmd = self.config['machine'].get('soft_shutdown_exit_command')
+        if not cmd:
+            return
+
+        self.info_log('Executing exit command %s', cmd)
+        try:
+            # pylint: disable=consider-using-with
+            subprocess.Popen(
+                cmd,
+                shell=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            self.error_log("Failed to execute exit command: %s", e)
+
+    def request_soft_shutdown(self, **_kwargs) -> None:
+        """Attempt to soft shut down, allowing hooks to deny the request."""
+        self.warning_log("Attempting soft shutdown")
+        self.events.post_boolean('machine_request_shutdown', callback=self._result_of_shutdown_request)
+
+    def _result_of_shutdown_request(self, ev_result=True):
+        """Handle the result of the shutdown request.
+
+        Called after the *machine_request_shutdown* event is posted.
+
+        If the boolean result is True, the stop future will be resolved (ending the run loop)
+        and the event 'machine_will_shutdown' is posted. If the result is False,
+        the event 'machine_abort_shutdown' is posted.
+
+        Args:
+        ----
+            ev_result : Bool result of the boolean event
+                *machine_request_shutdown.* If any registered event handler did not
+                want the machine to shut down, this will be False, else it's True.
+        """
+        if ev_result is False:
+            self.warning_log('Soft shutdown was denied')
+            self.events.post('machine_abort_shutdown')
+        else:
+            self.warning_log('Soft shutdown proceeding...')
+            self.events.post('machine_will_shutdown')
+            self.soft_power_down_active = True
+            self.stop('Soft shutdown')
 
     def _run_loop(self) -> None:    # pragma: no cover
         # Main machine run loop with when the default platform interface

--- a/mpf/platforms/fast/communicators/net_neuron.py
+++ b/mpf/platforms/fast/communicators/net_neuron.py
@@ -271,10 +271,21 @@ class FastNetNeuronCommunicator(FastSerialCommunicator):
         await self.send_and_wait_for_response_processed('SA:', 'SA:')
 
     def _process_wp(self, msg):
-        return
+        if msg == 'P':
+            if not self.platform.soft_power_held_time:
+                self.platform.soft_power_held_time = self.machine.clock.get_time()
+                self.info_log('Soft power down press started.')
+                self.machine.events.post('fast_soft_power_switch_active')
 
     def _process_wd(self, msg):
-        return
+        if msg == 'P':
+            if self.platform.soft_power_held_time:
+                delta_seconds = self.machine.clock.get_time() - self.platform.soft_power_held_time
+                self.machine.events.post('fast_soft_power_switch_inactive')
+                self.platform.soft_power_held_time = None
+                self.info_log('Soft power down released after %s seconds.', delta_seconds)
+                if delta_seconds * 1000 > self.platform.soft_power_hold_ms:
+                    self.platform.report_soft_power_down_request()
 
     def _process_sa(self, msg):
         if not self.platform.switches_initialized:
@@ -346,3 +357,13 @@ class FastNetNeuronCommunicator(FastSerialCommunicator):
     def stopping(self):
         """Stop the Neuron processor and disable the watchdog."""
         self.send_and_forget('WD:1')
+
+        if self.machine.soft_power_down_active:
+            delay_ms = self.platform.soft_power_down_final_delay_ms
+            hex_ms = f"{delay_ms:X}"
+
+            # Command WP:<ms> - inform the Neuron that a soft powerdown has been requested
+            # Note: if the Neuron is not running on soft power this will do nothing
+            # If the Neuron is using soft power, the powerdown will happen in the given number
+            # of milliseconds. This cannot be aborted, but can be extended by issuing further WPs
+            self.send_and_forget(f'WP:{hex_ms}')

--- a/mpf/platforms/fast/communicators/net_neuron.py
+++ b/mpf/platforms/fast/communicators/net_neuron.py
@@ -22,7 +22,7 @@ class FastNetNeuronCommunicator(FastSerialCommunicator):
     MAX_IO_BOARDS = 9
     MAX_SWITCHES = 104
     MAX_DRIVERS = 48
-    IGNORED_MESSAGES = ['WD:P', 'TL:P']
+    IGNORED_MESSAGES = ['TL:P']
     TRIGGER_CMD = 'TL'
     DRIVER_CMD = 'DL'
     SWITCH_CMD = 'SL'
@@ -37,6 +37,8 @@ class FastNetNeuronCommunicator(FastSerialCommunicator):
         self.switches = list()
         self.drivers = list()
 
+        self.message_processors['WD:'] = self._process_wd
+        self.message_processors['WP:'] = self._process_wp
         self.message_processors['SA:'] = self._process_sa
         self.message_processors['CH:'] = self._process_ch
         self.message_processors['!B:'] = self._process_boot_message
@@ -267,6 +269,12 @@ class FastNetNeuronCommunicator(FastSerialCommunicator):
     async def update_switches_from_hardware(self):
         """Process an SA: message and update switch states."""
         await self.send_and_wait_for_response_processed('SA:', 'SA:')
+
+    def _process_wp(self, msg):
+        return
+
+    def _process_wd(self, msg):
+        return
 
     def _process_sa(self, msg):
         if not self.platform.switches_initialized:

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -45,7 +45,8 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                  "exp_boards_by_address", "exp_boards_by_name", "exp_breakout_boards",
                  "exp_breakouts_with_leds", "hw_switch_data", "new_switch_data",
                  "io_boards", "io_boards_by_name", "switches_initialized",
-                 "drivers_initialized", "audio_interface"]
+                 "drivers_initialized", "audio_interface", "soft_power_held_time",
+                 "soft_power_hold_ms", "soft_power_down_final_delay_ms"]
 
     port_types = ['net', 'exp', 'exp_int', 'aud', 'dmd', 'rgb', 'seg', 'emu']
 
@@ -104,6 +105,13 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
         self.switches_initialized = False
         self.drivers_initialized = False
         self.audio_interface = None
+        self.soft_power_held_time = None  # type: Optional[float]
+
+        self.soft_power_hold_ms = 1
+        self.soft_power_down_final_delay_ms = None
+        if self.machine_type == 'neuron':
+            self.soft_power_hold_ms = self.config['net']['soft_power_hold_ms']  # type: int
+            self.soft_power_down_final_delay_ms = self.config['net']['soft_power_powerdown_delay']  # milliseconds
 
     def get_info_string(self):
         """Dump info strings about attached FAST hardware."""
@@ -1007,3 +1015,8 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
         # TODO: check that the rule is switch + coil and not another switch + this coil
         driver = coil.hw_driver
         driver.clear_autofire()
+
+    def report_soft_power_down_request(self):
+        """Neuron soft power requesting shutdown."""
+        self.warning_log("Neuron soft power down requested.")
+        self.machine.request_soft_shutdown()

--- a/mpf/tests/machine_files/soft_power_down/config/config.yaml
+++ b/mpf/tests/machine_files/soft_power_down/config/config.yaml
@@ -1,0 +1,1 @@
+#config_version=6

--- a/mpf/tests/platforms/fast.py
+++ b/mpf/tests/platforms/fast.py
@@ -142,7 +142,7 @@ class MockFastNetNeuron(MockFastSerial):
 
         self.autorespond_commands = {
             'WD:1' : 'WD:P',
-            'WD:3E8': 'WD:P',
+            'WD:1F4': 'WD:P',
             'SA:':'SA:0E,2900000000000000000000000000',
             'CH:2000,FF':'CH:P',
             'ID:': 'ID:NET FP-CPU-2000  02.13',
@@ -311,7 +311,7 @@ class MockFastNetNano(MockFastSerial):
 
         self.autorespond_commands = {
             'WD:1' : 'WD:P',
-            'WD:3E8': 'WD:P',
+            'WD:1F4': 'WD:P',
             "SA:": "SA:01,00,09,000000040000000000",  # switch 0x1A is active
             'ID:': 'ID:NET FP-CPU-002-2  01.05',
             }
@@ -331,7 +331,7 @@ class MockFastNetRetro(MockFastSerial):
 
         self.autorespond_commands = {
             'WD:1' : 'WD:P',
-            'WD:3E8': 'WD:P',
+            'WD:1F4': 'WD:P',
             'SA:':'SA:0E,2900000000000000000000000000',
             'CH:9500,FF':'CH:P',
             'ID:': 'ID:NET FP-SBI-0095  02.13',

--- a/mpf/tests/test_Fast_Power.py
+++ b/mpf/tests/test_Fast_Power.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock, patch
+import unittest
+from mpf.platforms.fast.communicators.net_neuron import FastNetNeuronCommunicator
+
+class TestFastSoftPowerDownUnit(unittest.TestCase):
+
+    @patch('subprocess.Popen')
+    def test_neuron_soft_power_button_scenarios(self, mock_popen):
+        """Verify the full behavioral matrix of the soft power button logic in isolation."""
+        mock_platform = MagicMock()
+        mock_platform.machine = MagicMock()
+        mock_platform.machine.clock.get_time.return_value = 1000.0  # Base clock time
+
+        # Mock configuration lookups matching how net_neuron.py accesses them
+        mock_platform.config = {
+            'net': {
+                'soft_power_hold_ms': 2500,
+                'soft_power_powerdown_delay': 4000
+            }
+        }
+        mock_platform.soft_power_hold_ms = 2500
+        mock_platform.soft_power_held_time = None
+
+        mock_communicator_config = {'debug': False, 'io_loop': {}, 'console_log': 'none', 'file_log': 'none'}
+        communicator = FastNetNeuronCommunicator(mock_platform, "COM3", mock_communicator_config)
+
+        # Case 1: Successful Intentional Hold (> 2.5s)
+        communicator._process_wp('P')
+
+        self.assertEqual(mock_platform.soft_power_held_time, 1000.0)
+        mock_platform.machine.events.post.assert_called_with('fast_soft_power_switch_active')
+
+        # Advance our mock clock forward by 3 seconds (> 2.5s threshold)
+        mock_platform.machine.clock.get_time.return_value = 1003.0
+
+        # Simulate a watchdog response after button release (WD:P)
+        communicator._process_wd('P')
+
+        # Verify that the hold state was reset and the shutdown command was issued
+        self.assertIsNone(mock_platform.soft_power_held_time)
+        mock_platform.machine.events.post.assert_any_call('fast_soft_power_switch_inactive')
+        mock_platform.report_soft_power_down_request.assert_called_once()
+
+        # Case 2: Aborted/Short Accidental Press (< 2.5s)
+        mock_platform.report_soft_power_down_request.reset_mock()
+        mock_platform.soft_power_held_time = None
+        mock_platform.machine.clock.get_time.return_value = 2000.0
+
+        communicator._process_wp('P')
+        self.assertEqual(mock_platform.soft_power_held_time, 2000.0)
+
+        # Only hold 0.5 seconds (< 2.5s threshold)
+        mock_platform.machine.clock.get_time.return_value = 2000.5
+
+        communicator._process_wd('P')
+
+        # Verify that state was cleared but the shutdown request was SAFELY blocked
+        self.assertIsNone(mock_platform.soft_power_held_time)
+        mock_platform.report_soft_power_down_request.assert_not_called()
+
+    def test_communicator_stopping_sends_serial_power_down_command(self):
+        """Verify that stopping the communicator formats and sends the final serial delay command."""
+        mock_platform = MagicMock()
+        mock_platform.machine = MagicMock()
+
+        # Simulate an approved active shutdown state
+        mock_platform.machine.soft_power_down_active = True
+
+        # Configure the exact platform values from your fast.py updates
+        mock_platform.soft_power_down_final_delay_ms = 4000  # 4000ms converts to FA0 in hex
+
+        mock_communicator_config = {'debug': False, 'io_loop': {}, 'console_log': 'none', 'file_log': 'none'}
+        communicator = FastNetNeuronCommunicator(mock_platform, "COM3", mock_communicator_config)
+
+        # Safely patch the slotted class method to track outbound transmissions
+        with patch.object(FastNetNeuronCommunicator, 'send_and_forget') as mock_send:
+            # Trigger the teardown routine
+            communicator.stopping()
+
+            # Assertions
+            mock_send.assert_any_call('WD:1')
+            mock_send.assert_any_call('WP:FA0')

--- a/mpf/tests/test_SoftPowerDown.py
+++ b/mpf/tests/test_SoftPowerDown.py
@@ -1,0 +1,69 @@
+import os
+import subprocess
+import warnings
+
+from unittest.mock import patch, MagicMock
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestSoftPowerDown(MpfTestCase):
+
+    def get_config_file(self):
+        return 'config.yaml'
+
+    def get_machine_path(self):
+        return 'tests/machine_files/soft_power_down/'
+
+    def setUp(self):
+        super().setUp()
+        self.machine.soft_power_down_active = False
+
+        # Suppress dangling process warnings from our mock shell commands
+        warnings.simplefilter("ignore", ResourceWarning)
+
+        self.mock_event('machine_will_shutdown')
+        self.mock_event('machine_abort_shutdown')
+
+    def test_shutdown_request_denied_by_handler(self):
+        """Verify that if a registered game handler returns False, the soft shutdown aborts."""
+        def veto_handler(**kwargs):
+            return False
+
+        self.machine.events.add_handler('machine_request_shutdown', veto_handler)
+
+        self.machine.events.post('request_soft_shutdown')
+        self.advance_time_and_run(1.0)  # Advance far enough to process async handlers
+
+        self.assertFalse(self.machine.soft_power_down_active)
+        self.assertFalse(self.machine.stop_future.done())
+
+        self.assertEventCalled('machine_abort_shutdown')
+
+    @patch('subprocess.Popen')
+    def test_shutdown_request_approved_and_executes_cmd(self, mock_popen):
+        """Verify that an approved shutdown posts events and fires the shell command."""
+        cmd = 'echo shutting down'
+        self.machine.config['machine']['soft_shutdown_exit_command'] = cmd
+
+        self.machine.soft_power_down_active = False
+
+        self.machine.events.post('request_soft_shutdown')
+        self.advance_time_and_run(1.0)  # Advance far enough to flush the async future queue
+
+        self.assertTrue(self.machine.soft_power_down_active)
+        self.assertTrue(self.machine.stop_future.done())
+
+        self.assertEventCalled('machine_will_shutdown')
+
+        with patch.object(self.machine.clock.loop, 'close'):
+            self.machine._do_stop()
+
+        mock_popen.assert_called_once_with(
+            cmd,
+            shell=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True
+        )
+
+        self.machine._do_stop = MagicMock()


### PR DESCRIPTION
This adds soft power down requesting as well as post-exit command support.

Flow 1: FAST soft power:
Note: watchdog runs double frequency vs config value, for safety. This commit also doubles the frequency, to improve resolution. This means that after a state change, there will be up to .25 seconds extra measured at the release moment. Though I suppose this also happens in reverse at the start moment. Oh well.

WD is constantly issued to the NET connection, normally receiving P response (WD:P)
If soft power button is pressed, response is WP:P

Commit adds processors for both messages, plus time tracking and resetting.
Note that the FAST system will auto power down on 7s hold, so the threshold should be comfortably lower than that to avoid accidental overpress. (Picked 2.5 default, which tbh feels a touch slow)

If time between press and release was long enough, asks the machine to attempt a soft power down.

Machine generically requests request_shutdown, allowing other hooks to reject the boolean event and keep the machine alive.
Nothing by default will hook in, so this should noop right into the handler, which marks the soft power down intention and signals the stop future to uh, stop.

The machine shutdown hooks into platforms, which means the neuron receives a stopping() call. Because the soft power off could be event-based, it checks whether it was generally a soft power down (not a fast-specific one) and attempts a WP:1000, which is a 4096ms delayed soft power down of the neuron. That 4s could probably be a setting, since users might need the neuron to power down dead last. If the neuron is _not_ on soft power, WP:XXXX will not do anything. (Well, it wont de-power, I need to check with the FAST devs on whether there are other side effects)


Flow 2: Event-based
Instead of using the neuron dedicated pathway, this introduces an event that attempts the shutdown generically, with the same request boolean event and followup. Just post "attempt_soft_power_down" :)




~~~~


I want to get some testing on this and reconsider some of the naming. Plus maybe testing, though all of this resides in the realm of hard-to-test.

This allows a dev to fire the event `attempt_soft_power_down` OR hold the FAST soft power button down for 2.25001 seconds to initiate soft power down.

Ways MPF can exit:
1. python issues in MPF startup
2. runtime python issues
3. config validation issues
4. Ctrl C (user kill)
5. hardware disconnection (port disconnection)
6. BCP client issues quit (godot esc)
7. soft power event hook
8. soft power hardware press

I've tested all these cases, and found that the exit command fires only as expected, for soft power event or button hold.

