### PR TITLE
Auditor and file saving fixes

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -1026,6 +1026,10 @@ mpf:
     paths: ignore
     report_crashes: single|enum(ask,never,always)|never
     rgbw_white_behavior: single|enum(white_only,min_rgb,duck_rgb)|duck_rgb
+data_manager:
+    __valid_in__: machine
+    __type__: config
+    use_fsync: single|bool|None
 multiballs:
     __valid_in__: machine, mode
     __type__: device

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -83,8 +83,8 @@ auditor:
     audit: list|str|None
     autosave: single|bool|true
     autosave_events: single|bool|true
-    events: list|event_handler|None
-    player: list|str|None
+    events: set|event_handler|None
+    player: set|str|None
     audit_shots: single|bool|true
     missing_switch_min_games: single|int|10
     num_player_top_records: single|int|1

--- a/mpf/core/data_manager.py
+++ b/mpf/core/data_manager.py
@@ -121,8 +121,6 @@ class DataManager(MpfController):
         while not self.machine.thread_stopper.is_set():
             if not self._dirty.wait(1):
                 continue
-            while FileManager.is_busy:
-                time.sleep(0.2)
             self._dirty.clear()
 
             data = copy.deepcopy(self.data)
@@ -139,6 +137,4 @@ class DataManager(MpfController):
 
         # if dirty write data one last time during shutdown
         if data and self._dirty.is_set():
-            while FileManager.is_busy:
-                time.sleep(0.2)
             FileManager.save(self.filename, data)

--- a/mpf/core/data_manager.py
+++ b/mpf/core/data_manager.py
@@ -21,7 +21,7 @@ class DataManager(MpfController):
     __slots__ = ["config", "name", "min_wait_secs", "filename", "data", "_dirty", "use_fsync"]
 
     def __init__(self, machine, name, min_wait_secs=1):
-        """Initialize data manger.
+        """Initialize data manager.
 
         The DataManager is responsible for reading and writing data to/from a
         file on disk.
@@ -125,25 +125,22 @@ class DataManager(MpfController):
 
     def _writing_thread(self):  # pragma: no cover
         # prevent early writes at start-up
-        data = None
         time.sleep(self.min_wait_secs)
         while not self.machine.thread_stopper.is_set():
             if not self._dirty.wait(1):
                 continue
             self._dirty.clear()
 
-            data = copy.deepcopy(self.data)
             # save data
             try:
-                FileManager.save(self.filename, data, self.use_fsync)
+                FileManager.save(self.filename, copy.deepcopy(self.data), self.use_fsync)
             except Exception as e:  # pylint: disable=broad-exception-caught
                 # If the file writer has an exception handle it here. Otherwise
                 # this thread will die and all subsequent write attempts will no-op.
                 self.info_log("ERROR writing file %s: %s", self.filename, e)
-            data = None
             # prevent too many writes
             time.sleep(self.min_wait_secs)
 
         # if dirty write data one last time during shutdown
-        if data and self._dirty.is_set():
-            FileManager.save(self.filename, data, self.use_fsync)
+        if self._dirty.is_set():
+            FileManager.save(self.filename, copy.deepcopy(self.data), self.use_fsync)

--- a/mpf/core/data_manager.py
+++ b/mpf/core/data_manager.py
@@ -3,6 +3,7 @@
 import copy
 import os
 import errno
+import sys
 import threading
 import time
 import _thread
@@ -17,7 +18,7 @@ class DataManager(MpfController):
 
     config_name = "data_manager"
 
-    __slots__ = ["name", "min_wait_secs", "filename", "data", "_dirty"]
+    __slots__ = ["config", "name", "min_wait_secs", "filename", "data", "_dirty", "use_fsync"]
 
     def __init__(self, machine, name, min_wait_secs=1):
         """Initialize data manger.
@@ -47,6 +48,14 @@ class DataManager(MpfController):
                                          self.machine.config['mpf']['paths'][name])
         else:
             raise AssertionError("Invalid path {} for {}".format(config_path, name))
+
+        self.config = self.machine.config_validator.validate_config(
+            "data_manager", self.machine.config.get('data_manager'))
+
+        maybe_use_fsync = self.config.get('use_fsync', None)
+        if maybe_use_fsync is None:
+            maybe_use_fsync = sys.platform != 'win32'
+        self.use_fsync = maybe_use_fsync
 
         self.data = dict()
         self._dirty = threading.Event()
@@ -126,7 +135,7 @@ class DataManager(MpfController):
             data = copy.deepcopy(self.data)
             # save data
             try:
-                FileManager.save(self.filename, data)
+                FileManager.save(self.filename, data, self.use_fsync)
             except Exception as e:  # pylint: disable=broad-exception-caught
                 # If the file writer has an exception handle it here. Otherwise
                 # this thread will die and all subsequent write attempts will no-op.
@@ -137,4 +146,4 @@ class DataManager(MpfController):
 
         # if dirty write data one last time during shutdown
         if data and self._dirty.is_set():
-            FileManager.save(self.filename, data)
+            FileManager.save(self.filename, data, self.use_fsync)

--- a/mpf/core/file_interface.py
+++ b/mpf/core/file_interface.py
@@ -48,6 +48,6 @@ class FileInterface:
         """Load file."""
         raise NotImplementedError
 
-    def save(self, filename, data):
+    def save(self, filename, data, use_fsync):
         """Save file."""
         raise NotImplementedError

--- a/mpf/core/file_manager.py
+++ b/mpf/core/file_manager.py
@@ -123,3 +123,12 @@ class FileManager:
 
         # move temp file
         os.replace(temp_file, filename)
+
+        try:
+            directory = os.open(os.path.dirname(os.path.abspath(filename)), os.O_RDONLY)
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+        except (OSError, TypeError) as e:
+            FileManager.log.debug("Directory fsync failed for file %s - %s", filename, e)

--- a/mpf/core/file_manager.py
+++ b/mpf/core/file_manager.py
@@ -106,7 +106,7 @@ class FileManager:
         return interface.load(file, verify_version, halt_on_error)
 
     @staticmethod
-    def save(filename, data):
+    def save(filename, data, use_fsync):
         """Save data to file."""
         if not FileManager.initialized:
             FileManager.init()
@@ -117,18 +117,19 @@ class FileManager:
         temp_file = os.path.dirname(filename) + os.sep + "_" + os.path.basename(filename)
 
         try:
-            FileManager.file_interfaces[ext].save(temp_file, data)
+            FileManager.file_interfaces[ext].save(temp_file, data, use_fsync)
         except KeyError:
             raise AssertionError("No config file processor available for file type {}".format(ext))
 
         # move temp file
         os.replace(temp_file, filename)
 
-        try:
-            directory = os.open(os.path.dirname(os.path.abspath(filename)), os.O_RDONLY)
+        if use_fsync:
             try:
-                os.fsync(directory)
-            finally:
-                os.close(directory)
-        except (OSError, TypeError) as e:
-            FileManager.log.debug("Directory fsync failed for file %s - %s", filename, e)
+                directory = os.open(os.path.dirname(os.path.abspath(filename)), os.O_RDONLY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+            except (OSError, TypeError) as e:
+                FileManager.log.debug("Directory fsync failed for file %s - %s", filename, e)

--- a/mpf/core/file_manager.py
+++ b/mpf/core/file_manager.py
@@ -22,7 +22,6 @@ class FileManager:
     log = logging.getLogger('FileManager')
     file_interfaces = dict()    # type: Dict[str, YamlInterface]
     initialized = False
-    is_busy = False
 
     @classmethod
     def init(cls):
@@ -112,12 +111,6 @@ class FileManager:
         if not FileManager.initialized:
             FileManager.init()
 
-        # FileManager is a singleton and many threads may attempt to write
-        # concurrently. Ruamel has a known issue where concurrent writes
-        # on a YamlInterface will throw. Set a flag to prevent multiple
-        # data writes concurrently.
-        # TODO: Create FileManager instances for each DataManager instance.
-        FileManager.is_busy = True
         ext = os.path.splitext(filename)[1]
 
         # save to temp file and move afterwards. prevents broken files
@@ -130,4 +123,3 @@ class FileManager:
 
         # move temp file
         os.replace(temp_file, filename)
-        FileManager.is_busy = False

--- a/mpf/file_interfaces/pickle_interface.py
+++ b/mpf/file_interfaces/pickle_interface.py
@@ -26,7 +26,7 @@ class PickleInterface(FileInterface):
                 raise
             return None
 
-    def save(self, filename, data):
+    def save(self, filename, data, _):
         """Save data to binary file."""
         with open(filename, "wb") as f:
             pickle.dump(data, f)

--- a/mpf/file_interfaces/yaml_interface.py
+++ b/mpf/file_interfaces/yaml_interface.py
@@ -17,6 +17,7 @@ def _get_yaml():
     if not hasattr(_thread_local, 'yaml'):
         _yaml_instance = yaml.YAML(typ='safe')
         _yaml_instance.default_flow_style = False
+        _yaml_instance.line_break = ''
         _thread_local.yaml = _yaml_instance
     return _thread_local.yaml
 
@@ -98,15 +99,10 @@ class YamlInterface(FileInterface):
     def save(self, filename: str, data: dict) -> None:   # pragma: no cover
         """Save config to yaml file."""
         with open(filename, 'w', encoding='utf8') as output_file:
-            _yaml_instance = _get_yaml()
-            _yaml_instance.default_flow_style = False
-            _yaml_instance.line_break = ''
-            _yaml_instance.dump(data, output_file)
+            _get_yaml().dump(data, output_file)
 
             try:
-                fd = output_file.fileno()
-                if isinstance(fd, int):  # True on real files, False on MagicMocks
-                    output_file.flush()
-                    os.fsync(fd)
-            except OSError as e:
-                self.log.error("Hardware disk sync failed for %s: %s", filename, e)
+                output_file.flush()
+                os.fsync(output_file.fileno())
+            except (OSError, TypeError) as e:
+                self.log.error("Disk sync failed for %s - %s", filename, e)

--- a/mpf/file_interfaces/yaml_interface.py
+++ b/mpf/file_interfaces/yaml_interface.py
@@ -96,13 +96,14 @@ class YamlInterface(FileInterface):
         """Parse yaml from a string."""
         return _get_yaml().load(data_string)
 
-    def save(self, filename: str, data: dict) -> None:   # pragma: no cover
+    def save(self, filename: str, data: dict, use_fsync: bool) -> None:   # pragma: no cover
         """Save config to yaml file."""
         with open(filename, 'w', encoding='utf8') as output_file:
             _get_yaml().dump(data, output_file)
 
-            try:
-                output_file.flush()
-                os.fsync(output_file.fileno())
-            except (OSError, TypeError) as e:
-                self.log.error("Disk sync failed for %s - %s", filename, e)
+            if use_fsync:
+                try:
+                    output_file.flush()
+                    os.fsync(output_file.fileno())
+                except (OSError, TypeError) as e:
+                    self.log.error("Disk sync failed for %s - %s", filename, e)

--- a/mpf/file_interfaces/yaml_interface.py
+++ b/mpf/file_interfaces/yaml_interface.py
@@ -1,5 +1,6 @@
 """Contains the YamlInterface class for reading & writing YAML files."""
 import copy
+import os
 import threading
 from typing import Any, Iterable, Dict
 
@@ -101,3 +102,11 @@ class YamlInterface(FileInterface):
             _yaml_instance.default_flow_style = False
             _yaml_instance.line_break = ''
             _yaml_instance.dump(data, output_file)
+
+            try:
+                fd = output_file.fileno()
+                if isinstance(fd, int):  # True on real files, False on MagicMocks
+                    output_file.flush()
+                    os.fsync(fd)
+            except OSError as e:
+                self.log.error("Hardware disk sync failed for %s: %s", filename, e)

--- a/mpf/file_interfaces/yaml_interface.py
+++ b/mpf/file_interfaces/yaml_interface.py
@@ -1,5 +1,6 @@
 """Contains the YamlInterface class for reading & writing YAML files."""
 import copy
+import threading
 from typing import Any, Iterable, Dict
 
 from ruamel import yaml
@@ -7,8 +8,16 @@ from ruamel.yaml.error import MarkedYAMLError
 
 from mpf.core.file_interface import FileInterface
 
-_yaml = yaml.YAML(typ='safe')
-_yaml.default_flow_style = False
+_thread_local = threading.local()
+
+
+def _get_yaml():
+    """Get or create a thread-isolated YAML instance."""
+    if not hasattr(_thread_local, 'yaml'):
+        _yaml_instance = yaml.YAML(typ='safe')
+        _yaml_instance.default_flow_style = False
+        _thread_local.yaml = _yaml_instance
+    return _thread_local.yaml
 
 
 class YamlInterface(FileInterface):
@@ -83,11 +92,12 @@ class YamlInterface(FileInterface):
     @staticmethod
     def process(data_string: Iterable[str]) -> dict:
         """Parse yaml from a string."""
-        return _yaml.load(data_string)
+        return _get_yaml().load(data_string)
 
     def save(self, filename: str, data: dict) -> None:   # pragma: no cover
         """Save config to yaml file."""
         with open(filename, 'w', encoding='utf8') as output_file:
-            _yaml.default_flow_style = False
-            _yaml.line_break = ''
-            _yaml.dump(data, output_file)
+            _yaml_instance = _get_yaml()
+            _yaml_instance.default_flow_style = False
+            _yaml_instance.line_break = ''
+            _yaml_instance.dump(data, output_file)

--- a/mpf/tests/machine_files/auditor/config/config.yaml
+++ b/mpf/tests/machine_files/auditor/config/config.yaml
@@ -13,9 +13,11 @@ auditor:
     events:
         - test_event1
         - test_event2
+        - test_event2  # duplicate should get deduped with set
     player:
         - my_var
         - optional_var
+        - score  # dedups
 
 modes:
     - base

--- a/mpf/tests/machine_files/data_manager/config/config.yaml
+++ b/mpf/tests/machine_files/data_manager/config/config.yaml
@@ -5,3 +5,6 @@ mpf:
         absolute_test: /data/test_dir/test_file.yaml
         relative_test: subdir/subdir2/test.yaml
         disabled_test: False
+
+data_manager:
+    use_fsync: True

--- a/mpf/tests/test_FileManager.py
+++ b/mpf/tests/test_FileManager.py
@@ -1,0 +1,75 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+from mpf.core.file_manager import FileManager
+
+
+class TestFileManager(unittest.TestCase):
+    def setUp(self):
+        if not FileManager.initialized:
+            FileManager.init()
+        # Keep a backup of the original global yaml interface to prevent leaking mocks
+        self.original_yaml_interface = FileManager.file_interfaces.get(".yaml")
+
+    def tearDown(self):
+        # Restore the original interface so later test suites don't crash
+        if self.original_yaml_interface:
+            FileManager.file_interfaces[".yaml"] = self.original_yaml_interface
+
+    def test_invalid_extension(self):
+        """If an invalid extension is supplied, it must throw an AssertionError."""
+        if not FileManager.initialized:
+            FileManager.init()
+            
+        with self.assertRaises(AssertionError):
+            FileManager.save("test.invalid_ext", {}, False)
+
+    @patch("os.open")
+    @patch("os.fsync")
+    @patch("os.close")
+    @patch("os.replace")
+    def test_directory_fsync_option(self, mock_replace, mock_close, mock_fsync, mock_open):
+        """Verify that saving a file attempts to sync its parent directory."""
+        if not FileManager.initialized:
+            FileManager.init()
+
+        # Mock a file interface so it doesn't look for an actual disk backend
+        mock_interface = MagicMock()
+        FileManager.file_interfaces[".yaml"] = mock_interface
+        mock_open.return_value = 77  # Mock an arbitrary folder file descriptor
+
+        # Save without fsync
+        FileManager.save("test_dir/file.yaml", {}, False)
+
+        # Verify that the parent directory path was opened, synchronized, and closed
+        mock_open.assert_not_called()
+        mock_fsync.assert_not_called()
+        mock_close.assert_not_called()
+
+        # Save with fsync
+        FileManager.save("test_dir/file.yaml", {}, True)
+
+        # Verify that the parent directory path was opened, synchronized, and closed
+        mock_open.assert_called_once()
+        mock_fsync.assert_called_once_with(77)
+        mock_close.assert_called_once_with(77)
+
+    @patch("os.open")
+    @patch("os.replace")
+    def test_directory_fsync_handles_windows_permission_error(self, mock_replace, mock_open):
+        """Ensure the method doesn't crash if os.open raises a platform error (like on Windows)."""
+        if not FileManager.initialized:
+            FileManager.init()
+
+        mock_interface = MagicMock()
+        FileManager.file_interfaces[".yaml"] = mock_interface
+        FileManager.log = MagicMock()
+
+        # Simulate a Windows PermissionError/OSError when opening a directory path
+        mock_open.side_effect = PermissionError(13, "Permission denied")
+
+        # Execution should complete cleanly instead of throwing unhandled exceptions
+        FileManager.save("test_dir/file.yaml", {}, True)
+
+        # Confirm the safety path captured the issue gracefully inside the debug logs
+        FileManager.log.debug.assert_called_once()

--- a/mpf/tests/test_FileManager.py
+++ b/mpf/tests/test_FileManager.py
@@ -20,7 +20,7 @@ class TestFileManager(unittest.TestCase):
         """If an invalid extension is supplied, it must throw an AssertionError."""
         if not FileManager.initialized:
             FileManager.init()
-            
+
         with self.assertRaises(AssertionError):
             FileManager.save("test.invalid_ext", {}, False)
 

--- a/mpf/tests/test_YamlInterface.py
+++ b/mpf/tests/test_YamlInterface.py
@@ -1,5 +1,8 @@
 import unittest
+import os
+from unittest.mock import patch, mock_open, MagicMock
 from ruamel.yaml.constructor import DuplicateKeyError
+
 from mpf.file_interfaces.yaml_interface import YamlInterface
 
 
@@ -57,3 +60,33 @@ int_1: 123
                 raise AssertionError('YAML value "{}" is {}, not {}'.format(v,
                     type(v), eval(k.split('_')[0])))
             self.assertEqual(values[k], v)
+
+    @patch("mpf.file_interfaces.yaml_interface.open", new_callable=mock_open)
+    @patch("os.fsync")
+    def test_yaml_save_triggers_fsync(self, mock_os_fsync, mock_file_open):
+        """Verify that saving a file forces a flush and an os.fsync call."""
+        interface = YamlInterface()
+        interface.log = MagicMock()
+
+        mock_file_handle = mock_file_open.return_value
+        mock_file_handle.fileno.return_value = 42
+
+        interface.save("test_durability.yaml", {"high_score": 100000}, True)
+
+        mock_file_handle.flush.assert_called()
+        mock_os_fsync.assert_called_once_with(42)
+        interface.log.error.assert_not_called()
+
+    @patch("mpf.file_interfaces.yaml_interface.open", new_callable=mock_open)
+    @patch("os.fsync")
+    def test_yaml_save_handles_fsync_os_error_gracefully(self, mock_os_fsync, mock_file_open):
+        """Ensure that if the OS throws an error during fsync, it is logged and caught."""
+        interface = YamlInterface()
+        interface.log = MagicMock()
+
+        mock_file_handle = mock_file_open.return_value
+        mock_file_handle.fileno.return_value = 42
+        mock_os_fsync.side_effect = OSError(5, "Input/output error")
+
+        interface.save("broken_disk.yaml", {"high_score": 100000}, True)
+        interface.log.error.assert_called_once()


### PR DESCRIPTION
developers were using game_ended etc and getting double counted audits because they did not realize the default auditor config already includes it

also adds a bunch of file management improvements and safety for all the builtin yaml files in data/
- yaml interface is threadsafe
- yaml interface uses fsync
- file manager uses directory fsync (and anticipates windows exceptions with permissionerror)
- data manager accepts config option on whether to use fsync (default to None which handles OS preferences, windows to False, else True)
- data manager uses fresh data dump if dirty on thread stop