### PR TITLE
allow **_kwargs instead of **kwargs in event handlers

### DIFF
--- a/mpf/core/events.py
+++ b/mpf/core/events.py
@@ -224,13 +224,14 @@ class EventManager(MpfController):
                                      'handler you passed?'.format(handler, event))
 
             sig = inspect.signature(handler)
-            if 'kwargs' not in sig.parameters:
-                raise AssertionError("Handler {} for event '{}' is missing **kwargs. Actual signature: {}".format(
-                    handler, event, sig))
-
-            if sig.parameters['kwargs'].kind != inspect.Parameter.VAR_KEYWORD:
-                raise AssertionError("Handler {} for event '{}' param kwargs is missing '**'. "
+            catchall_name = next((name for name in ('kwargs', '_kwargs') if name in sig.parameters), None)
+            if catchall_name is None:
+                raise AssertionError("Handler {} for event '{}' is missing **kwargs. "
                                      "Actual signature: {}".format(handler, event, sig))
+
+            if sig.parameters[catchall_name].kind != inspect.Parameter.VAR_KEYWORD:
+                raise AssertionError("Handler {} for event '{}' param {} is missing '**'. "
+                                     "Actual signature: {}".format(handler, event, catchall_name, sig))
 
         event, condition, additional_priority = self.get_event_and_condition_from_string(event)
         priority += additional_priority

--- a/mpf/tests/machine_files/custom_code/code/test_code.py
+++ b/mpf/tests/machine_files/custom_code/code/test_code.py
@@ -6,7 +6,11 @@ class TestCustomCode(CustomCode):
         self.log.debug("Loaded!")
 
         self.machine.events.add_handler('test_event', self._update)
+        self.machine.events.add_handler('test_event_2', self._alternative_kwargs)
 
     def _update(self, **kwargs):
         del kwargs
         self.machine.events.post("test_response")
+
+    def _alternative_kwargs(self, **_kwargs):
+        self.machine.events.post("test_response_2")

--- a/mpf/tests/test_CustomCode.py
+++ b/mpf/tests/test_CustomCode.py
@@ -15,3 +15,10 @@ class TestCustomCode(MpfTestCase):
         self.machine_run()
 
         self.assertEqual(1, self._events['test_response'])
+
+    def test_scoring_2(self):
+        self.mock_event("test_response_2")
+        self.post_event("test_event_2")
+        self.machine_run()
+
+        self.assertEqual(1, self._events['test_response_2'])


### PR DESCRIPTION
this naming convention tells linters to ignore it, meaning we would not need "del kwargs" all over the codebase