### PR TITLE
Conditional-only handler cleanup

### DIFF
--- a/mpf/core/events.py
+++ b/mpf/core/events.py
@@ -458,6 +458,8 @@ class EventManager(MpfController):
                                                              _future=future,
                                                              _keys=keys,
                                                              event=event_name)))
+
+        future.add_done_callback(lambda f: [self.remove_handler_by_key(k) for k in keys])
         return future
 
     def _wait_handler(self, _future: asyncio.Future, _keys: List[EventHandlerKey], **kwargs):

--- a/mpf/core/placeholder_manager.py
+++ b/mpf/core/placeholder_manager.py
@@ -4,7 +4,7 @@ import string
 import asyncio
 import operator as op
 import abc
-from functools import lru_cache
+from functools import lru_cache, partial
 
 import re
 from typing import Tuple, List, Any, Union
@@ -860,7 +860,27 @@ class BasePlaceholderManager(MpfController):
             subscriptions.append(self.machine.wait_for_stop())
             future = Util.any(subscriptions)
         future = asyncio.ensure_future(future)
+
+        future.add_done_callback(
+            partial(self._cleanup_placeholder_subscriptions, subscriptions=subscriptions)
+        )
         return value, future
+
+    def _cleanup_placeholder_subscriptions(self, future, subscriptions):
+        """Cancel child placeholder subscriptions when the parent template frame finishes."""
+        del future
+
+        for sub in subscriptions:
+            if isinstance(sub, asyncio.Future):
+                if not sub.done():
+                    # Cancel outstanding asyncio Future/Task instance
+                    sub.cancel()
+            elif asyncio.iscoroutine(sub):
+                try:
+                    # close raw coroutines (like sleep)
+                    sub.close()
+                except RuntimeWarning:
+                    pass
 
     @lru_cache(typed=True)
     def parse_conditional_template(self, template, default_number=None):

--- a/mpf/tests/machine_files/event_manager/config/test_event_manager.yaml
+++ b/mpf/tests/machine_files/event_manager/config/test_event_manager.yaml
@@ -7,6 +7,7 @@ event_player:
     test_event_player_delayed:
         - test_event_player2|2s
         - test_event_player3:2s
+    "{current_player.score>=999999999}": never_happens
 
 random_event_player:
     test_random_event_player1:

--- a/mpf/tests/machine_files/event_manager/config/test_event_manager.yaml
+++ b/mpf/tests/machine_files/event_manager/config/test_event_manager.yaml
@@ -7,7 +7,12 @@ event_player:
     test_event_player_delayed:
         - test_event_player2|2s
         - test_event_player3:2s
-    "{current_player.score>=999999999}": never_happens
+    "{machine.lifetime_earnings >= 500}": never_happens_machine
+    "{machine.switches.s_test_1.state == 1}": sometimes_happens_switch
+
+switches:
+    s_test_1:
+        number:
 
 random_event_player:
     test_random_event_player1:

--- a/mpf/tests/machine_files/event_manager/modes/game_mode/config/game_mode.yaml
+++ b/mpf/tests/machine_files/event_manager/modes/game_mode/config/game_mode.yaml
@@ -3,6 +3,11 @@ mode:
   start_events: game_mode_start
   stop_events: game_mode_end
 
+event_player:
+    "{players[0].score>=99999999}": never_happens_players
+    "{current_player.score>=999999999}": never_happens_player
+    "{current_player.score<=current_player.score + 1 and current_player.score > -1}": always_happens_multiple_ast
+
 random_event_player:
     test_random_event_player_mode2:
         - out1

--- a/mpf/tests/test_EventManager.py
+++ b/mpf/tests/test_EventManager.py
@@ -915,20 +915,45 @@ class TestEventManager(MpfFakeGameTestCase, MpfTestCase):
 
     def test_handler_cleanup_on_variable_change(self):
         self.start_game()
+        self.machine.events.post('game_mode_start')
+        self.advance_time_and_run(0.01)
 
-        # This method forces the framework into its broken subscription loop
-        # It needs a callback function to trigger when the condition changes
-        def dummy_callback(*args, **_kwargs):
-            pass
+        initial_count_pte = len(self.machine.events.registered_handlers['player_turn_ended'])
+        initial_count_player_added = len(self.machine.events.registered_handlers['player_added'])
 
-        # Setup a condition-only subscription or segment display update
-        initial_count = len(self.machine.events.registered_handlers['player_turn_ended'])
-
-        # Simulate high frequency score churn
         for i in range(100):
             self.machine.game.player.score += 100
             self.advance_time_and_run(0.01)
 
-        # Assert that the handler count has not ballooned
-        final_count = len(self.machine.events.registered_handlers['player_turn_ended'])
+        final_count_pte = len(self.machine.events.registered_handlers['player_turn_ended'])
+        final_count_player_added = len(self.machine.events.registered_handlers['player_added'])
+        self.assertEqual(initial_count_pte, final_count_pte)
+        self.assertEqual(initial_count_player_added, final_count_player_added)
+
+    def test_handler_cleanup_on_machine_variable_change(self):
+        self.start_game()
+        self.advance_time_and_run(0.01)
+
+        event_name = 'machine_var_lifetime_earnings'
+        initial_count = len(self.machine.events.registered_handlers.get(event_name, []))
+
+        for i in range(100):
+            self.machine.variables.set_machine_var('lifetime_earnings', 10 + i)
+            self.advance_time_and_run(0.01)
+
+        final_count = len(self.machine.events.registered_handlers.get(event_name, []))
+        self.assertEqual(initial_count, final_count)
+
+    def test_handler_cleanup_on_switch_state_change(self):
+        self.start_game()
+        self.advance_time_and_run(0.01)
+
+        event_name = 'switch_s_test_1_active'
+        initial_count = len(self.machine.events.registered_handlers.get(event_name, []))
+
+        for _ in range(50):
+            self.hit_switch_and_run('s_test_1', 0.01)
+            self.release_switch_and_run('s_test_1', 0.01)
+
+        final_count = len(self.machine.events.registered_handlers.get(event_name, []))
         self.assertEqual(initial_count, final_count)

--- a/mpf/tests/test_EventManager.py
+++ b/mpf/tests/test_EventManager.py
@@ -912,3 +912,23 @@ class TestEventManager(MpfFakeGameTestCase, MpfTestCase):
         # invalid space
         with self.assertRaises(ValueError):
             self.machine.events.add_handler("event_name {machine.variables.test}", self._handler)
+
+    def test_handler_cleanup_on_variable_change(self):
+        self.start_game()
+
+        # This method forces the framework into its broken subscription loop
+        # It needs a callback function to trigger when the condition changes
+        def dummy_callback(*args, **_kwargs):
+            pass
+
+        # Setup a condition-only subscription or segment display update
+        initial_count = len(self.machine.events.registered_handlers['player_turn_ended'])
+
+        # Simulate high frequency score churn
+        for i in range(100):
+            self.machine.game.player.score += 100
+            self.advance_time_and_run(0.01)
+
+        # Assert that the handler count has not ballooned
+        final_count = len(self.machine.events.registered_handlers['player_turn_ended'])
+        self.assertEqual(initial_count, final_count)


### PR DESCRIPTION
Conditional-only event listeners attach to their relevant AST
nodes for player variables or other variables as appropriate.
Specifically with player-related bindings, additional subscriptions
are made to player turn rotation events, to cancel the future and dump
the handler.

The issue is that with these several subscriptions, only one will ever
occur, and the others need to be cleaned up. This is addressed by
adding cancellation signals to the unused hooks when the parent
future is done.

```yaml
event_player:
  {current_player.score > 0 and current_player.score < 10000}: keep_going
```
So in this example, every time the player's score changes, _two_ subscriptions to the current player's score player variable change event are made, as well as two subscriptions to player turn rotation events (to ensure the listeners are cleaned up if unused.)

The fix is that any of the subscribed events should cause the rest to cancel, so that futures arent left waiting around until the ball end turn rotation catches up to them.

Note that this PR does NOT fix that the above example binds to current_player.score two times. It's weird, but it also doesn't multi-trigger the handler, so it's only as bad as the number of times a dev repeats the same variable in the same conditional hook line.