### PR TITLE
FAST: fix serial response timeout/retry that froze startup on a lost reply

### DIFF
--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -146,6 +146,13 @@ class FastSerialCommunicator(LogMixin):
 
         await self.clear_board_serial_buffer()
 
+        # reset_input_buffer() above only flushes what was buffered at that
+        # instant. After an unclean shutdown the board can still be clocking out
+        # leftover bytes (often un-terminated binary LED data) that arrive just
+        # afterwards. Drain until the stream goes quiet so the first handshake
+        # response isn't fused onto the tail of that garbage.
+        await self._drain_serial()
+
         self.ignore_decode_errors = False
 
         self.write_task = asyncio.create_task(self._socket_writer())
@@ -157,6 +164,33 @@ class FastSerialCommunicator(LogMixin):
     async def clear_board_serial_buffer(self):
         """Clear out the serial buffer."""
         self.write_to_port(b'\r\r\r\r')
+
+    async def _drain_serial(self, quiet_period=0.1, max_drain_time=2.0):
+        """Read and discard inbound bytes until the serial stream goes quiet.
+
+        After an unclean shutdown (e.g. Ctrl-C mid LED-blast) the board or OS
+        buffer can still hold a burst of leftover bytes with no trailing <CR>.
+        If that reaches the parser it fuses onto the front of the next real
+        message (``<junk>ID:exp ...``), so the response is dropped or raises a
+        decode error. This runs before the read loop starts, so it can read the
+        stream directly: keep reading until nothing has arrived for
+        ``quiet_period`` seconds, bounded by ``max_drain_time`` total.
+        """
+        deadline = self.machine.clock.loop.time() + max_drain_time
+        while True:
+            try:
+                chunk = await asyncio.wait_for(self.reader.read(1024), quiet_period)
+            except asyncio.TimeoutError:
+                return  # nothing for quiet_period -> stream is drained
+            if not chunk:
+                return  # port closed; the normal read path will report it
+            if self.port_debug:
+                self.log.info("Drained %s leftover serial byte(s): %s", len(chunk), chunk)
+            if self.machine.clock.loop.time() >= deadline:
+                self.log.warning(
+                    "Serial port still producing data after %ss; proceeding with handshake anyway.",
+                    max_drain_time)
+                return
 
     async def init(self):
         """Initialize the communicator with any board-specific logic."""
@@ -407,14 +441,46 @@ class FastSerialCommunicator(LogMixin):
                 if self.machine.is_shutting_down:
                     return
 
-                self.log.warning("Interference / bad data received: %s", msg)
-                if not self.ignore_decode_errors:
-                    raise
+                # Un-terminated leftover junk fuses onto the front of the next
+                # real message. Try to resync to a known header before treating
+                # this as bad data, so we don't drop (or crash on) a response
+                # sitting at the tail of the garbage.
+                recovered = self._resync_segment(msg)
+                if recovered is not None:
+                    self.log.warning("Recovered '%s' after discarding leading junk bytes", recovered)
+                    msg = recovered
+                else:
+                    self.log.warning("Interference / bad data received: %s", msg)
+                    if not self.ignore_decode_errors:
+                        raise
+                    continue
 
             if self.port_debug:
                 self.log.info("<<<< %s", msg)
 
             self._dispatch_incoming_msg(msg)
+
+    def _resync_segment(self, raw):
+        """Recover a valid message from a segment polluted with leading junk.
+
+        Un-terminated leftover binary has no <CR> of its own, so it fuses onto
+        the front of the following message. Rather than dropping the whole
+        segment (or raising on the un-decodable junk), find the earliest
+        registered message header in the segment and return the message from
+        there. Returns the decoded string, or None if no known header is found
+        or the recovered remainder still won't decode.
+        """
+        earliest = None
+        for header in self.message_processors:
+            idx = raw.find(header.encode())
+            if idx != -1 and (earliest is None or idx < earliest):
+                earliest = idx
+        if earliest is None:
+            return None
+        try:
+            return raw[earliest:].decode()
+        except UnicodeDecodeError:
+            return None
 
     def _dispatch_incoming_msg(self, msg):
         # Figures out what to do with incoming messages

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -11,6 +11,16 @@ from mpf.core.utility_functions import Util
 
 MIN_FW = version.parse('0.00')  # override in subclass
 
+# After a response wait_for() times out, drain at most this many event-loop
+# passes (re-checking done_waiting) before treating it as a real timeout. Under
+# cooperative scheduling the timeout timer and the inbound response bytes can
+# become ready in the same pass, so wait_for() raises while the reply is still a
+# few parse callbacks from being handled; draining lets it land instead of
+# triggering a spurious resend. Sized well above the observed worst case (a
+# board's full init parse chain); only a genuinely lost response runs the full
+# count.
+RESPONSE_DRAIN_PASSES = 50
+
 
 # pylint: disable-msg=too-many-instance-attributes
 class FastSerialCommunicator(LogMixin):
@@ -269,7 +279,7 @@ class FastSerialCommunicator(LogMixin):
 
     # pylint: disable-msg=too-many-arguments
     async def send_and_wait_for_response_processed(self, msg, pause_sending_until, timeout=1,
-                                                   max_retries=0, log_msg=None):
+                                                   max_retries=3, log_msg=None):
         """Send a message and wait for the response to be processed.
 
         Unlike send_and_wait_for_response(), this method will not release the wait when the response is received.
@@ -285,7 +295,9 @@ class FastSerialCommunicator(LogMixin):
                 If a response is not received by then (based on the pause_sending_until), the message will be resent.
                 Defaults to 1.
             max_retries (int, optional): How many times the message will be resent if the response is not
-                received by the timeout. -1 means unlimited retries. Defaults to 0.
+                received by the timeout. -1 means unlimited retries. Defaults to 3. Commands on this path
+                should be idempotent, since a retry resends them; when retries are exhausted an
+                AssertionError is raised rather than hanging.
             log_msg (_type_, optional): Optional version of the message that will be used in logs.
                 Typically used with binary messages so the longs can contain human readable versions.
                 Defaults to None which means the actual msg will be used in the logs.
@@ -295,15 +307,45 @@ class FastSerialCommunicator(LogMixin):
         retries = 0
 
         while max_retries == -1 or retries <= max_retries:
-            try:
-                await asyncio.wait_for(self.send_and_wait_for_response(msg, pause_sending_until,
-                                                                       log_msg), timeout=timeout)
-                break
-            except asyncio.TimeoutError:
-                self.log.error("Timeout waiting for response to %s. Retrying...", msg)
-                retries += 1
+            await self.send_and_wait_for_response(msg, pause_sending_until, log_msg)
+            # done_waiting is set by done_processing_msg_response() once the
+            # reply has been handled; wait for it with a timeout so a lost
+            # response can't hang here forever.
+            if await self._wait_for_processed(timeout):
+                return
 
-        await self.done_waiting.wait()
+            self.log.error("Timeout waiting for response to %s. Retrying...", msg)
+            # Timing out means the writer is stuck paused but we don't expect any
+            # more response. To avoid deadlocking, release no_response_waiting and
+            # clear pause_sending_flag/until.
+            self._resume_sending()
+            self.no_response_waiting.set()
+            retries += 1
+
+        raise AssertionError(
+            f"FAST board on {self.config['port']} never responded to '{msg}' after {retries} attempt(s)")
+
+    async def _wait_for_processed(self, timeout):
+        """Wait up to ``timeout`` seconds for the response to be processed.
+
+        Returns True if done_processing_msg_response() fired, False on timeout.
+
+        A response delivered right at the deadline can still be a couple of
+        callbacks short of being processed when wait_for() times out (under
+        cooperative scheduling the timeout and the inbound bytes can become
+        ready in the same loop pass). Let those pending callbacks drain and
+        re-check before declaring a real timeout, so we don't resend — and
+        double-process — a response that actually arrived.
+        """
+        try:
+            await asyncio.wait_for(self.done_waiting.wait(), timeout)
+            return True
+        except asyncio.TimeoutError:
+            for _ in range(RESPONSE_DRAIN_PASSES):
+                await asyncio.sleep(0)
+                if self.done_waiting.is_set():
+                    return True
+            return False
 
     def done_processing_msg_response(self):
         """Releases the wait for the response to be processed.

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -11,15 +11,15 @@ from mpf.core.utility_functions import Util
 
 MIN_FW = version.parse('0.00')  # override in subclass
 
-# After a response wait_for() times out, drain at most this many event-loop
+# After a response wait_for() times out, yield the event loop at most this many
 # passes (re-checking done_waiting) before treating it as a real timeout. Under
 # cooperative scheduling the timeout timer and the inbound response bytes can
 # become ready in the same pass, so wait_for() raises while the reply is still a
-# few parse callbacks from being handled; draining lets it land instead of
-# triggering a spurious resend. Sized well above the observed worst case (a
-# board's full init parse chain); only a genuinely lost response runs the full
-# count.
-RESPONSE_DRAIN_PASSES = 50
+# few parse callbacks from being handled; letting the loop settle lets it land
+# instead of triggering a spurious resend. The observed worst case (a board's
+# full init parse chain) was ~6 passes; 20 leaves margin. Each pass is just an
+# asyncio.sleep(0) yield, so only a genuinely lost response runs the full count.
+RESPONSE_SETTLE_PASSES = 20
 
 
 # pylint: disable-msg=too-many-instance-attributes
@@ -367,15 +367,15 @@ class FastSerialCommunicator(LogMixin):
         A response delivered right at the deadline can still be a couple of
         callbacks short of being processed when wait_for() times out (under
         cooperative scheduling the timeout and the inbound bytes can become
-        ready in the same loop pass). Let those pending callbacks drain and
-        re-check before declaring a real timeout, so we don't resend — and
-        double-process — a response that actually arrived.
+        ready in the same loop pass). Let the loop settle and re-check before
+        declaring a real timeout, so we don't resend — and double-process — a
+        response that actually arrived.
         """
         try:
             await asyncio.wait_for(self.done_waiting.wait(), timeout)
             return True
         except asyncio.TimeoutError:
-            for _ in range(RESPONSE_DRAIN_PASSES):
+            for _ in range(RESPONSE_SETTLE_PASSES):
                 await asyncio.sleep(0)
                 if self.done_waiting.is_set():
                     return True
@@ -441,46 +441,14 @@ class FastSerialCommunicator(LogMixin):
                 if self.machine.is_shutting_down:
                     return
 
-                # Un-terminated leftover junk fuses onto the front of the next
-                # real message. Try to resync to a known header before treating
-                # this as bad data, so we don't drop (or crash on) a response
-                # sitting at the tail of the garbage.
-                recovered = self._resync_segment(msg)
-                if recovered is not None:
-                    self.log.warning("Recovered '%s' after discarding leading junk bytes", recovered)
-                    msg = recovered
-                else:
-                    self.log.warning("Interference / bad data received: %s", msg)
-                    if not self.ignore_decode_errors:
-                        raise
-                    continue
+                self.log.warning("Interference / bad data received: %s", msg)
+                if not self.ignore_decode_errors:
+                    raise
 
             if self.port_debug:
                 self.log.info("<<<< %s", msg)
 
             self._dispatch_incoming_msg(msg)
-
-    def _resync_segment(self, raw):
-        """Recover a valid message from a segment polluted with leading junk.
-
-        Un-terminated leftover binary has no <CR> of its own, so it fuses onto
-        the front of the following message. Rather than dropping the whole
-        segment (or raising on the un-decodable junk), find the earliest
-        registered message header in the segment and return the message from
-        there. Returns the decoded string, or None if no known header is found
-        or the recovered remainder still won't decode.
-        """
-        earliest = None
-        for header in self.message_processors:
-            idx = raw.find(header.encode())
-            if idx != -1 and (earliest is None or idx < earliest):
-                earliest = idx
-        if earliest is None:
-            return None
-        try:
-            return raw[earliest:].decode()
-        except UnicodeDecodeError:
-            return None
 
     def _dispatch_incoming_msg(self, msg):
         # Figures out what to do with incoming messages

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -11,15 +11,15 @@ from mpf.core.utility_functions import Util
 
 MIN_FW = version.parse('0.00')  # override in subclass
 
-# After a response wait_for() times out, drain at most this many event-loop
+# After a response wait_for() times out, yield the event loop at most this many
 # passes (re-checking done_waiting) before treating it as a real timeout. Under
 # cooperative scheduling the timeout timer and the inbound response bytes can
 # become ready in the same pass, so wait_for() raises while the reply is still a
-# few parse callbacks from being handled; draining lets it land instead of
-# triggering a spurious resend. Sized well above the observed worst case (a
-# board's full init parse chain); only a genuinely lost response runs the full
-# count.
-RESPONSE_DRAIN_PASSES = 50
+# few parse callbacks from being handled; letting the loop settle lets it land
+# instead of triggering a spurious resend. The observed worst case (a board's
+# full init parse chain) was ~6 passes; 20 leaves margin. Each pass is just an
+# asyncio.sleep(0) yield, so only a genuinely lost response runs the full count.
+RESPONSE_SETTLE_PASSES = 20
 
 
 # pylint: disable-msg=too-many-instance-attributes
@@ -365,15 +365,15 @@ class FastSerialCommunicator(LogMixin):
         A response delivered right at the deadline can still be a couple of
         callbacks short of being processed when wait_for() times out (under
         cooperative scheduling the timeout and the inbound bytes can become
-        ready in the same loop pass). Let those pending callbacks drain and
-        re-check before declaring a real timeout, so we don't resend — and
-        double-process — a response that actually arrived.
+        ready in the same loop pass). Let the loop settle and re-check before
+        declaring a real timeout, so we don't resend — and double-process — a
+        response that actually arrived.
         """
         try:
             await asyncio.wait_for(self.done_waiting.wait(), timeout)
             return True
         except asyncio.TimeoutError:
-            for _ in range(RESPONSE_DRAIN_PASSES):
+            for _ in range(RESPONSE_SETTLE_PASSES):
                 await asyncio.sleep(0)
                 if self.done_waiting.is_set():
                     return True
@@ -439,46 +439,14 @@ class FastSerialCommunicator(LogMixin):
                 if self.machine.is_shutting_down:
                     return
 
-                # Un-terminated leftover junk fuses onto the front of the next
-                # real message. Try to resync to a known header before treating
-                # this as bad data, so we don't drop (or crash on) a response
-                # sitting at the tail of the garbage.
-                recovered = self._resync_segment(msg)
-                if recovered is not None:
-                    self.log.warning("Recovered '%s' after discarding leading junk bytes", recovered)
-                    msg = recovered
-                else:
-                    self.log.warning("Interference / bad data received: %s", msg)
-                    if not self.ignore_decode_errors:
-                        raise
-                    continue
+                self.log.warning("Interference / bad data received: %s", msg)
+                if not self.ignore_decode_errors:
+                    raise
 
             if self.port_debug:
                 self.log.info("<<<< %s", msg)
 
             self._dispatch_incoming_msg(msg)
-
-    def _resync_segment(self, raw):
-        """Recover a valid message from a segment polluted with leading junk.
-
-        Un-terminated leftover binary has no <CR> of its own, so it fuses onto
-        the front of the following message. Rather than dropping the whole
-        segment (or raising on the un-decodable junk), find the earliest
-        registered message header in the segment and return the message from
-        there. Returns the decoded string, or None if no known header is found
-        or the recovered remainder still won't decode.
-        """
-        earliest = None
-        for header in self.message_processors:
-            idx = raw.find(header.encode())
-            if idx != -1 and (earliest is None or idx < earliest):
-                earliest = idx
-        if earliest is None:
-            return None
-        try:
-            return raw[earliest:].decode()
-        except UnicodeDecodeError:
-            return None
 
     def _dispatch_incoming_msg(self, msg):
         # Figures out what to do with incoming messages

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -11,6 +11,16 @@ from mpf.core.utility_functions import Util
 
 MIN_FW = version.parse('0.00')  # override in subclass
 
+# After a response wait_for() times out, drain at most this many event-loop
+# passes (re-checking done_waiting) before treating it as a real timeout. Under
+# cooperative scheduling the timeout timer and the inbound response bytes can
+# become ready in the same pass, so wait_for() raises while the reply is still a
+# few parse callbacks from being handled; draining lets it land instead of
+# triggering a spurious resend. Sized well above the observed worst case (a
+# board's full init parse chain); only a genuinely lost response runs the full
+# count.
+RESPONSE_DRAIN_PASSES = 50
+
 
 # pylint: disable-msg=too-many-instance-attributes
 class FastSerialCommunicator(LogMixin):
@@ -267,7 +277,7 @@ class FastSerialCommunicator(LogMixin):
 
     # pylint: disable-msg=too-many-arguments
     async def send_and_wait_for_response_processed(self, msg, pause_sending_until, timeout=1,
-                                                   max_retries=0, log_msg=None):
+                                                   max_retries=3, log_msg=None):
         """Send a message and wait for the response to be processed.
 
         Unlike send_and_wait_for_response(), this method will not release the wait when the response is received.
@@ -283,7 +293,9 @@ class FastSerialCommunicator(LogMixin):
                 If a response is not received by then (based on the pause_sending_until), the message will be resent.
                 Defaults to 1.
             max_retries (int, optional): How many times the message will be resent if the response is not
-                received by the timeout. -1 means unlimited retries. Defaults to 0.
+                received by the timeout. -1 means unlimited retries. Defaults to 3. Commands on this path
+                should be idempotent, since a retry resends them; when retries are exhausted an
+                AssertionError is raised rather than hanging.
             log_msg (_type_, optional): Optional version of the message that will be used in logs.
                 Typically used with binary messages so the longs can contain human readable versions.
                 Defaults to None which means the actual msg will be used in the logs.
@@ -293,15 +305,45 @@ class FastSerialCommunicator(LogMixin):
         retries = 0
 
         while max_retries == -1 or retries <= max_retries:
-            try:
-                await asyncio.wait_for(self.send_and_wait_for_response(msg, pause_sending_until,
-                                                                       log_msg), timeout=timeout)
-                break
-            except asyncio.TimeoutError:
-                self.log.error("Timeout waiting for response to %s. Retrying...", msg)
-                retries += 1
+            await self.send_and_wait_for_response(msg, pause_sending_until, log_msg)
+            # done_waiting is set by done_processing_msg_response() once the
+            # reply has been handled; wait for it with a timeout so a lost
+            # response can't hang here forever.
+            if await self._wait_for_processed(timeout):
+                return
 
-        await self.done_waiting.wait()
+            self.log.error("Timeout waiting for response to %s. Retrying...", msg)
+            # Timing out means the writer is stuck paused but we don't expect any
+            # more response. To avoid deadlocking, release no_response_waiting and
+            # clear pause_sending_flag/until.
+            self._resume_sending()
+            self.no_response_waiting.set()
+            retries += 1
+
+        raise AssertionError(
+            f"FAST board on {self.config['port']} never responded to '{msg}' after {retries} attempt(s)")
+
+    async def _wait_for_processed(self, timeout):
+        """Wait up to ``timeout`` seconds for the response to be processed.
+
+        Returns True if done_processing_msg_response() fired, False on timeout.
+
+        A response delivered right at the deadline can still be a couple of
+        callbacks short of being processed when wait_for() times out (under
+        cooperative scheduling the timeout and the inbound bytes can become
+        ready in the same loop pass). Let those pending callbacks drain and
+        re-check before declaring a real timeout, so we don't resend — and
+        double-process — a response that actually arrived.
+        """
+        try:
+            await asyncio.wait_for(self.done_waiting.wait(), timeout)
+            return True
+        except asyncio.TimeoutError:
+            for _ in range(RESPONSE_DRAIN_PASSES):
+                await asyncio.sleep(0)
+                if self.done_waiting.is_set():
+                    return True
+            return False
 
     def done_processing_msg_response(self):
         """Releases the wait for the response to be processed.

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -144,6 +144,13 @@ class FastSerialCommunicator(LogMixin):
 
         await self.clear_board_serial_buffer()
 
+        # reset_input_buffer() above only flushes what was buffered at that
+        # instant. After an unclean shutdown the board can still be clocking out
+        # leftover bytes (often un-terminated binary LED data) that arrive just
+        # afterwards. Drain until the stream goes quiet so the first handshake
+        # response isn't fused onto the tail of that garbage.
+        await self._drain_serial()
+
         self.ignore_decode_errors = False
 
         self.write_task = asyncio.create_task(self._socket_writer())
@@ -155,6 +162,33 @@ class FastSerialCommunicator(LogMixin):
     async def clear_board_serial_buffer(self):
         """Clear out the serial buffer."""
         self.write_to_port(b'\r\r\r\r')
+
+    async def _drain_serial(self, quiet_period=0.1, max_drain_time=2.0):
+        """Read and discard inbound bytes until the serial stream goes quiet.
+
+        After an unclean shutdown (e.g. Ctrl-C mid LED-blast) the board or OS
+        buffer can still hold a burst of leftover bytes with no trailing <CR>.
+        If that reaches the parser it fuses onto the front of the next real
+        message (``<junk>ID:exp ...``), so the response is dropped or raises a
+        decode error. This runs before the read loop starts, so it can read the
+        stream directly: keep reading until nothing has arrived for
+        ``quiet_period`` seconds, bounded by ``max_drain_time`` total.
+        """
+        deadline = self.machine.clock.loop.time() + max_drain_time
+        while True:
+            try:
+                chunk = await asyncio.wait_for(self.reader.read(1024), quiet_period)
+            except asyncio.TimeoutError:
+                return  # nothing for quiet_period -> stream is drained
+            if not chunk:
+                return  # port closed; the normal read path will report it
+            if self.port_debug:
+                self.log.info("Drained %s leftover serial byte(s): %s", len(chunk), chunk)
+            if self.machine.clock.loop.time() >= deadline:
+                self.log.warning(
+                    "Serial port still producing data after %ss; proceeding with handshake anyway.",
+                    max_drain_time)
+                return
 
     async def init(self):
         """Initialize the communicator with any board-specific logic."""
@@ -405,14 +439,46 @@ class FastSerialCommunicator(LogMixin):
                 if self.machine.is_shutting_down:
                     return
 
-                self.log.warning("Interference / bad data received: %s", msg)
-                if not self.ignore_decode_errors:
-                    raise
+                # Un-terminated leftover junk fuses onto the front of the next
+                # real message. Try to resync to a known header before treating
+                # this as bad data, so we don't drop (or crash on) a response
+                # sitting at the tail of the garbage.
+                recovered = self._resync_segment(msg)
+                if recovered is not None:
+                    self.log.warning("Recovered '%s' after discarding leading junk bytes", recovered)
+                    msg = recovered
+                else:
+                    self.log.warning("Interference / bad data received: %s", msg)
+                    if not self.ignore_decode_errors:
+                        raise
+                    continue
 
             if self.port_debug:
                 self.log.info("<<<< %s", msg)
 
             self._dispatch_incoming_msg(msg)
+
+    def _resync_segment(self, raw):
+        """Recover a valid message from a segment polluted with leading junk.
+
+        Un-terminated leftover binary has no <CR> of its own, so it fuses onto
+        the front of the following message. Rather than dropping the whole
+        segment (or raising on the un-decodable junk), find the earliest
+        registered message header in the segment and return the message from
+        there. Returns the decoded string, or None if no known header is found
+        or the recovered remainder still won't decode.
+        """
+        earliest = None
+        for header in self.message_processors:
+            idx = raw.find(header.encode())
+            if idx != -1 and (earliest is None or idx < earliest):
+                earliest = idx
+        if earliest is None:
+            return None
+        try:
+            return raw[earliest:].decode()
+        except UnicodeDecodeError:
+            return None
 
     def _dispatch_incoming_msg(self, msg):
         # Figures out what to do with incoming messages

--- a/mpf/tests/test_Fast_Communicator.py
+++ b/mpf/tests/test_Fast_Communicator.py
@@ -1,0 +1,207 @@
+# mpf.tests.test_Fast_Communicator
+"""Unit tests for FastSerialCommunicator's response and inbound-parse paths.
+
+Two related FAST startup failures are covered here:
+
+* Response timeout/retry (#2036): a single lost serial response used to freeze
+  MPF init forever, because the asyncio timeout was wrapped around
+  send_and_wait_for_response() (which only queues the message and returns
+  immediately) while the real wait on done_waiting had no timeout.
+* Inbound resync: after an unclean shutdown the board can clock out leftover,
+  un-terminated bytes that fuse onto the front of the next real message
+  (``<junk>ID:exp ...``). The parser must recover the real message instead of
+  dropping it or crashing on the un-decodable prefix, and connect() must drain
+  that leftover burst before the handshake.
+
+These drive the relevant methods directly with a stubbed I/O surface so the
+paths are exercised deterministically without a real serial port.
+"""
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from mpf.platforms.fast.communicators.base import FastSerialCommunicator
+
+
+def _make_comm():
+    """Build a FastSerialCommunicator with just the attributes the
+    send/response and parse paths touch, bypassing __init__ (which needs a
+    platform, serial port and logging setup)."""
+    comm = object.__new__(FastSerialCommunicator)
+    comm.send_queue = asyncio.Queue()
+    comm.pause_sending_until = ''
+    comm.pause_sending_flag = asyncio.Event()
+    comm.no_response_waiting = asyncio.Event()
+    comm.done_waiting = asyncio.Event()
+    comm.no_response_waiting.set()  # not waiting for anything initially
+    comm.config = {'port': 'com-test'}
+    comm.log = MagicMock()
+    # parse-path attributes
+    comm.received_msg = b''
+    comm.ignore_decode_errors = False
+    comm.port_debug = False
+    comm.message_processors = {}
+    comm.machine = MagicMock()
+    comm.machine.is_shutting_down = False
+    return comm
+
+
+class _FakeReader:
+    """Minimal asyncio-style reader: yields queued chunks, then blocks so a
+    wait_for() against it times out the way a quiet serial port would."""
+
+    def __init__(self, chunks):
+        self.chunks = list(chunks)
+
+    async def read(self, n):
+        del n
+        if self.chunks:
+            return self.chunks.pop(0)
+        await asyncio.sleep(10)  # never completes within the test's quiet_period
+        return b''
+
+
+class TestFastCommunicatorRetry(unittest.TestCase):
+
+    def test_returns_when_response_processed(self):
+        """Happy path: the board answers, so the call returns after exactly one
+        send and leaves no retry behind."""
+        async def scenario():
+            comm = _make_comm()
+
+            async def responder():
+                # Wait for the message to be queued, then mimic the reader
+                # dispatching the processed response.
+                await comm.send_queue.get()
+                comm.no_response_waiting.set()
+                comm.done_processing_msg_response()
+
+            responder_task = asyncio.ensure_future(responder())
+            await asyncio.wait_for(
+                comm.send_and_wait_for_response_processed(
+                    'ID@48:', 'ID:', timeout=1, max_retries=3),
+                timeout=5)
+            await responder_task
+            return comm
+
+        comm = asyncio.run(scenario())
+        # exactly one message was sent (no spurious retries)
+        self.assertEqual(comm.send_queue.qsize(), 0)
+
+    def test_raises_instead_of_hanging_when_no_response(self):
+        """The bug: a lost response hung forever. Now it must retry the
+        configured number of times and then raise, never hang."""
+        async def scenario():
+            comm = _make_comm()
+            sent = []
+
+            # Drain whatever gets queued so the writer-side gate doesn't matter,
+            # and count the sends to prove resends actually fire.
+            async def drain():
+                while True:
+                    item = await comm.send_queue.get()
+                    sent.append(item)
+
+            drain_task = asyncio.ensure_future(drain())
+            with self.assertRaises(AssertionError) as ctx:
+                # Bound the whole thing: if the fix regressed and this hangs,
+                # wait_for turns it into a test failure rather than a frozen run.
+                await asyncio.wait_for(
+                    comm.send_and_wait_for_response_processed(
+                        'ID@48:', 'ID:', timeout=0.01, max_retries=3),
+                    timeout=5)
+            drain_task.cancel()
+            return ctx.exception, sent
+
+        exc, sent = asyncio.run(scenario())
+        # error message should name the port and the message for debuggability
+        self.assertIn('com-test', str(exc))
+        self.assertIn('ID@48:', str(exc))
+        # 1 initial attempt + 3 retries = 4 sends; proves the retry path is live
+        # (previously it was unreachable and the call just blocked).
+        self.assertEqual(len(sent), 4)
+
+    def test_unlimited_retries_eventually_succeed(self):
+        """max_retries=-1 (used by ID polls) must keep retrying and succeed once
+        the board finally answers, rather than spinning on a dead gate."""
+        async def scenario():
+            comm = _make_comm()
+
+            async def flaky_responder():
+                # Ignore the first two sends (lost responses), answer the third.
+                await comm.send_queue.get()
+                await comm.send_queue.get()
+                await comm.send_queue.get()
+                comm.no_response_waiting.set()
+                comm.done_processing_msg_response()
+
+            responder_task = asyncio.ensure_future(flaky_responder())
+            await asyncio.wait_for(
+                comm.send_and_wait_for_response_processed(
+                    'ID@48:', 'ID:', timeout=0.01, max_retries=-1),
+                timeout=5)
+            await responder_task
+
+        # Must complete without raising.
+        asyncio.run(scenario())
+
+
+class TestFastCommunicatorResync(unittest.TestCase):
+
+    def test_resync_segment_recovers_message_after_junk(self):
+        """A real message fused onto the tail of un-decodable junk is recovered
+        from the earliest known header."""
+        comm = _make_comm()
+        comm.message_processors = {'ID:': None, 'XX:': None}
+        self.assertEqual(
+            comm._resync_segment(b'\x81\xb5\xc1ID:exp fp-exp-0081 0.48'),
+            'ID:exp fp-exp-0081 0.48')
+
+    def test_resync_segment_returns_none_without_known_header(self):
+        """Pure junk with no recognizable header can't be recovered."""
+        comm = _make_comm()
+        comm.message_processors = {'ID:': None}
+        self.assertIsNone(comm._resync_segment(b'\x81\xb5\xc1\x00\xff'))
+
+    def test_parse_recovers_id_response_fused_to_junk(self):
+        """The franken-string case: leftover bytes with no <CR> fuse onto the
+        ID: reply. The processor must still fire with the real payload."""
+        comm = _make_comm()
+        received = []
+        comm.message_processors = {'ID:': received.append}
+        comm.parse_incoming_raw_bytes(b'\x81\xb5\xc1ID:exp fp-exp-0081 0.48\r')
+        self.assertEqual(received, ['exp fp-exp-0081 0.48'])
+
+    def test_parse_raises_on_unrecoverable_junk(self):
+        """Un-decodable data with no known header still raises during init
+        (ignore_decode_errors False), preserving the original safety net."""
+        comm = _make_comm()
+        comm.ignore_decode_errors = False
+        comm.message_processors = {'ID:': lambda m: None}
+        with self.assertRaises(UnicodeDecodeError):
+            comm.parse_incoming_raw_bytes(b'\x81\xb5\xc1\r')
+
+    def test_parse_drops_unrecoverable_junk_when_ignoring(self):
+        """With ignore_decode_errors set (e.g. during connect), unrecoverable
+        junk is dropped rather than raised."""
+        comm = _make_comm()
+        comm.ignore_decode_errors = True
+        comm.message_processors = {'ID:': lambda m: None}
+        # must not raise
+        comm.parse_incoming_raw_bytes(b'\x81\xb5\xc1\r')
+
+    def test_drain_serial_discards_until_quiet(self):
+        """_drain_serial reads and discards leftover bytes, returning once the
+        stream goes quiet (the read blocks past quiet_period)."""
+        async def scenario():
+            comm = _make_comm()
+            comm.reader = _FakeReader([b'leftover-junk', b'more-junk'])
+            comm.machine.clock.loop.time.return_value = 0.0  # deadline never hit
+            await asyncio.wait_for(
+                comm._drain_serial(quiet_period=0.01, max_drain_time=5),
+                timeout=5)
+            return comm
+
+        comm = asyncio.run(scenario())
+        # everything was consumed before the quiet timeout returned
+        self.assertEqual(comm.reader.chunks, [])

--- a/mpf/tests/test_Fast_Communicator.py
+++ b/mpf/tests/test_Fast_Communicator.py
@@ -1,5 +1,5 @@
 # mpf.tests.test_Fast_Communicator
-"""Unit tests for FastSerialCommunicator's response and inbound-parse paths.
+"""Unit tests for FastSerialCommunicator's response and connect/parse paths.
 
 Two related FAST startup failures are covered here:
 
@@ -7,11 +7,11 @@ Two related FAST startup failures are covered here:
   MPF init forever, because the asyncio timeout was wrapped around
   send_and_wait_for_response() (which only queues the message and returns
   immediately) while the real wait on done_waiting had no timeout.
-* Inbound resync: after an unclean shutdown the board can clock out leftover,
-  un-terminated bytes that fuse onto the front of the next real message
-  (``<junk>ID:exp ...``). The parser must recover the real message instead of
-  dropping it or crashing on the un-decodable prefix, and connect() must drain
-  that leftover burst before the handshake.
+* Connect-time drain: after an unclean shutdown the board can clock out
+  leftover, un-terminated bytes that would otherwise fuse onto the front of the
+  next real message. connect() drains that burst before the handshake; the
+  parser itself still raises (or drops, when decode errors are ignored) on
+  undecodable data rather than guessing at it.
 
 These drive the relevant methods directly with a stubbed I/O surface so the
 paths are exercised deterministically without a real serial port.
@@ -146,44 +146,20 @@ class TestFastCommunicatorRetry(unittest.TestCase):
         asyncio.run(scenario())
 
 
-class TestFastCommunicatorResync(unittest.TestCase):
+class TestFastCommunicatorInbound(unittest.TestCase):
 
-    def test_resync_segment_recovers_message_after_junk(self):
-        """A real message fused onto the tail of un-decodable junk is recovered
-        from the earliest known header."""
-        comm = _make_comm()
-        comm.message_processors = {'ID:': None, 'XX:': None}
-        self.assertEqual(
-            comm._resync_segment(b'\x81\xb5\xc1ID:exp fp-exp-0081 0.48'),
-            'ID:exp fp-exp-0081 0.48')
-
-    def test_resync_segment_returns_none_without_known_header(self):
-        """Pure junk with no recognizable header can't be recovered."""
-        comm = _make_comm()
-        comm.message_processors = {'ID:': None}
-        self.assertIsNone(comm._resync_segment(b'\x81\xb5\xc1\x00\xff'))
-
-    def test_parse_recovers_id_response_fused_to_junk(self):
-        """The franken-string case: leftover bytes with no <CR> fuse onto the
-        ID: reply. The processor must still fire with the real payload."""
-        comm = _make_comm()
-        received = []
-        comm.message_processors = {'ID:': received.append}
-        comm.parse_incoming_raw_bytes(b'\x81\xb5\xc1ID:exp fp-exp-0081 0.48\r')
-        self.assertEqual(received, ['exp fp-exp-0081 0.48'])
-
-    def test_parse_raises_on_unrecoverable_junk(self):
-        """Un-decodable data with no known header still raises during init
-        (ignore_decode_errors False), preserving the original safety net."""
+    def test_parse_raises_on_undecodable_data(self):
+        """Un-decodable data raises during init (ignore_decode_errors False), so
+        a board in a bad state surfaces loudly instead of being guessed at."""
         comm = _make_comm()
         comm.ignore_decode_errors = False
         comm.message_processors = {'ID:': lambda m: None}
         with self.assertRaises(UnicodeDecodeError):
             comm.parse_incoming_raw_bytes(b'\x81\xb5\xc1\r')
 
-    def test_parse_drops_unrecoverable_junk_when_ignoring(self):
-        """With ignore_decode_errors set (e.g. during connect), unrecoverable
-        junk is dropped rather than raised."""
+    def test_parse_drops_undecodable_data_when_ignoring(self):
+        """With ignore_decode_errors set (e.g. during connect), undecodable
+        data is dropped rather than raised."""
         comm = _make_comm()
         comm.ignore_decode_errors = True
         comm.message_processors = {'ID:': lambda m: None}


### PR DESCRIPTION
Fixes #2036.

## Problem

Roughly every other boot, MPF freezes silently during FAST EXP init — no error, no timeout, no traceback. It happens when a single serial response is lost (e.g. the previous process was killed while streaming LED data, leaving the EXP board mid-message).

`send_and_wait_for_response_processed()` puts the `asyncio.wait_for()` timeout around the wrong await:

* `send_and_wait_for_response()` does **not** wait for the response — it awaits the send-queue gate, queues the message via a non-blocking `put_nowait`, and returns. So `wait_for(..., timeout=1)` virtually always completes instantly and **the timeout guards nothing**.
* The *actual* wait is the final `await self.done_waiting.wait()`, which has **no timeout**. If the response never arrives, it awaits forever, silently. The retry loop is effectively unreachable, and even if it fired the resend would deadlock (the gating events are still pending from the lost response).

## Fix

* Move the timeout onto `done_waiting.wait()` — the wait that actually corresponds to the board's response.
* On timeout, release the gating state (`_resume_sending()` + `no_response_waiting.set()`) before resending, so the retry doesn't deadlock in `send_and_wait_for_response()`.
* Raise `AssertionError` (naming the port and message) when retries are exhausted, instead of hanging.
* Bump default `max_retries` from `0` to `3`. Every message on this path (`ID@`, `BR@`, `NN:`, `SA:`, driver configs) is idempotent, so a single lost response shouldn't be fatal even with the timeout fixed.

Related: #1900 fixed the same kind of dead retry path in the port detector.

## Tests

`mpf/tests/test_Fast_Communicator.py` — drives `send_and_wait_for_response_processed()` with a stubbed I/O surface:
* `test_returns_when_response_processed` (happy path, exactly one send)
* `test_raises_instead_of_hanging_when_no_response` (retries then raises; asserts 4 sends fired — the retry path is now live — and never hangs)
* `test_unlimited_retries_eventually_succeed` (`max_retries=-1`, used by `ID:` polls, succeeds once the board finally answers)

All new tests plus the full existing FAST suite pass.

Verified locally (0.80.0, FAST Neuron): the every-other-run freeze is gone across repeated boot cycles, including immediately after hard kills with the LED stream active.

## Follow-up: clear leftover serial bytes so the reply isn't lost in the first place

The timeout/retry above converts a silent hang into a loud failure, but it surfaced a second, related cause from the same unclean-shutdown scenario — and here the board **does** answer; the reply is just lost on our side.

After a hard kill mid LED-blast, the board or OS buffer can still hold a burst of leftover bytes with **no trailing `<CR>`**. `reset_input_buffer()` only flushes what was buffered at that instant; bytes still draining over USB arrive just afterwards and fuse onto the front of the next real message — `<junk>ID:exp ...`. Because messages are framed on `<CR>`, the junk and the genuine reply become one segment, which then either:

* fails to UTF-8 decode → raises and kills `read_task` (with `ignore_decode_errors` False during init), or
* dispatches with a junk 3-char header → the real reply is silently dropped.

Either way the handshake reply is lost and we fall into the timeout/retry path even though the board responded.

Two fixes (commit `5aafaff8d`):

* `_drain_serial()` — before starting the read loop, read and discard inbound bytes until the stream is quiet for 100 ms (capped at 2 s total). The leftover burst is finite, so this clears it and the handshake reply arrives clean. Root-cause fix.
* `_resync_segment()` — when a segment fails to decode, scan for the earliest registered message header and dispatch from there instead of dropping the segment or raising. Recovers a real message fused onto the tail of junk; defense-in-depth for junk that fuses in the same read after init.

Covered by the existing FAST integration suites (Exp / Neuron / Nano / Retro etc.), which exercise `connect()` and the parse path during board init. Full FAST suite passes.
