### PR TITLE
FAST: don't crash the serial reader on an undecodable message

### DIFF
--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -441,9 +441,14 @@ class FastSerialCommunicator(LogMixin):
                 if self.machine.is_shutting_down:
                     return
 
-                self.log.warning("Interference / bad data received: %s", msg)
+                # Line noise or leftover binary can appear mid-stream (e.g. a
+                # board left mid-message by an unclean shutdown, fusing junk onto
+                # a real reply). Drop the corrupted segment and keep reading
+                # rather than raising, which would kill read_task and crash MPF.
+                # The send/confirmation path re-requests anything genuinely lost.
                 if not self.ignore_decode_errors:
-                    raise
+                    self.log.warning("Interference / bad data received, dropping: %s", msg)
+                continue
 
             if self.port_debug:
                 self.log.info("<<<< %s", msg)

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -446,8 +446,8 @@ class FastSerialCommunicator(LogMixin):
                 # a real reply). Drop the corrupted segment and keep reading
                 # rather than raising, which would kill read_task and crash MPF.
                 # The send/confirmation path re-requests anything genuinely lost.
-                if not self.ignore_decode_errors:
-                    self.log.warning("Interference / bad data received, dropping: %s", msg)
+                # Always warn so the underlying noise stays visible for debugging.
+                self.log.warning("Interference / bad data received, dropping: %s", msg)
                 continue
 
             if self.port_debug:

--- a/mpf/tests/test_Fast_Communicator.py
+++ b/mpf/tests/test_Fast_Communicator.py
@@ -1,7 +1,7 @@
 # mpf.tests.test_Fast_Communicator
 """Unit tests for FastSerialCommunicator's response and connect/parse paths.
 
-Two related FAST startup failures are covered here:
+Three related FAST startup failures are covered here:
 
 * Response timeout/retry (#2036): a single lost serial response used to freeze
   MPF init forever, because the asyncio timeout was wrapped around
@@ -9,9 +9,12 @@ Two related FAST startup failures are covered here:
   immediately) while the real wait on done_waiting had no timeout.
 * Connect-time drain: after an unclean shutdown the board can clock out
   leftover, un-terminated bytes that would otherwise fuse onto the front of the
-  next real message. connect() drains that burst before the handshake; the
-  parser itself still raises (or drops, when decode errors are ignored) on
-  undecodable data rather than guessing at it.
+  next real message. connect() drains that burst before the handshake.
+* Undecodable data mid-stream (#2051): a UnicodeDecodeError in
+  parse_incoming_raw_bytes used to be re-raised after connect, which kills
+  read_task via its raise_exceptions done-callback and crashes MPF whenever
+  line noise or leftover binary fuses onto a real reply. The parser now drops
+  the corrupted segment (with a warning) and keeps reading.
 
 These drive the relevant methods directly with a stubbed I/O surface so the
 paths are exercised deterministically without a real serial port.
@@ -148,16 +151,19 @@ class TestFastCommunicatorRetry(unittest.TestCase):
 
 class TestFastCommunicatorInbound(unittest.TestCase):
 
-    def test_parse_raises_on_undecodable_data(self):
-        """Un-decodable data raises during init (ignore_decode_errors False), so
-        a board in a bad state surfaces loudly instead of being guessed at."""
+    def test_drops_undecodable_data_and_keeps_reading(self):
+        """A corrupted segment is dropped rather than raised, so a single noisy
+        read can't kill the read loop (which would crash MPF). A following valid
+        message in the same buffer is still dispatched."""
         comm = _make_comm()
         comm.ignore_decode_errors = False
-        comm.message_processors = {'ID:': lambda m: None}
-        with self.assertRaises(UnicodeDecodeError):
-            comm.parse_incoming_raw_bytes(b'\x81\xb5\xc1\r')
+        received = []
+        comm.message_processors = {'ID:': received.append}
+        # junk fused onto an ER:P reply, then a clean ID: response
+        comm.parse_incoming_raw_bytes(b'\x825\xffER:P\rID:exp fp-exp-0081 0.48\r')
+        self.assertEqual(received, ['exp fp-exp-0081 0.48'])
 
-    def test_parse_drops_undecodable_data_when_ignoring(self):
+    def test_drops_undecodable_data_when_ignoring(self):
         """With ignore_decode_errors set (e.g. during connect), undecodable
         data is dropped rather than raised."""
         comm = _make_comm()


### PR DESCRIPTION
## Problem

When MPF receives an undecodable serial segment after connect, `parse_incoming_raw_bytes()` re-raises the `UnicodeDecodeError` (since `ignore_decode_errors` is `False` post-connect). That exception propagates out of `_socket_reader` and, via the `read_task`'s `Util.raise_exceptions` done-callback, **crashes MPF**.

This happens when line noise or leftover binary fuses onto the front of a real reply — e.g. octo hit it mid-init during the EXP `ER@` light-config block, where `b'\x82\x35\xffER:P'` (junk + a real `ER:P`) failed to decode and took the whole process down:

```
WARNING : FAST [EXP] : Interference / bad data received: b'\x825\xffER:P'
...
  File ".../fast/communicators/base.py", line 360, in parse_incoming_raw_bytes
    msg = msg.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x82 in position 0: invalid start byte
```

## Fix

Drop the corrupted segment and keep reading instead of re-raising, so a single noisy read can't kill the reader. The send/confirmation path re-requests anything genuinely lost. Unexpected (non-ignored) junk is still logged as a warning so it stays visible.

## Tests

`mpf/tests/test_Fast_Communicator.py` drives `parse_incoming_raw_bytes()` directly: a corrupted segment is dropped and a following valid message in the same buffer is still dispatched (i.e. the read loop survives); junk during the connect window is dropped quietly. Full FAST suite passes.

## Relationship to #2043

Independent of #2043 (this crash reproduces on released dev2, without it) and touches a different code path, so it can land on its own. Heads up: #2043 also adds a `test_Fast_Communicator.py` (covering the timeout/retry + drain work). Whichever merges second, I'll reconcile the two test files — they're both mine and the merge is trivial.
