### PR TITLE
Sequence shot improvements

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1740,6 +1740,7 @@ sequence_shots:
     delay_switch_list: dict|machine(switches):ms|None
     delay_event_list: event_handler|event_handler:ms|None
     sequence_timeout: single|ms|0
+    sequence_timeout_reset_on_advance: single|bool|false
     playfield: single|machine(playfields)|None
     allow_multiple_active: single|bool|true
 switches:

--- a/mpf/devices/sequence_shot.py
+++ b/mpf/devices/sequence_shot.py
@@ -22,7 +22,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
     class_label = 'sequence_shot'
 
     __slots__ = ["delay", "active_sequences", "active_delays", "_sequence_events", "_delay_events",
-                 "_allow_multiple_active", "_start_time"]
+                 "_allow_multiple_active", "_start_time", "_timeout_reset_on_advance"]
 
     def __init__(self, machine, name):
         """Initialize sequence shot."""
@@ -35,6 +35,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
         self._sequence_events = []      # type: List[str]
         self._delay_events = {}         # type: Dict[str, int]
         self._allow_multiple_active = None
+        self._timeout_reset_on_advance = None
         self._start_time = None
 
     @property
@@ -66,6 +67,7 @@ class SequenceShot(SystemWideDevice, ModeDevice):
 
         self._sequence_events = self.config['event_sequence']
         self._allow_multiple_active = self.config['allow_multiple_active']
+        self._timeout_reset_on_advance = self.config['sequence_timeout_reset_on_advance']
 
         for switch in self.config['switch_sequence']:
             self._sequence_events.append(self.machine.switch_controller.get_active_event_for_switch(switch.name))
@@ -180,6 +182,12 @@ class SequenceShot(SystemWideDevice, ModeDevice):
             self.debug_log("Advancing the sequence. Next: %s", next_event)
 
             self.active_sequences.append(ActiveSequence(sequence.id, current_position_index, next_event))
+
+            if self._timeout_reset_on_advance:
+                self.delay.reset(name=sequence.id,
+                                 ms=self.config['sequence_timeout'],
+                                 callback=self._sequence_timeout,
+                                 seq_id=sequence.id)
 
     def _completed(self):
         #measure the elapsed time between start and completion of the sequence

--- a/mpf/tests/machine_files/sequence_shot/config/config.yaml
+++ b/mpf/tests/machine_files/sequence_shot/config/config.yaml
@@ -84,6 +84,15 @@ sequence_shots:
         cancel_switches:
             - switch_4
             - switch_5
+    sequence_events_with_dupes_and_cancel:
+        event_sequence:
+            - event_6
+            - event_7
+            - event_6
+            - event_7
+        cancel_events:
+            - event_6
+            - event_7
     sequence_multiple_disabled:
         event_sequence:
             - event6

--- a/mpf/tests/machine_files/sequence_shot/config/config.yaml
+++ b/mpf/tests/machine_files/sequence_shot/config/config.yaml
@@ -107,3 +107,10 @@ sequence_shots:
             - seq4_1
         delay_switch_list:
             seq4_delay: 1s
+    sequence_with_timeout_reset_on_advance:
+        event_sequence:
+            - event_10
+            - event_11
+            - event_12
+        sequence_timeout: 1s
+        sequence_timeout_reset_on_advance: True

--- a/mpf/tests/test_SequenceShot.py
+++ b/mpf/tests/test_SequenceShot.py
@@ -303,6 +303,20 @@ class TestShots(MpfTestCase):
         # second timeout from interleaved sequence. can we prevent this?
         self.assertEventCalled("sequence1_timeout", times=2)
 
+    def test_sequence_with_timeout_reset_on_advance(self):
+        """Reset on advance resets timer on each step."""
+        self.mock_event("sequence_with_timeout_reset_on_advance_hit")
+        self.mock_event("sequence_with_timeout_reset_on_advance_timeout")
+        self.post_event("event_10")
+        self.advance_time_and_run(.9)
+        self.post_event("event_11")
+        self.advance_time_and_run(.9)
+        self.post_event("event_12")
+        self.advance_time_and_run(.1)
+        self.assertEventCalled("sequence_with_timeout_reset_on_advance_hit", times=1)
+        self.advance_time_and_run(2)
+        self.assertEventNotCalled("sequence_with_timeout_reset_on_advance_timeout")
+
     def test_mode_seqence(self):
         """"Test sequence in mode."""
         self.mock_event("sequence_mode_event_hit")

--- a/mpf/tests/test_SequenceShot.py
+++ b/mpf/tests/test_SequenceShot.py
@@ -218,6 +218,28 @@ class TestShots(MpfTestCase):
         self.hit_and_release_switch("switch_5")
         self.assertEventCalled("sequence_with_dupes_and_cancel2_hit", 1)
 
+    def test_sequence_events_with_duplicates_and_cancel(self):
+        self.mock_event("sequence_events_with_dupes_and_cancel_hit")
+        self.post_event("event_6")
+        self.machine_run()
+        self.post_event("event_6")
+        self.machine_run()
+        self.post_event("event_7")
+        self.machine_run()
+        self.post_event("event_7")
+        self.assertEventCalled("sequence_events_with_dupes_and_cancel_hit", 0)
+        self.post_event("event_6")
+        self.machine_run()
+        self.post_event("event_7")
+        self.machine_run()
+        self.post_event("event_6")
+        self.machine_run()
+        self.post_event("event_7")
+        self.machine_run()
+        self.assertEventCalled("sequence_events_with_dupes_and_cancel_hit", 1)
+        self.post_event("event_7")
+        self.assertEventCalled("sequence_events_with_dupes_and_cancel_hit", 1)
+
     def test_interleaved_sequences(self):
         """"Two balls pass through the sequence."""
         self.mock_event("sequence1_hit")


### PR DESCRIPTION
Found an inconsistency between the cancel events and cancel switches.

Cancel switches will prefer not to cancel when a sequence could use that event to advance, while events do not have the same proactive check. First commit adds a failing test, and I don't have a solution for this yet.

Second commit was a lark when I realized that the sequence timeout is set once for each run through the sequence, instead of allowing each step to reset the timeout time. Perhaps the timeout value could also be an array, so that each step could have its own timeout, say for complex loops where some switches are bunched.