### PR TITLE
Add DC motor support with FAST and Virtual implementations

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -311,6 +311,18 @@ coils:
 custom_code:
     __valid_in__: machine
     __type__: list
+dc_motors:
+    __valid_in__: machine
+    __type__: device
+    default_power: single|float|0.0
+    number: single|str|
+    control_events: dict|str:subconfig(dc_motors_pulse_settings)|None
+    platform: single|str|None
+    platform_settings: single|dict|None
+dc_motors_pulse_settings:
+    action: single|enum(pulse,stop)|pulse
+    power: single|float|None
+    duration: single|template_secs|None
 digital_outputs:
     __valid_in__: machine
     __type__: device
@@ -736,6 +748,7 @@ hardware:
     i2c: list|str|default
     stepper_controllers: list|str|default
     shaker_controllers: list|str|default
+    motor_controllers: list|str|default
     hardware_sound_system: list|str|default
 hardware_sound_systems:
     __valid_in__: machine

--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -320,7 +320,7 @@ dc_motors:
     platform: single|str|None
     platform_settings: single|dict|None
 dc_motors_pulse_settings:
-    action: single|enum(pulse,stop)|pulse
+    action: single|enum(pulse,reverse_pulse,stop)|pulse
     power: single|float|None
     duration: single|template_secs|None
 digital_outputs:

--- a/mpf/core/platform.py
+++ b/mpf/core/platform.py
@@ -12,6 +12,7 @@ from mpf.core.utility_functions import Util
 
 
 if TYPE_CHECKING:
+    from mpf.devices.dc_motor import DCMotor   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.shaker import Shaker   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.switch import Switch   # pylint: disable-msg=cyclic-import,unused-import
     from mpf.devices.stepper import Stepper     # pylint: disable-msg=cyclic-import,unused-import
@@ -454,6 +455,7 @@ class ShakerPlatform(BasePlatform, metaclass=abc.ABCMeta):
             config: Config for this shaker.
         """
         raise NotImplementedError
+
 
 class MotorPlatform(BasePlatform, metaclass=abc.ABCMeta):
 

--- a/mpf/core/platform.py
+++ b/mpf/core/platform.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.switch_platform_interface import SwitchPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
+    from mpf.platforms.interfaces.motor_platform_interface import MotorPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInterface    # pylint: disable-msg=cyclic-import,unused-import; # noqa
     from mpf.platforms.interfaces.segment_display_platform_interface import SegmentDisplayPlatformInterface     # pylint: disable-msg=cyclic-import,unused-import; # noqa
@@ -63,6 +64,7 @@ class BasePlatform(LogMixin, metaclass=abc.ABCMeta):
         self.features['has_hardware_sound_systems'] = True
         self.features['has_steppers'] = False
         self.features['has_shakers'] = False
+        self.features['has_motors'] = False
         self.features['allow_empty_numbers'] = False
         self.features['hardware_eos_repulse'] = False
 
@@ -450,6 +452,52 @@ class ShakerPlatform(BasePlatform, metaclass=abc.ABCMeta):
         ----
             number: Number of the shaker
             config: Config for this shaker.
+        """
+        raise NotImplementedError
+
+class MotorPlatform(BasePlatform, metaclass=abc.ABCMeta):
+
+    """Baseclass for dc motor platforms in MPF."""
+
+    __slots__ = []  # type: List[str]
+
+    def __init__(self, machine):
+        """Add dc motor feature."""
+        super().__init__(machine)
+        self.features['has_motors'] = True
+
+    @classmethod
+    def get_dc_motor_config_section(cls) -> Optional[str]:
+        """Return config section for additional stepper config items."""
+        return None
+
+    def validate_dc_motor_section(self, dc_motor: "DCMotor", config: dict) -> dict:
+        """Validate a dc motor config for platform.
+
+        Args:
+        ----
+            dc_motor: DC Motor to validate.
+            config: Config to validate.
+
+        Returns: Validated config.
+        """
+        if self.get_dc_motor_config_section():
+            spec = self.get_dc_motor_config_section()    # pylint: disable-msg=assignment-from-none
+            config = dc_motor.machine.config_validator.validate_config(spec, config, dc_motor.name)
+        elif config:
+            raise AssertionError("No platform_config supported but not empty {} for dc motor {}".
+                                 format(config, dc_motor.name))
+
+        return config
+
+    @abc.abstractmethod
+    async def configure_dc_motor(self, number: str, config: dict) -> "MotorPlatformInterface":
+        """Configure a dc motor device in platform.
+
+        Args:
+        ----
+            number: Number of the dc motor
+            config: Config for this dc motor.
         """
         raise NotImplementedError
 

--- a/mpf/devices/dc_motor.py
+++ b/mpf/devices/dc_motor.py
@@ -20,7 +20,7 @@ class DCMotor(SystemWideDevice):
     collection = 'dc_motors'
     class_label = 'dc_motor'
 
-    __slots__ = ["hw_motor", "platform", "type", "__dict__"]
+    __slots__ = ["hw_motor", "type", "__dict__"]
 
     def __init__(self, machine: MachineController, name: str) -> None:
         """Initialize dc motor."""
@@ -35,22 +35,21 @@ class DCMotor(SystemWideDevice):
         self.platform.assert_has_feature("motors")
         self.hw_motor = await self.platform.configure_dc_motor(self.config['number'], self.config['platform_settings'])
         for event, config in self.config['control_events'].items():
-            if config.get('action') == 'stop':
+            action = config.get('action')
+            if action == 'stop':
                 self.machine.events.add_handler(event, self.event_stop)
-                continue
-            if config.get('action') == 'pulse':
+            elif action == 'pulse':
                 self.machine.events.add_handler(event,
                                                 self.event_pulse,
                                                 power=config.get('power'),
                                                 duration=config['duration'].evaluate({}))
-                continue
-            if config.get('action') == 'reverse_pulse':
+            elif action == 'reverse_pulse':
                 self.machine.events.add_handler(event,
                                                 self.event_reverse_pulse,
                                                 power=config.get('power'),
                                                 duration=config['duration'].evaluate({}))
-                continue
-            # TODO: warn or crash on bad action selection?
+            else:
+                self.raise_config_error("Invalid action in dc_motor entry: {}".format(action), 1)
 
     @event_handler(1)
     def event_pulse(self, duration=None, power=None, **kwargs):
@@ -77,7 +76,7 @@ class DCMotor(SystemWideDevice):
         if power is None:
             power = self.config['default_power']
         if not duration:
-            raise AssertionError("DC Motor reverse pulse called with no duration value")
+            raise AssertionError("DC Motor reverse_pulse called with no duration value")
         self.hw_motor.reverse_pulse(duration, power)
 
     @event_handler(5)

--- a/mpf/devices/dc_motor.py
+++ b/mpf/devices/dc_motor.py
@@ -1,0 +1,71 @@
+"""A digital output on either a light or driver platform."""
+from typing import Optional, TYPE_CHECKING
+
+from mpf.core.delays import DelayManager
+from mpf.core.events import event_handler
+
+from mpf.core.machine import MachineController
+from mpf.core.system_wide_device import SystemWideDevice
+
+if TYPE_CHECKING:
+    from mpf.core.platform import MotorPlatform    # pylint: disable-msg=cyclic-import,unused-import
+    from mpf.platforms.interfaces.motor_platform_interface import MotorPlatformInterface  # pylint: disable-msg=cyclic-import,unused-import; #noqa
+
+
+class DCMotor(SystemWideDevice):
+
+    """Represents a dc motor device in a pinball machine."""
+
+    config_section = 'dc_motors'
+    collection = 'dc_motors'
+    class_label = 'dc_motor'
+
+    __slots__ = ["hw_motor", "platform", "type", "__dict__"]
+
+    def __init__(self, machine: MachineController, name: str) -> None:
+        """Initialize dc motor."""
+        self.hw_motor = None            # type: Optional[MotorPlatformInterface]
+        self.platform = None            # type: Optional[MotorPlatform]
+        super().__init__(machine, name)
+        self.delay = DelayManager(self.machine)
+
+    async def _initialize(self):
+        await super()._initialize()
+        self.platform = self.machine.get_platform_sections('motor_controllers', self.config['platform'])
+        self.platform.assert_has_feature("motors")
+        self.hw_motor = await self.platform.configure_dc_motor(self.config['number'], self.config['platform_settings'])
+        for event, config in self.config['control_events'].items():
+            if config.get('action') == 'stop':
+                self.machine.events.add_handler(event, self.event_stop)
+                continue
+            if config.get('action') == 'pulse':
+                self.machine.events.add_handler(event,
+                                                self.event_pulse,
+                                                power=config.get('power'),
+                                                duration=config['duration'].evaluate({}))
+                continue
+            # TODO: warn or crash on bad action selection?
+
+    @event_handler(1)
+    def event_pulse(self, duration=None, power=None, **kwargs):
+        """Event handler for triggering a pulse."""
+        del kwargs
+        self.pulse(duration, power)
+
+    def pulse(self, duration=None, power=None):
+        """Pulse the dc motor for the given duration and power level."""
+        if power is None:
+            power = self.config['default_power']
+        if not duration:
+            raise AssertionError("DC Motor pulse called with no duration value")
+        self.hw_motor.pulse(duration, power)
+
+    @event_handler(2)
+    def event_stop(self, **kwargs):
+        """Event handler for stopping the dc motor."""
+        del kwargs
+        self.stop()
+
+    def stop(self):
+        """Stop the dc motor."""
+        self.hw_motor.stop()

--- a/mpf/devices/dc_motor.py
+++ b/mpf/devices/dc_motor.py
@@ -44,6 +44,12 @@ class DCMotor(SystemWideDevice):
                                                 power=config.get('power'),
                                                 duration=config['duration'].evaluate({}))
                 continue
+            if config.get('action') == 'reverse_pulse':
+                self.machine.events.add_handler(event,
+                                                self.event_reverse_pulse,
+                                                power=config.get('power'),
+                                                duration=config['duration'].evaluate({}))
+                continue
             # TODO: warn or crash on bad action selection?
 
     @event_handler(1)
@@ -61,6 +67,20 @@ class DCMotor(SystemWideDevice):
         self.hw_motor.pulse(duration, power)
 
     @event_handler(2)
+    def event_reverse_pulse(self, duration=None, power=None, **kwargs):
+        """Event handler for triggering a reverse pulse."""
+        del kwargs
+        self.reverse_pulse(duration, power)
+
+    def reverse_pulse(self, duration=None, power=None):
+        """Pulse the dc motor for the given duration and power level in reverse."""
+        if power is None:
+            power = self.config['default_power']
+        if not duration:
+            raise AssertionError("DC Motor reverse pulse called with no duration value")
+        self.hw_motor.reverse_pulse(duration, power)
+
+    @event_handler(5)
     def event_stop(self, **kwargs):
         """Event handler for stopping the dc motor."""
         del kwargs

--- a/mpf/devices/shaker.py
+++ b/mpf/devices/shaker.py
@@ -21,7 +21,7 @@ class Shaker(SystemWideDevice):
     collection = 'shakers'
     class_label = 'shaker'
 
-    __slots__ = ["hw_shaker", "type", "__dict__"]
+    __slots__ = ["hw_shaker", "platform", "type", "__dict__"]
 
     def __init__(self, machine: MachineController, name: str) -> None:
         """Initialize shaker."""

--- a/mpf/devices/shaker.py
+++ b/mpf/devices/shaker.py
@@ -21,7 +21,7 @@ class Shaker(SystemWideDevice):
     collection = 'shakers'
     class_label = 'shaker'
 
-    __slots__ = ["hw_shaker", "platform", "type", "__dict__"]
+    __slots__ = ["hw_shaker", "type", "__dict__"]
 
     def __init__(self, machine: MachineController, name: str) -> None:
         """Initialize shaker."""
@@ -36,13 +36,16 @@ class Shaker(SystemWideDevice):
         self.platform.assert_has_feature("shakers")
         self.hw_shaker = await self.platform.configure_shaker(self.config['number'], self.config['platform_settings'])
         for event, config in self.config['control_events'].items():
-            if config.get('action') == 'stop':
+            action = config.get('action')
+            if action == 'stop':
                 self.machine.events.add_handler(event, self.event_stop)
-                continue
-            self.machine.events.add_handler(event,
-                                            self.event_pulse,
-                                            power=config.get('power'),
-                                            duration=config['duration'].evaluate({}))
+            elif action == 'pulse' or action is None:
+                self.machine.events.add_handler(event,
+                                                self.event_pulse,
+                                                power=config.get('power'),
+                                                duration=config['duration'].evaluate({}))
+            else:
+                self.raise_config_error("Invalid action in shaker '{}'".format(action), 1)
 
     @event_handler(1)
     def event_pulse(self, duration=None, power=None, **kwargs):

--- a/mpf/mpfconfig.yaml
+++ b/mpf/mpfconfig.yaml
@@ -65,6 +65,7 @@ mpf:
         playfield_transfers: mpf.devices.playfield_transfer.PlayfieldTransfer
         multiballs: mpf.devices.multiball.Multiball
         motors: mpf.devices.motor.Motor
+        dc_motors: mpf.devices.dc_motor.DCMotor
         ball_saves: mpf.devices.ball_save.BallSave
         accelerometers: mpf.devices.accelerometer.Accelerometer
         servos: mpf.devices.servo.Servo
@@ -427,6 +428,7 @@ hardware:
   i2c: default
   shaker_controllers: default
   stepper_controllers: default
+  motor_controllers: default
 
 combo_switches:
   both_flippers:

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """FAST Pinball hardware platform."""
 
 import asyncio
@@ -1003,9 +1004,6 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
         """
         self.debug_log("Clearing HW Rule for switch: %s, coils: %s",
                        switch.hw_switch.number, coil.hw_driver.number)
-
         # TODO: check that the rule is switch + coil and not another switch + this coil
-
         driver = coil.hw_driver
-
         driver.clear_autofire()

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -9,7 +9,7 @@ from mpf.core.platform import (RgbDmdPlatform, DriverConfig, DriverSettings,
                                LightsPlatform, RepulseSettings,
                                SegmentDisplayPlatform, ServoPlatform,
                                StepperPlatform, ShakerPlatform,
-                               SwitchConfig, SwitchSettings)
+                               SwitchConfig, SwitchSettings, MotorPlatform)
 from mpf.core.utility_functions import Util
 from mpf.exceptions.config_file_error import ConfigFileError
 from mpf.exceptions.runtime_error import MpfRuntimeError
@@ -19,9 +19,9 @@ from mpf.platforms.fast.fast_dmd import FASTDMD
 from mpf.platforms.fast.fast_driver import FASTDriver
 from mpf.platforms.fast.fast_gi import FASTGIString
 from mpf.platforms.fast.fast_io_board import FastIoBoard
-from mpf.platforms.fast.fast_led import (FASTRGBLED, FASTLEDChannel,
-                                         FASTExpLED)
+from mpf.platforms.fast.fast_led import (FASTRGBLED, FASTLEDChannel, FASTExpLED)
 from mpf.platforms.fast.fast_light import FASTMatrixLight
+from mpf.platforms.fast.fast_motor import FastMotor
 from mpf.platforms.fast.fast_port_detector import FastPortDetector
 from mpf.platforms.fast.fast_segment_display import FASTSegmentDisplay
 from mpf.platforms.fast.fast_servo import FastServo
@@ -35,7 +35,7 @@ from mpf.platforms.system11 import System11OverlayPlatform
 
 class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                            SegmentDisplayPlatform, StepperPlatform,
-                           ShakerPlatform, System11OverlayPlatform):
+                           ShakerPlatform, System11OverlayPlatform, MotorPlatform):
 
     """Platform class for the FAST Pinball hardware."""
 
@@ -507,7 +507,7 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
             number: Number of shaker
             config: Dict of config settings.
 
-        Returns: Stepper object.
+        Returns: Shaker object.
         """
         # TODO consolidate with similar code in configure_light()
         number = number.lower()
@@ -527,6 +527,33 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
         # verify this board support servos
         assert int(port) <= int(brk_board.features['shaker_ports'])  # TODO should this be stored as an int?
         return FastShaker(brk_board, port, config)
+
+    async def configure_dc_motor(self, number: str, config: Dict):
+        """Configure a dc motor.
+
+        Args:
+        ----
+            number: Number of dc motor
+            config: Dict of config settings.
+
+        Returns: DC Motor object.
+        """
+        number = number.lower()
+        parts = number.split("-")
+
+        exp_board = self.exp_boards_by_name[parts[0]]
+
+        try:
+            _, port = parts
+            breakout_id = '0'
+        except ValueError:
+            _, breakout_id, port = parts
+            breakout_id = breakout_id.strip('b')
+
+        brk_board = exp_board.breakouts[breakout_id]
+
+        assert int(port) <= int(brk_board.features['motor_ports'])
+        return FastMotor(brk_board, port, config)
 
     def configure_switch(self, number: str, config: SwitchConfig, platform_config: dict) -> FASTSwitch:
         """Configure the switch object for a FAST Pinball controller.

--- a/mpf/platforms/fast/fast_defines.py
+++ b/mpf/platforms/fast/fast_defines.py
@@ -76,6 +76,11 @@ BREAKOUT_FEATURES = {
         'min_fw': '0.44',
         'shaker_ports': 1
     },
+    'FP-EXP-0051': {
+        'min_fw': '0.48',
+        'led_ports': 4,
+        'motor_ports': 2
+    },
     'FP-EXP-0061': {
         'min_fw': '0.48',
         'led_ports': 4,

--- a/mpf/platforms/fast/fast_motor.py
+++ b/mpf/platforms/fast/fast_motor.py
@@ -28,7 +28,8 @@ class FastMotor(MotorPlatformInterface):
         base_command = "MF"
         hex_power = Util.float_to_hex(power)
         hex_duration = Util.int_to_hex_string(duration_secs * 1000, True)
-        self.log.debug("Pulsing motor index %s: for %s seconds with power %s", self.motor_index, duration_secs, power)
+        self.log.debug("Pulsing motor index %s: for %s seconds with power %s",
+                       self.motor_index, duration_secs, power)
 
         self._send_command(base_command, [hex_duration, hex_power])
 

--- a/mpf/platforms/fast/fast_motor.py
+++ b/mpf/platforms/fast/fast_motor.py
@@ -32,6 +32,20 @@ class FastMotor(MotorPlatformInterface):
 
         self._send_command(base_command, [hex_duration, hex_power])
 
+    def reverse_pulse(self, duration_secs=None, power=None):
+        """Pulse the motor at the specified power for the specified duration in reverse."""
+        if not power or not duration_secs:
+            self.log.debug("Motor reverse pulse called with no power or duration, will not move.")
+            return
+
+        base_command = "MR"
+        hex_power = Util.float_to_hex(power)
+        hex_duration = Util.int_to_hex_string(duration_secs * 1000, True)
+        self.log.debug("Pulsing motor index %s: for %s seconds with power %s in reverse",
+                       self.motor_index, duration_secs, power)
+
+        self._send_command(base_command, [hex_duration, hex_power])
+
     def stop(self):
         """Called during shutdown."""
         self.log.debug("Stopping motor")

--- a/mpf/platforms/fast/fast_motor.py
+++ b/mpf/platforms/fast/fast_motor.py
@@ -1,0 +1,44 @@
+"""Fast dc motor implementation."""
+
+from mpf.core.utility_functions import Util
+from mpf.platforms.interfaces.motor_platform_interface import MotorPlatformInterface
+
+
+class FastMotor(MotorPlatformInterface):
+
+    """A dc motor in the FAST platform connected to a FAST Expansion Board."""
+
+    __slots__ = ["base_address", "config", "exp_connection", "log", "motor_index"]
+
+    def __init__(self, breakout_board, port, config):
+        """Initialize dc motor."""
+        self.config = config
+        self.exp_connection = breakout_board.communicator
+
+        self.motor_index = Util.int_to_hex_string(int(port) - 1)  # Motors are 0-indexed
+        self.base_address = breakout_board.address
+        self.log = breakout_board.log
+
+    def pulse(self, duration_secs=None, power=None):
+        """Pulse the motor at the specified power for the specified duration."""
+        if not power or not duration_secs:
+            self.log.debug("Motor pulse called with no power or duration, will not move.")
+            return
+
+        base_command = "MF"
+        hex_power = Util.float_to_hex(power)
+        hex_duration = Util.int_to_hex_string(duration_secs * 1000, True)
+        self.log.debug("Pulsing motor index %s: for %s seconds with power %s", self.motor_index, duration_secs, power)
+
+        self._send_command(base_command, [hex_duration, hex_power])
+
+    def stop(self):
+        """Called during shutdown."""
+        self.log.debug("Stopping motor")
+        self._send_command("MC")
+
+    def _send_command(self, base_command, payload=None):
+        if not payload:
+            payload = []
+        self.exp_connection.send_and_forget(','.join([
+            f'{base_command}@{self.base_address}:{self.motor_index}', *payload]))

--- a/mpf/platforms/fast/fast_shaker.py
+++ b/mpf/platforms/fast/fast_shaker.py
@@ -8,8 +8,7 @@ class FastShaker(ShakerPlatformInterface):
 
     """A shaker in the FAST platform connected to a FAST Expansion Board."""
 
-    __slots__ = ["base_address", "config", "exp_connection", "log", "shaker_index",
-                 "_is_moving", "_default_speed"]
+    __slots__ = ["base_address", "config", "exp_connection", "log", "shaker_index"]
 
     def __init__(self, breakout_board, port, config):
         """Initialize servo."""

--- a/mpf/platforms/interfaces/motor_platform_interface.py
+++ b/mpf/platforms/interfaces/motor_platform_interface.py
@@ -1,0 +1,29 @@
+"""Platform interface for dc motors."""
+from typing import List
+
+import abc
+
+
+class MotorPlatformInterface(metaclass=abc.ABCMeta):
+
+    """Interface for dc motors in hardware platforms.
+
+    MotorPlatformInterface is an abstract base class that should be overridden for all
+    dc motor interface classes on supported platforms.  This class ensures the proper required
+    methods are implemented to support dc motor operations in MPF.
+    """
+
+    __slots__ = []  # type: List[str]
+
+    @abc.abstractmethod
+    def pulse(self, duration_secs, power):
+        """Enable the dc motor for specified duration and power level."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def stop(self):
+        """Stop this dc motor.
+
+        This should stop the output and end motion.
+        """
+        raise NotImplementedError

--- a/mpf/platforms/interfaces/motor_platform_interface.py
+++ b/mpf/platforms/interfaces/motor_platform_interface.py
@@ -21,6 +21,11 @@ class MotorPlatformInterface(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def reverse_pulse(self, duration_secs, power):
+        """Enable the dc motor for specified duration and power level in reverse."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def stop(self):
         """Stop this dc motor.
 

--- a/mpf/platforms/smart_virtual.py
+++ b/mpf/platforms/smart_virtual.py
@@ -265,6 +265,7 @@ class AddBallToTargetAction(BaseSmartVirtualCoilAction):
             raise AssertionError("Invalid result {}".format(self.result))
 
 
+# pylint: disable=too-many-ancestors
 class SmartVirtualHardwarePlatform(VirtualPlatform):
 
     """Base class for the smart_virtual hardware platform."""

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -701,6 +701,10 @@ class VirtualDCMotor(MotorPlatformInterface):
         """Pulse virtual dc motor."""
         self.log.debug("Pulsing dc motor for %ss at power: %s", duration_secs, power)
 
+    def reverse_pulse(self, duration_secs=None, power=None):
+        """Pulse virtual dc motor in reverse."""
+        self.log.debug("Pulsing dc motor for %ss at power: %s in reverse", duration_secs, power)
+
     def stop(self):
         """Pulse virtual dc motor."""
         self.log.debug("Stopping dc motor")

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -11,6 +11,7 @@ from mpf.platforms.interfaces.segment_display_platform_interface import SegmentD
 
 from mpf.platforms.interfaces.dmd_platform import DmdPlatformInterface
 from mpf.platforms.interfaces.light_platform_interface import LightPlatformInterface
+from mpf.platforms.interfaces.motor_platform_interface import MotorPlatformInterface
 from mpf.platforms.interfaces.servo_platform_interface import ServoPlatformInterface
 from mpf.platforms.interfaces.switch_platform_interface import SwitchPlatformInterface
 from mpf.platforms.interfaces.stepper_platform_interface import StepperPlatformInterface
@@ -18,7 +19,7 @@ from mpf.platforms.interfaces.shaker_platform_interface import ShakerPlatformInt
 
 from mpf.core.platform import ServoPlatform, SwitchPlatform, DriverPlatform, AccelerometerPlatform, I2cPlatform, \
     DmdPlatform, RgbDmdPlatform, LightsPlatform, DriverConfig, SwitchConfig, SegmentDisplayPlatform, StepperPlatform, \
-    HardwareSoundPlatform, SwitchSettings, DriverSettings, RepulseSettings, ShakerPlatform
+    HardwareSoundPlatform, SwitchSettings, DriverSettings, RepulseSettings, ShakerPlatform, MotorPlatform
 from mpf.core.utility_functions import Util
 from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInterface, PulseSettings, HoldSettings
 
@@ -26,7 +27,7 @@ from mpf.platforms.interfaces.driver_platform_interface import DriverPlatformInt
 # pylint: disable=too-many-ancestors,too-many-public-methods
 class VirtualHardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform, LightsPlatform, SwitchPlatform,
                               DriverPlatform, DmdPlatform, RgbDmdPlatform, SegmentDisplayPlatform, StepperPlatform,
-                              HardwareSoundPlatform, ShakerPlatform):
+                              HardwareSoundPlatform, ShakerPlatform, MotorPlatform):
 
     """Base class for the virtual hardware platform."""
 
@@ -144,6 +145,11 @@ class VirtualHardwarePlatform(AccelerometerPlatform, I2cPlatform, ServoPlatform,
         """Configure a shaker in platform."""
         del config
         return VirtualShaker(number)
+
+    async def configure_dc_motor(self, number: str, config: Dict):
+        """Configure a dc motor in platform."""
+        del config
+        return VirtualDCMotor(number)
 
     def _get_platforms(self):
         platforms = []
@@ -675,3 +681,26 @@ class VirtualShaker(ShakerPlatformInterface):
     def stop(self):
         """Pulse virtual shaker."""
         self.log.debug("Stopping shaker")
+
+class VirtualDCMotor(MotorPlatformInterface):
+
+    """A virtual dc motor object."""
+
+    __slots__ = ["state", "log", "__dict__", "number"]
+
+    def __init__(self, number) -> None:
+        """Initialize virtual dc motor."""
+        self.number = number
+        self.log = logging.getLogger("VirtualDCMotor.{}".format(number))
+
+    def __repr__(self):
+        """Str representation."""
+        return "VirtualDCMotor.{}".format(self.number)
+
+    def pulse(self, duration_secs=None, power=None):
+        """Pulse virtual dc motor."""
+        self.log.debug("Pulsing dc motor for %ss at power: %s", duration_secs, power)
+
+    def stop(self):
+        """Pulse virtual dc motor."""
+        self.log.debug("Stopping dc motor")

--- a/mpf/platforms/virtual.py
+++ b/mpf/platforms/virtual.py
@@ -682,6 +682,7 @@ class VirtualShaker(ShakerPlatformInterface):
         """Pulse virtual shaker."""
         self.log.debug("Stopping shaker")
 
+
 class VirtualDCMotor(MotorPlatformInterface):
 
     """A virtual dc motor object."""

--- a/mpf/tests/machine_files/dc_motor/config/config.yaml
+++ b/mpf/tests/machine_files/dc_motor/config/config.yaml
@@ -10,5 +10,9 @@ dc_motors:
         action: pulse
         power: 0.75
         duration: 1.5s
+      trigger_motor_1_reverse_pulse_event:
+        action: reverse_pulse
+        power: 0.5
+        duration: 2.5s
       kill_motor_1_motion_event:
         action: stop

--- a/mpf/tests/machine_files/dc_motor/config/config.yaml
+++ b/mpf/tests/machine_files/dc_motor/config/config.yaml
@@ -1,0 +1,14 @@
+#config_version=6
+
+dc_motors:
+  test_motor_1:
+    number: 1
+    platform: default
+    default_power: 1.0
+    control_events:
+      trigger_motor_1_pulse_event:
+        action: pulse
+        power: 0.75
+        duration: 1.5s
+      kill_motor_1_motion_event:
+        action: stop

--- a/mpf/tests/test_DCMotor.py
+++ b/mpf/tests/test_DCMotor.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+from mpf.tests.MpfTestCase import MpfTestCase
+
+
+class TestDCMotor(MpfTestCase):
+
+    def get_config_file(self):
+        return "config.yaml"
+
+    def get_machine_path(self):
+        return 'tests/machine_files/dc_motor/'
+
+    def test_dc_motor_device_allocation(self):
+        motor = self.machine.dc_motors['test_motor_1']
+        self.assertIsNotNone(motor)
+        self.assertEqual(motor.platform, self.machine.default_platform)
+        self.assertEqual("VirtualDCMotor.1", repr(motor.hw_motor))
+
+    def test_control_events_parsing_and_execution(self):
+        motor = self.machine.dc_motors['test_motor_1']
+        mock_hw = MagicMock()
+        motor.hw_motor = mock_hw
+        self.machine.events.post('trigger_motor_1_pulse_event')
+        self.advance_time_and_run(0.1)
+        mock_hw.pulse.assert_called_once_with(1.5, 0.75)
+
+    def test_stop_action_cleanup(self):
+        motor = self.machine.dc_motors['test_motor_1']
+        mock_hw = MagicMock()
+        motor.hw_motor = mock_hw
+        self.machine.events.post('kill_motor_1_motion_event')
+        self.advance_time_and_run(0.1)
+        mock_hw.stop.assert_called_once()

--- a/mpf/tests/test_DCMotor.py
+++ b/mpf/tests/test_DCMotor.py
@@ -24,6 +24,10 @@ class TestDCMotor(MpfTestCase):
         self.advance_time_and_run(0.1)
         mock_hw.pulse.assert_called_once_with(1.5, 0.75)
 
+        self.machine.events.post('trigger_motor_1_reverse_pulse_event')
+        self.advance_time_and_run(0.1)
+        mock_hw.reverse_pulse.assert_called_once_with(2.5, 0.5)
+
     def test_stop_action_cleanup(self):
         motor = self.machine.dc_motors['test_motor_1']
         mock_hw = MagicMock()


### PR DESCRIPTION
Basically just a copy of the shaker interface. We could potentially swap the 1313 shaker fast class as well as base device class to this, to be more generic. Note: there is a preexisting Motor class that represents one or two driver outputs controlling a higher level state-machine type device. It is not generically usable as a platformed device, as it sits on top of raw platform devices and coordinates them.