### PR TITLE
utility function string_to_ms should not crash with more obvious cases

### DIFF
--- a/mpf/core/utility_functions.py
+++ b/mpf/core/utility_functions.py
@@ -588,13 +588,16 @@ class Util:
         if isinstance(time_string, (int, float)):
             return int(time_string)
 
-        time_string = str(time_string).upper()
+        time_string = str(time_string).upper().strip()
 
-        if time_string.endswith('MS') or time_string.endswith('MSEC'):
-            return int(time_string[:-2])
+        if time_string == 'NONE':
+            return 0
+
+        if time_string.endswith('MS'):
+            return int(float(time_string[:-2]))
 
         if time_string.endswith('MSEC'):
-            return int(time_string[:-4])
+            return int(float(time_string[:-4]))
 
         if time_string.endswith('D'):
             return int(float(time_string[:-1]) * 86400 * 1000)
@@ -611,7 +614,7 @@ class Util:
         if time_string.endswith('SEC'):
             return int(float(time_string[:-3]) * 1000)
 
-        return int(time_string)
+        return int(float(time_string))
 
     @staticmethod
     def string_to_secs(time_string: str) -> float:

--- a/mpf/tests/test_Utility_Functions.py
+++ b/mpf/tests/test_Utility_Functions.py
@@ -5,13 +5,60 @@ from mpf.core.utility_functions import Util
 class TestUtil(unittest.TestCase):
 
     def test_string_to_ms(self):
-        self.assertEqual(86400000, Util.string_to_ms('1d'))
-        self.assertEqual(3600000, Util.string_to_ms('1h'))
-        self.assertEqual(60000, Util.string_to_ms('1m'))
-        self.assertEqual(1000, Util.string_to_ms('1s'))
-        self.assertEqual(1, Util.string_to_ms('1ms'))
-        self.assertEqual(0, Util.string_to_ms(None))
-        self.assertEqual(0, Util.string_to_ms(False))
+        # Base Units
+        self.assertEqual(Util.string_to_ms('1d'), 86400000)
+        self.assertEqual(Util.string_to_ms('1h'), 3600000)
+        self.assertEqual(Util.string_to_ms('1m'), 60000)
+        self.assertEqual(Util.string_to_ms('1s'), 1000)
+        self.assertEqual(Util.string_to_ms('1ms'), 1)
+
+        # Quirky Units
+        self.assertEqual(Util.string_to_ms('200msec'), 200)
+        self.assertEqual(Util.string_to_ms('200Msec'), 200)
+        self.assertEqual(Util.string_to_ms('2sec'), 2000)
+        self.assertEqual(Util.string_to_ms('2Sec'), 2000)
+        self.assertEqual(Util.string_to_ms('1.5S'), 1500)
+        self.assertEqual(Util.string_to_ms('100.0ms'), 100)
+
+        # Unitless int/floats as strings
+        self.assertEqual(Util.string_to_ms('200'), 200)
+        self.assertEqual(Util.string_to_ms('100.0'), 100)
+
+        # Actual int/float
+        self.assertEqual(Util.string_to_ms(500), 500)
+        self.assertEqual(Util.string_to_ms(1.5), 1)
+
+        # Strings implying zero
+        self.assertEqual(Util.string_to_ms('None'), 0)
+        self.assertEqual(Util.string_to_ms('NONE'), 0)
+
+        # T/F/N native behavior
+        self.assertEqual(Util.string_to_ms(True), 1)
+        self.assertEqual(Util.string_to_ms(False), 0)
+        self.assertEqual(Util.string_to_ms(None), 0)
+
+        # Whitespace handling
+        self.assertEqual(Util.string_to_ms('  500ms  '), 500)
+        self.assertEqual(Util.string_to_ms('2s '), 2000)
+
+    def test_string_to_ms_unhandled(self):
+        with self.assertRaises(ValueError):
+            Util.string_to_ms('')
+
+        with self.assertRaises(ValueError):
+            Util.string_to_ms('no')
+
+        with self.assertRaises(ValueError):
+            Util.string_to_ms('pinball')
+
+        with self.assertRaises(ValueError):
+            Util.string_to_ms('True')
+
+        with self.assertRaises(ValueError):
+            Util.string_to_ms('200mss')
+
+        with self.assertRaises(ValueError):
+            Util.string_to_ms('2s 1s')
 
     def test_keys_to_lower(self):
         inner_dict = dict(key1=1, Key2=2)


### PR DESCRIPTION
It sketches me out how many of these were crashes before. ~~I almost worry that somehow something depended on things like "" crashing instead of converting to zero.~~ And who knows what this would do with negative numbers! (edit: left undefined for now! No opinion!)

On the other hand, this is a low level utility function, and I think it should be as permissive as possible in converting, so as to avoid crashes at runtime (since this is used all over the place). I'm not 100% sure I like converting the native True False and Nones, ~~but really the thing I'm unsettled on is whether "" should crash still (so we dont blindly start letting errors where a string should have come through and instead was truncated) or whether it should become 0. Maybe some special cases deserve logging.~~ Don't do it! Crash on blanks!