### PR TITLE
add configs for neoseg displays on fast exp light control hardware

### DIFF
--- a/docs/dev/Send variables via self.machine.events.post.rst
+++ b/docs/dev/Send variables via self.machine.events.post.rst
@@ -6,7 +6,7 @@ http://developer.missionpinball.org/en/dev/api/self.machine.events.html?highligh
 
 The best example here is to use the communication between MPF and MPF MC.
 MPF MC can pretty much only read variables from ``self.player`` from MPF (``self.mc.player`` in MC),  however you simply don't want
-to create extra variables in here just to make it readable readable in MC. This would result in having to much unnecessary data. 
+to create extra variables in here just to make it readable readable in MC. This would result in having to much unnecessary data.
 Instead you can use ``self.machine.events.post`` just like you would write a function in python.
 
 For example we set this up in a mode code in MPF:
@@ -21,7 +21,7 @@ It should always start with the ``event`` that you want to post. After this you 
 In MC code we create a function that will be activated once the event is posted. Make sure you have added a event_handler first or else it won't work.
 
 .. code-block:: python
-    
+
   def awesome_event(self, data1, data2, **kwargs):
     print("i really love the game {} I always end up {}".format(data1, data2)
 

--- a/docs/overview/installation.rst
+++ b/docs/overview/installation.rst
@@ -47,8 +47,8 @@ In order to build the developer documentation, you will also need:
 * ``sphinxcontrib.napoleon``
 * ``gitpython``
 
-Building the developer documentation requires a symbolic link from ``mpf\docs\examples`` to a checkout of the ``mpf-examples`` repository. 
-This is normally automatically created when the documentation is built, but under Windows 10 and higher, symlinks can only be created by 
-administrators, so the process will fail. If you would prefer not to run the build as an administrator, you can create the link manually 
+Building the developer documentation requires a symbolic link from ``mpf\docs\examples`` to a checkout of the ``mpf-examples`` repository.
+This is normally automatically created when the documentation is built, but under Windows 10 and higher, symlinks can only be created by
+administrators, so the process will fail. If you would prefer not to run the build as an administrator, you can create the link manually
 by running ``mklink /d examples <examples directory>`` at the command line from inside the ``docs`` directory.
 

--- a/docs/testing/running_mpf_tests.rst
+++ b/docs/testing/running_mpf_tests.rst
@@ -14,8 +14,8 @@ test that's run), and then when it's done, you should see a message showing
 how many tests were run and that they were successful. The whole process should
 take less a minute or so.
 
-Note that ``mpf-mc`` must be installed as well as ``mpf`` for all tests to run. 
-If it isn't, some tests will fail with the error "start took more than 20s", because 
+Note that ``mpf-mc`` must be installed as well as ``mpf`` for all tests to run.
+If it isn't, some tests will fail with the error "start took more than 20s", because
 MPF waited endlessly for the nonexistent media controller to be available.
 
 (If you see any messages about some tests taking more than 0.5s, that's ok.)

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -834,7 +834,7 @@ neoseg_displays:
     number_template: single|str|None
     start_x: single|float|None
     start_y: single|float|None
-    size: single|enum(2digit,8digit)|8digit
+    size: single|enum(2digit,8digit,2digit-rg-swapped,8digit-rg-swapped)|8digit
     light_template: single|subconfig(lights,device)|
 lights:
     __valid_in__: machine

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -544,7 +544,7 @@ fast:
     __type__: config
     net: single|subconfig(fast_net)|None
     exp: single|subconfig(fast_exp)|None
-    exp_int: single|subconfig(fast_exp)|None    
+    exp_int: single|subconfig(fast_exp)|None
     aud: single|subconfig(fast_aud)|None
     seg: single|subconfig(fast_seg)|None
     dmd: single|subconfig(fast_dmd)|None

--- a/mpf/devices/light_group.py
+++ b/mpf/devices/light_group.py
@@ -14,6 +14,21 @@ from mpf.core.system_wide_device import SystemWideDevice
 from mpf.devices.light import Light
 
 
+NEOSEG_8DIGIT_ORDER = [
+    95, 90, 93, 82, 85, 89, 86, 91, 88, 87, 81, 92, 83, 84, 94,
+    104, 76, 79, 96, 99, 103, 100, 77, 102, 101, 75, 78, 97, 98, 80,
+    110, 105, 108, 67, 70, 74, 71, 106, 73, 72, 66, 107, 68, 69, 109,
+    119, 61, 64, 111, 114, 118, 115, 62, 117, 116, 60, 63, 112, 113, 65,
+    5, 0, 3, 52, 55, 59, 56, 1, 58, 57, 51, 2, 53, 54, 4,
+    14, 46, 49, 6, 9, 13, 10, 47, 12, 11, 45, 48, 7, 8, 50,
+    20, 15, 18, 37, 40, 44, 41, 16, 43, 42, 36, 17, 38, 39, 19,
+    29, 31, 34, 21, 24, 28, 25, 32, 27, 26, 30, 33, 22, 23, 35]
+
+NEOSEG_2DIGIT_ORDER = [
+    5, 0, 3, 22, 25, 29, 26, 1, 28, 27, 21, 2, 23, 24, 4,
+    14, 16, 19, 6, 9, 13, 10, 17, 12, 11, 15, 18, 7, 8, 20]
+
+
 class LightGroup(SystemWideDevice):
 
     """An abstract group of lights."""
@@ -92,25 +107,41 @@ class LightGroup(SystemWideDevice):
         for light in self.lights:
             light.color(color, fade_ms, priority, key)
 
+    def _swap_grb_rgb_channel_offsets(self, offsets):
+        """Swap every first and second out of sets of three (GRB->RGB)."""
+        adjustments = {0: 1, 1: -1, 2: 0}
+        return [
+            x + adjustments[x % 3]
+            for x in offsets
+        ]
+
     def _reorder_lights(self):
         if self.config['size'] == '8digit':
             #Magic order for 8 digit NeoSeg displays from CobraPin
-            order = [95, 90, 93, 82, 85, 89, 86, 91, 88, 87, 81, 92, 83, 84, 94,
-                     104, 76, 79, 96, 99, 103, 100, 77, 102, 101, 75, 78, 97, 98, 80,
-                     110, 105, 108, 67, 70, 74, 71, 106, 73, 72, 66, 107, 68, 69, 109,
-                     119, 61, 64, 111, 114, 118, 115, 62, 117, 116, 60, 63, 112, 113, 65,
-                     5, 0, 3, 52, 55, 59, 56, 1, 58, 57, 51, 2, 53, 54, 4,
-                     14, 46, 49, 6, 9, 13, 10, 47, 12, 11, 45, 48, 7, 8, 50,
-                     20, 15, 18, 37, 40, 44, 41, 16, 43, 42, 36, 17, 38, 39, 19,
-                     29, 31, 34, 21, 24, 28, 25, 32, 27, 26, 30, 33, 22, 23, 35]
+            order = NEOSEG_8DIGIT_ORDER
+
         elif self.config['size'] == '2digit':
             #Magic order for 2 digit NeoSeg displays from CobraPin
-            order = [5, 0, 3, 22, 25, 29, 26, 1, 28, 27, 21, 2, 23, 24, 4,
-                     14, 16, 19, 6, 9, 13, 10, 17, 12, 11, 15, 18, 7, 8, 20]
+            order = NEOSEG_2DIGIT_ORDER
+
+        elif self.config['size'] == '8digit-rg-swapped':
+            #Magic order for 8 digit NeoSeg displays from CobraPin when platform numbering uses RGB channel order
+            order = self._swap_grb_rgb_channel_offsets(NEOSEG_8DIGIT_ORDER)
+
+        elif self.config['size'] == '2digit-rg-swapped':
+            #Magic order for 2 digit NeoSeg displays from CobraPin when platform numbering uses RGB channel order
+            order = self._swap_grb_rgb_channel_offsets(NEOSEG_2DIGIT_ORDER)
         else:
             order = range(0, len(self.lights))
 
-        self.lights = [self.lights[i] for i in order]
+        mapped_lights = []
+        try:
+            for i in order:
+                mapped_lights.append(self.lights[i])
+            self.lights = mapped_lights
+        except IndexError:
+            self.error_log("Attempted to use light index %s but source list only had %s items", i, len(self.lights))
+            raise
 
     def wait_for_loaded(self):
         """Return future."""
@@ -180,11 +211,12 @@ class NeoSegDisplay(LightGroup):
     __slots__ = []  # type: List[str]
 
     def _create_lights(self):
-        if self.config['size'] == '8digit':
+        if self.config['size'] in ('8digit', '8digit-rg-swapped'):
             count = 120
-        elif self.config['size'] == '2digit':
+        elif self.config['size'] in ('2digit', '2digit-rg-swapped'):
             count = 30
         else:
+            self.warning_log("NeoSegDisplay %s could not determine number of lights to create.", self.name)
             count = 0
 
         for index in range(self.config['number_start'], self.config['number_start'] + count):

--- a/mpf/platforms/virtual_pinball/virtual_pinball.py
+++ b/mpf/platforms/virtual_pinball/virtual_pinball.py
@@ -160,7 +160,7 @@ class VirtualPinballPlatform(LightsPlatform, SwitchPlatform, DriverPlatform, Seg
 
     """VPX platform."""
 
-    __slots__ = ["_lights", "_switches", "_drivers", "_last_drivers", "_last_lights", 
+    __slots__ = ["_lights", "_switches", "_drivers", "_last_drivers", "_last_lights",
                  "_started", "rules", "_configured_segment_displays", "_last_segment_text"]
 
     def __init__(self, machine):

--- a/mpf/tests/machine_files/auditor/config/config.yaml
+++ b/mpf/tests/machine_files/auditor/config/config.yaml
@@ -6,7 +6,7 @@ game:
 player_vars:
     score:
         initial_value: 0
-    my_var: 
+    my_var:
         initial_value: 0
 
 auditor:

--- a/mpf/tests/machine_files/light/config/light_groups.yaml
+++ b/mpf/tests/machine_files/light/config/light_groups.yaml
@@ -50,3 +50,15 @@ neoseg_displays:
     light_template:
       type: w
       subtype: led
+  neoSeg_2:
+    start_channel: 0-1-0
+    size: 8digit-rg-swapped
+    light_template:
+      type: w
+      subtype: led
+  neoSeg_3:
+    start_channel: 0-1-120
+    size: 2digit-rg-swapped
+    light_template:
+      type: w
+      subtype: led

--- a/mpf/tests/machine_files/service_mode/config/config.yaml
+++ b/mpf/tests/machine_files/service_mode/config/config.yaml
@@ -67,7 +67,7 @@ lights:
 #   tracks:
 #     sfx: []
 #   enabled: true
-# 
+#
 # keyboard:
 #     right:
 #         switch: s_service_enter

--- a/mpf/tests/test_LightGroups.py
+++ b/mpf/tests/test_LightGroups.py
@@ -20,8 +20,7 @@ class TestLightGroups(MpfTestCase):
         self.assertLightColor("stripe1_light_3", "red")
         self.assertLightColor("stripe1_light_4", "red")
 
-    def test_config(self):
-        # stripe 1
+    def test_config_stripe_1(self):
         self.assertEqual("led-10-r", self.machine.lights["stripe1_light_0"].hw_drivers["red"][0].number)
         self.assertListEqual(["test", "stripe1"], self.machine.lights["stripe1_light_0"].config['tags'])
         self.assertEqual("led-11-r", self.machine.lights["stripe1_light_1"].hw_drivers["red"][0].number)
@@ -30,7 +29,7 @@ class TestLightGroups(MpfTestCase):
         self.assertEqual("led-14-r", self.machine.lights["stripe1_light_4"].hw_drivers["red"][0].number)
         self.assertListEqual(["test", "stripe1"], self.machine.lights["stripe1_light_4"].config['tags'])
 
-        # stripe 2
+    def test_config_stripe_2(self):
         self.assertEqual("led-7-200-r", self.machine.lights["stripe2_light_0"].hw_drivers["red"][0].number)
         self.assertEqual(10, self.machine.lights["stripe2_light_0"].config['x'])
         self.assertEqual(20, self.machine.lights["stripe2_light_0"].config['y'])
@@ -38,17 +37,14 @@ class TestLightGroups(MpfTestCase):
         self.assertEqual(15, self.machine.lights["stripe2_light_1"].config['x'])
         self.assertEqual(20, self.machine.lights["stripe2_light_1"].config['y'])
 
-        # stripe 3
+    def test_config_stripe_3(self):
         self.assertEqual("led-ABC-123", self.machine.lights["stripe3_light_0"].hw_drivers["red"][0].number)
         self.assertEqual("led-ABC-123+1", self.machine.lights["stripe3_light_0"].hw_drivers["green"][0].number)
-        self.assertEqual("led-ABC-123+2",
-                         self.machine.lights["stripe3_light_0"].hw_drivers["blue"][0].number)
-        self.assertEqual("led-ABC-123+3",
-                         self.machine.lights["stripe3_light_0"].hw_drivers["white"][0].number)
-        self.assertEqual("led-ABC-123+4",
-                         self.machine.lights["stripe3_light_1"].hw_drivers["red"][0].number)
+        self.assertEqual("led-ABC-123+2", self.machine.lights["stripe3_light_0"].hw_drivers["blue"][0].number)
+        self.assertEqual("led-ABC-123+3", self.machine.lights["stripe3_light_0"].hw_drivers["white"][0].number)
+        self.assertEqual("led-ABC-123+4", self.machine.lights["stripe3_light_1"].hw_drivers["red"][0].number)
 
-        # ring 1
+    def test_config_rings(self):
         self.assertEqual("led-20-r", self.machine.lights["ring1_light_0"].hw_drivers["red"][0].number)
         self.assertEqual("led-21-r", self.machine.lights["ring1_light_1"].hw_drivers["red"][0].number)
         self.assertEqual("led-22-r", self.machine.lights["ring1_light_2"].hw_drivers["red"][0].number)
@@ -67,13 +63,18 @@ class TestLightGroups(MpfTestCase):
         self.assertEqual(100, self.machine.lights["ring1_light_9"].config['x'])
         self.assertEqual(53, self.machine.lights["ring1_light_9"].config['y'])
 
-        # neoSeg_0
+    def test_config_neoSeg_0(self):  # 8 digit
         self.assertEqual("led-0-0-0", self.machine.lights["neoSeg_0_light_0"].hw_drivers["white"][0].number)
         self.assertEqual("led-0-0-0+1", self.machine.lights["neoSeg_0_light_1"].hw_drivers["white"][0].number)
         self.assertEqual("led-0-0-0+2", self.machine.lights["neoSeg_0_light_2"].hw_drivers["white"][0].number)
         self.assertEqual("neoSeg_0_light_119", self.machine.lights["neoSeg_0_light_119"].name)
-        # sanity check order...not 100%
+
         self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[0].name, self.machine.lights["neoSeg_0_light_95"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[1].name, self.machine.lights["neoSeg_0_light_90"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[2].name, self.machine.lights["neoSeg_0_light_93"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[3].name, self.machine.lights["neoSeg_0_light_82"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[4].name, self.machine.lights["neoSeg_0_light_85"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[5].name, self.machine.lights["neoSeg_0_light_89"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[20].name, self.machine.lights["neoSeg_0_light_103"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[40].name, self.machine.lights["neoSeg_0_light_66"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[60].name, self.machine.lights["neoSeg_0_light_5"].name)
@@ -81,12 +82,12 @@ class TestLightGroups(MpfTestCase):
         self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[100].name, self.machine.lights["neoSeg_0_light_36"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_0"].lights[119].name, self.machine.lights["neoSeg_0_light_35"].name)
 
-        # neoSeg_1
+    def test_config_neoSeg_1(self):  # 2 digit
         self.assertEqual("led-0-0-120", self.machine.lights["neoSeg_1_light_0"].hw_drivers["white"][0].number)
         self.assertEqual("led-0-0-120+1", self.machine.lights["neoSeg_1_light_1"].hw_drivers["white"][0].number)
         self.assertEqual("led-0-0-120+2", self.machine.lights["neoSeg_1_light_2"].hw_drivers["white"][0].number)
         self.assertEqual("neoSeg_1_light_29", self.machine.lights["neoSeg_1_light_29"].name)
-        # sanity check order...not 100%
+
         self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[0].name, self.machine.lights["neoSeg_1_light_5"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[5].name, self.machine.lights["neoSeg_1_light_29"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[10].name, self.machine.lights["neoSeg_1_light_21"].name)
@@ -94,3 +95,34 @@ class TestLightGroups(MpfTestCase):
         self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[20].name, self.machine.lights["neoSeg_1_light_13"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[25].name, self.machine.lights["neoSeg_1_light_15"].name)
         self.assertEqual(self.machine.neoseg_displays["neoSeg_1"].lights[29].name, self.machine.lights["neoSeg_1_light_20"].name)
+
+    def test_config_neoSeg_2(self):  # 8 digit on rgb-ordered channels
+        self.assertEqual("led-0-1-0", self.machine.lights["neoSeg_2_light_0"].hw_drivers["white"][0].number)
+        self.assertEqual("led-0-1-0+1", self.machine.lights["neoSeg_2_light_1"].hw_drivers["white"][0].number)
+        self.assertEqual("neoSeg_2_light_119", self.machine.lights["neoSeg_2_light_119"].name)
+
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[0].name, self.machine.lights["neoSeg_2_light_95"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[1].name, self.machine.lights["neoSeg_2_light_91"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[2].name, self.machine.lights["neoSeg_2_light_94"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[3].name, self.machine.lights["neoSeg_2_light_81"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[4].name, self.machine.lights["neoSeg_2_light_84"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[5].name, self.machine.lights["neoSeg_2_light_89"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[20].name, self.machine.lights["neoSeg_2_light_102"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[40].name, self.machine.lights["neoSeg_2_light_67"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[60].name, self.machine.lights["neoSeg_2_light_5"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[80].name, self.machine.lights["neoSeg_2_light_12"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[100].name, self.machine.lights["neoSeg_2_light_37"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_2"].lights[119].name, self.machine.lights["neoSeg_2_light_35"].name)
+
+    def test_config_neoSeg_3(self):  # 2 digit on rgb-ordered channels
+        self.assertEqual("led-0-1-120", self.machine.lights["neoSeg_3_light_0"].hw_drivers["white"][0].number)
+        self.assertEqual("led-0-1-120+1", self.machine.lights["neoSeg_3_light_1"].hw_drivers["white"][0].number)
+        self.assertEqual("neoSeg_3_light_29", self.machine.lights["neoSeg_3_light_29"].name)
+
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_3"].lights[0].name, self.machine.lights["neoSeg_3_light_5"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_3"].lights[5].name, self.machine.lights["neoSeg_3_light_29"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_3"].lights[10].name, self.machine.lights["neoSeg_3_light_22"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_3"].lights[15].name, self.machine.lights["neoSeg_3_light_14"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_3"].lights[20].name, self.machine.lights["neoSeg_3_light_12"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_3"].lights[25].name, self.machine.lights["neoSeg_3_light_16"].name)
+        self.assertEqual(self.machine.neoseg_displays["neoSeg_3"].lights[29].name, self.machine.lights["neoSeg_3_light_20"].name)

--- a/mpf/tests/test_LightNumbering.py
+++ b/mpf/tests/test_LightNumbering.py
@@ -14,8 +14,7 @@ class TestLightNumbering(MpfTestCase):
         led1 = self.machine.lights["first"]
         led2 = self.machine.lights["second"]
         led3 = self.machine.lights["third"]
-        led4 = self.machine.lights["fourth"]       
-
+        led4 = self.machine.lights["fourth"]
 
         self.assertEqual(led1.hw_drivers["green"][0].number,"led-0-0-0")
         self.assertEqual(led1.hw_drivers["red"][0].number,"led-0-0-0+1")

--- a/mpf/tests/test_RandomEventPlayer.py
+++ b/mpf/tests/test_RandomEventPlayer.py
@@ -100,17 +100,17 @@ class TestRandomEventPlayerBase():
             self.runner.advance_time_and_run()
             self.runner.assertNotEqual(self.prevEvent, self.lastEvent)
             self.runner.assertEqual(self.lastEvent, self.events[expectedIdx])
-    
+
     def _test_conditional_random(self):
         self._reset()
-        
+
         # Only one event is true
         results = list()
         for x in range(RANDOM_RUNS):
             self.runner.post_event("test_{}_conditional_random".format(self.scope))
             self.runner.advance_time_and_run()
             self.assertEqual(RANDOM_RUNS, results.count('event1'))
-        
+
         # Conditional event kwarg is true
         results = list()
         for x in range(RANDOM_RUNS):

--- a/tools/smart_matrix_dmd_teensy_code/smart_matrix_dmd_teensy_code.ino
+++ b/tools/smart_matrix_dmd_teensy_code/smart_matrix_dmd_teensy_code.ino
@@ -53,7 +53,7 @@ void setup() {
   matrix.begin();
 
   matrix.setBrightness(defaultBrightness);
-  
+
   // clear screen
   backgroundLayer.fillScreen(defaultBackgroundColor);
   backgroundLayer.swapBuffers();
@@ -67,7 +67,7 @@ void loop() {
   char* buffer = (char*)backgroundLayer.backBuffer();
   int bytesAvail = Serial.available();
   boolean swap = false;
-  
+
   if ((bytesAvail > 1) && (dataPos > 0))
   {
     if (bytesAvail > dataExpected) bytesAvail = dataExpected;


### PR DESCRIPTION
I'm not convinced that being on FAST is what causes the channel order to be different. I'll check with Cobra and also maybe wire up my Cobrapin controller to see if it's the controller or the segment unit.