### PR TITLE
Initialization error logging

### DIFF
--- a/mpf/commands/game.py
+++ b/mpf/commands/game.py
@@ -237,6 +237,8 @@ class Command:
     def sigint_handler(self, signum=None, frame=None):
         """Handle SIGINT."""
         del signum, frame
+        if self.machine:
+            self.machine.error_log("SIGINT received")
         self._sigint_count += 1
         if self._sigint_count > 1:
             self.exit("Received second SIGINT. Will exit ungracefully!")

--- a/mpf/core/machine.py
+++ b/mpf/core/machine.py
@@ -678,10 +678,15 @@ class MachineController(LogMixin):
             return False
         except RuntimeError as e:
             self._crash_shutdown()
-            # do not show a runtime useless runtime error
             self.error_log("Failed to initialize MPF")
             report_crash(e, "init_runtime_error", self.config)
             return False
+
+        if not init.done():
+            self._crash_shutdown()
+            self.error_log("MPF Initialization was interrupted or aborted before completing.")
+            return False
+
         if init.done() and init.exception():
             self._crash_shutdown()
             try:

--- a/mpf/platforms/fast/communicators/base.py
+++ b/mpf/platforms/fast/communicators/base.py
@@ -64,10 +64,12 @@ class FastSerialCommunicator(LogMixin):
         else:
             self.watchdog_cmd = None
 
-        # TODO change these to not be hardcoded
-        # TODO do something with the URL endpoint
-        self.configure_logging(logger=f'FAST [{self.remote_processor}]', console_level=config['debug'],
-                               file_level=config['debug'], url_base='https://fastpinball.com/mpf/error')
+        if config['debug']:
+            config['console_log'] = 'full'
+            config['file_log'] = 'full'
+
+        self.configure_logging(logger=f'FAST [{self.remote_processor}]', console_level=config['console_log'],
+                               file_level=config['file_log'], url_base='https://fastpinball.com/mpf/error')
 
     def __repr__(self):
         """Return representation of FAST processor."""

--- a/mpf/platforms/fast/communicators/exp.py
+++ b/mpf/platforms/fast/communicators/exp.py
@@ -58,7 +58,7 @@ class FastExpCommunicator(FastSerialCommunicator):
         """Query the EXP bus for connected boards."""
         for board_name, board_config in self.config['boards'].items():
 
-            # FP-eXp-0071-2 -> FP-EXP-0071
+            # normalize model: FP-eXp-0071-2 -> FP-EXP-0071
             board_config['model'] = ('-').join(board_config['model'].split('-')[:3]).upper()
 
             if board_config['address']:  # need to do it this way since valid config will have 'address' = None
@@ -75,6 +75,7 @@ class FastExpCommunicator(FastSerialCommunicator):
             self.platform.register_expansion_board(board_obj)  # registers with the platform
 
             self.active_board = board_address
+            self.info_log("Querying EXP board: '%s' on address: %s", board_name, board_address)
             await self.send_and_wait_for_response_processed(f'ID@{board_address}:', 'ID:')
 
             for breakout_board in board_obj.breakouts.values():


### PR DESCRIPTION
I'm going to backport these to 57/80 as well because the new information printed fills a real gap in logging/explanation when devs write in.

- adds explicit logging on Ctrl C/SIGINT
- adds info log before querying EXP boards on setup (a very common hanging setup spot)
- adds handler in machine initialize that keeps a failed setup from trying to start attract anyway