### PR TITLE
FAST: clamp LED fade brightness to fix binascii 'Odd-length string' crash

### DIFF
--- a/mpf/platforms/fast/fast_led.py
+++ b/mpf/platforms/fast/fast_led.py
@@ -40,7 +40,11 @@ class FASTRGBLED:
             channel = self.channels[index]
             if channel:
                 brightness, _, done = channel.get_fade_and_brightness(current_time)
-                result += f'{int(brightness * 255):02X}'
+                # Clamp to a single byte: an out-of-range brightness here would
+                # format to a 1- or 3-char hex channel and crash the downstream
+                # binascii unpacking with an "Odd-length string" error.
+                clamped_brightness = min(255, max(0, int(brightness * 255)))
+                result += f'{clamped_brightness:02X}'
                 if not done:
                     self.dirty = True
             else:
@@ -116,6 +120,12 @@ class FASTLEDChannel(LightPlatformInterface):
             fade_ms = max_fade_ms
             ratio = ((current_time + (fade_ms / 1000.0) - start_time) /
                      (target_time - start_time))
+            # A fade's start_time and the current_time passed in come from
+            # separate clock reads, so current_time can land a hair before
+            # start_time, making this ratio slightly out of [0, 1]. That would
+            # push brightness below 0 (fade up) or above 1 (fade down); clamp
+            # the ratio so the interpolation stays in range for both directions.
+            ratio = max(0.0, min(1.0, ratio))
             brightness = start_brightness + (target_brightness - start_brightness) * ratio
             done = False
         else:
@@ -125,15 +135,15 @@ class FASTLEDChannel(LightPlatformInterface):
             self._last_brightness = brightness
             done = True
 
-        # There is a bug that can sometimes cause the start_time to be ahead of the current_time,
-        # resulting in a negative brightness value. This may be a floating-point rounding error,
-        # or maybe something else. I can't figure it out, so just floor the value to be non-negative.
-        if brightness < 0:
-            brightness = 0
-            self.led.log.warning("Calculated a negative brightness (%s) for led %s channel %s. current_time: %s "
+        # Final guard in case start/target brightness themselves are ever out
+        # of [0, 1]: an out-of-range value would crash the hex formatter in
+        # current_color, so clamp both ends.
+        if brightness < 0 or brightness > 1:
+            self.led.log.warning("Calculated an out-of-range brightness (%s) for led %s channel %s. current_time: %s "
                                  "start_brightness: %s, start_time: %s, target_brightness: %s, target_time: %s",
                                  brightness, self.led, self.channel, current_time, start_brightness, start_time,
                                  target_brightness, target_time)
+            brightness = max(0.0, min(1.0, brightness))
 
         return brightness, fade_ms, done
 

--- a/mpf/tests/test_Fast_Led.py
+++ b/mpf/tests/test_Fast_Led.py
@@ -1,0 +1,61 @@
+# mpf.tests.test_Fast_Led
+"""Unit tests for FAST LED fade/brightness math."""
+import unittest
+from unittest.mock import MagicMock
+
+from mpf.platforms.fast.fast_led import FASTLEDChannel
+
+
+class _FakeLed:
+    """Minimal stand-in for FASTRGBLED for unit-testing a single channel."""
+
+    def __init__(self, hardware_fade_ms=0):
+        self.number = '880'
+        self.hardware_fade_ms = hardware_fade_ms
+        self.dirty = False
+        self.log = MagicMock()
+
+
+class TestFastLed(unittest.TestCase):
+
+    def _channel(self, hardware_fade_ms=0):
+        return FASTLEDChannel(_FakeLed(hardware_fade_ms), 0)
+
+    def test_fade_interpolates_to_three_places(self):
+        # Half-way through a 0 -> 1 fade the brightness is 0.5.
+        ch = self._channel()
+        start = 1000.0
+        ch.set_fade(start_brightness=0.0, start_time=start,
+                    target_brightness=1.0, target_time=start + 1.0)
+
+        brightness, _, _ = ch.get_fade_and_brightness(start + 0.5)
+
+        self.assertAlmostEqual(brightness, 0.5, places=3)
+
+    def test_fade_up_when_current_time_precedes_start_time(self):
+        # When current_time reads as before the fade's start_time, a fade up
+        # must not calculate a brightness below 0.
+        ch = self._channel()
+        now = 1000.0
+        ch.set_fade(start_brightness=0.0, start_time=now + 0.01,
+                    target_brightness=1.0, target_time=now + 0.5)
+
+        brightness, _, _ = ch.get_fade_and_brightness(now)
+
+        self.assertGreaterEqual(brightness, 0.0)
+        self.assertLessEqual(brightness, 1.0)
+
+    def test_fade_down_when_current_time_precedes_start_time(self):
+        # The same out-of-order read while fading down must not calculate a
+        # brightness above 1, which would format to a 3-char hex channel and
+        # crash the downstream binascii unpacking.
+        ch = self._channel()
+        now = 1000.0
+        ch.set_fade(start_brightness=1.0, start_time=now + 0.01,
+                    target_brightness=0.0, target_time=now + 0.5)
+
+        brightness, _, _ = ch.get_fade_and_brightness(now)
+
+        self.assertGreaterEqual(brightness, 0.0)
+        self.assertLessEqual(brightness, 1.0)
+        self.assertEqual(2, len(f'{int(brightness * 255):02X}'))


### PR DESCRIPTION
Fixes #2037.

## Problem

During LED fades, MPF can crash with `binascii.Error: Odd-length string`.

PR #1780 addressed the *negative* (fade-up) half of an out-of-range brightness and noted the root cause was unclear. The mechanism is clock jitter: a fade's `start_time` and the `current_time` used in `get_fade_and_brightness()` come from separate `clock.get_time()` reads, so `current_time` can land a hair **before** `start_time`. The interpolation ratio then goes slightly out of `[0, 1]`:

* fade **up** (`target > start`): brightness < 0 → floored to 0 by #1780 ✔
* fade **down** (`target < start`): brightness > 1.0 → `int(brightness * 255)` ≥ 256 → 3 hex chars → odd-length string crash. **Still unfixed.** ✘

Same bug, both polarities; #1780 clamped only one.

## Fix

1. **Clamp the interpolation ratio to `[0, 1]`** where it is computed — kills both polarities at the source.
2. **Belt-and-braces clamp at the hex-format site** in `current_color` so an out-of-range value can never produce a non-2-char channel.
3. Generalize the pre-existing negative-only floor to a symmetric guard. (It also logged `brightness` *after* setting it to 0, so it always reported "0"; now it logs the real value.)

## Tests

`mpf/tests/test_Fast_Led.py` — focused unit tests for the fade math:
* `test_fade_down_with_clock_jitter_stays_in_range` (the #2037 case — fails without this fix)
* `test_fade_up_with_clock_jitter_stays_in_range` (the #1780 case stays fixed)
* `test_normal_fade_midpoint_unaffected` (clamp doesn't distort a well-formed fade)

All new tests plus the full existing FAST suite (Exp, Neuron, Nano, Retro, Audio, Dmd, Seg) pass.

Reproduced and verified locally on 0.80.0 with a FAST Neuron + FP-EXP-2000/FP-EXP-0071 (previously reproducible with fade-down shows at 31.25 Hz LED update rate).
