### PR TITLE
Reset combo switch state when its mode stops

### DIFF
--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -88,16 +88,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self._remove_switch_handlers()
         self._kill_delays()
 
-        # The switches may still be held when the mode stops. This happens
-        # whenever the combo's own event ends the mode that owns it, e.g. a
-        # "hold both buttons to cancel the game" combo defined in a game mode.
-        # With the handlers gone the eventual release is never seen, so any
-        # state left here would latch for the life of the process:
-        # _switch_1_went_active and _switch_2_went_active both return early on
-        # "if self._switches_N_active", and _switch_state returns early on
-        # "if state == self.state". The combo would then fire exactly once and
-        # never again. The device observes nothing while unloaded, so the only
-        # honest state to hold is none at all.
+        # Ensure reset to inactive state when mode ends, in case combo switch event is reason mode ended.
         self._state = 'inactive'
         self._switches_1_active = False
         self._switches_2_active = False

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -88,6 +88,20 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self._remove_switch_handlers()
         self._kill_delays()
 
+        # The switches may still be held when the mode stops. This happens
+        # whenever the combo's own event ends the mode that owns it, e.g. a
+        # "hold both buttons to cancel the game" combo defined in a game mode.
+        # With the handlers gone the eventual release is never seen, so any
+        # state left here would latch for the life of the process:
+        # _switch_1_went_active and _switch_2_went_active both return early on
+        # "if self._switches_N_active", and _switch_state returns early on
+        # "if state == self.state". The combo would then fire exactly once and
+        # never again. The device observes nothing while unloaded, so the only
+        # honest state to hold is none at all.
+        self._state = 'inactive'
+        self._switches_1_active = False
+        self._switches_2_active = False
+
     def _register_switch_handlers(self):
         for switch in self.config['switches_1']:
             self._switch_handlers.append(switch.add_handler(self._switch_1_went_active, state=1, return_info=True))

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -90,7 +90,8 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self._remove_switch_handlers()
         self._kill_delays()
 
-        # Ensure reset to inactive state when mode ends, in case combo switch event is triggered mode end, or combo switch was partially engaged as mode ended.
+        # Ensure reset to inactive state when mode ends, in case combo switch event triggers mode end,
+        # or the combo switch was partially engaged as mode ended.
         self._reset_state()
 
     def _reset_state(self):

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -90,7 +90,7 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self._remove_switch_handlers()
         self._kill_delays()
 
-        # Ensure reset to inactive state when mode ends, in case combo switch event is reason mode ended.
+        # Ensure reset to inactive state when mode ends, in case combo switch event is triggered mode end, or combo switch was partially engaged as mode ended.
         self._reset_state()
 
     def _reset_state(self):

--- a/mpf/devices/combo_switch.py
+++ b/mpf/devices/combo_switch.py
@@ -51,6 +51,8 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
 
     def device_loaded_in_mode(self, mode: Mode, player: Player):
         """Add event handlers."""
+        # Start from scratch: switches already held when the mode starts do not count.
+        self._reset_state()
         self._add_switch_handlers()
 
     def _add_switch_handlers(self):
@@ -89,6 +91,9 @@ class ComboSwitch(SystemWideDevice, ModeDevice):
         self._kill_delays()
 
         # Ensure reset to inactive state when mode ends, in case combo switch event is reason mode ended.
+        self._reset_state()
+
+    def _reset_state(self):
         self._state = 'inactive'
         self._switches_1_active = False
         self._switches_2_active = False

--- a/mpf/tests/test_ComboSwitches.py
+++ b/mpf/tests/test_ComboSwitches.py
@@ -566,6 +566,36 @@ class TestComboSwitches(MpfTestCase):
         self.assertEventNotCalled('mode1_combo_inactive')
         self.assertEventNotCalled('mode1_combo_one')
 
+    def test_combo_switches_in_mode_stopped_while_held(self):
+        # A mode can stop while its combo switches are still held down. The
+        # common case is a combo whose own event ends the mode that owns it,
+        # such as a "hold both buttons to cancel the game" combo defined in a
+        # game mode. The release then arrives with no handlers registered, so
+        # the device must not keep the state its last hit left behind.
+        self.machine.modes["mode1"].start()
+        self.advance_time_and_run()
+
+        self.mock_event('mode1_combo_both')
+        self.hit_switch_and_run('switch1', .1)
+        self.hit_switch_and_run('switch2', .1)
+        self.assertEventCalled('mode1_combo_both')
+
+        # Mode stops with both switches STILL DOWN, then the player lets go.
+        self.machine.modes["mode1"].stop()
+        self.advance_time_and_run()
+        self.release_switch_and_run('switch1', .1)
+        self.release_switch_and_run('switch2', .1)
+
+        self.machine.modes["mode1"].start()
+        self.advance_time_and_run()
+        self.assertEqual('inactive', self.machine.combo_switches["mode1_combo"].state)
+
+        # The identical gesture has to work again.
+        self.mock_event('mode1_combo_both')
+        self.hit_switch_and_run('switch1', .1)
+        self.hit_switch_and_run('switch2', .1)
+        self.assertEventCalled('mode1_combo_both')
+
     def test_built_in_combos(self):
         self.mock_event('flipper_cancel')
         self.hit_switch_and_run('switch9', .1)

--- a/mpf/tests/test_ComboSwitches.py
+++ b/mpf/tests/test_ComboSwitches.py
@@ -567,11 +567,8 @@ class TestComboSwitches(MpfTestCase):
         self.assertEventNotCalled('mode1_combo_one')
 
     def test_combo_switches_in_mode_stopped_while_held(self):
-        # A mode can stop while its combo switches are still held down. The
-        # common case is a combo whose own event ends the mode that owns it,
-        # such as a "hold both buttons to cancel the game" combo defined in a
-        # game mode. The release then arrives with no handlers registered, so
-        # the device must not keep the state its last hit left behind.
+        # Mode stops while both switches are still held, e.g. when the combo's
+        # own event ends the mode. The state must not latch.
         self.machine.modes["mode1"].start()
         self.advance_time_and_run()
 
@@ -580,7 +577,7 @@ class TestComboSwitches(MpfTestCase):
         self.hit_switch_and_run('switch2', .1)
         self.assertEventCalled('mode1_combo_both')
 
-        # Mode stops with both switches STILL DOWN, then the player lets go.
+        # Mode stops with both switches still down, then the player lets go.
         self.machine.modes["mode1"].stop()
         self.advance_time_and_run()
         self.release_switch_and_run('switch1', .1)
@@ -594,6 +591,57 @@ class TestComboSwitches(MpfTestCase):
         self.mock_event('mode1_combo_both')
         self.hit_switch_and_run('switch1', .1)
         self.hit_switch_and_run('switch2', .1)
+        self.assertEventCalled('mode1_combo_both')
+
+    def test_combo_switches_in_mode_restarted_while_held(self):
+        # Mode restarts while both switches are held: the combo resets and the
+        # held switches do not count.
+        self.machine.modes["mode1"].start()
+        self.advance_time_and_run()
+
+        self.mock_event('mode1_combo_both')
+        self.hit_switch_and_run('switch1', .1)
+        self.hit_switch_and_run('switch2', .1)
+        self.assertEventCalled('mode1_combo_both')
+
+        self.machine.modes["mode1"].stop()
+        self.advance_time_and_run()
+        self.machine.modes["mode1"].start()
+        self.advance_time_and_run()
+        self.assertEqual('inactive', self.machine.combo_switches["mode1_combo"].state)
+
+        # Releasing the pre-held switches posts nothing.
+        self.mock_event('mode1_combo_one')
+        self.mock_event('mode1_combo_inactive')
+        self.release_switch_and_run('switch1', .1)
+        self.release_switch_and_run('switch2', .1)
+        self.assertEventNotCalled('mode1_combo_one')
+        self.assertEventNotCalled('mode1_combo_inactive')
+
+        # A fresh gesture works.
+        self.mock_event('mode1_combo_both')
+        self.hit_switch_and_run('switch1', .1)
+        self.hit_switch_and_run('switch2', .1)
+        self.assertEventCalled('mode1_combo_both')
+
+    def test_combo_switches_in_mode_pre_held_switch_does_not_count(self):
+        # One switch is already held when the mode starts: adding the other
+        # member must not fire the combo.
+        self.machine.modes["mode1"].start()
+        self.advance_time_and_run()
+        self.hit_switch_and_run('switch1', .1)
+        self.machine.modes["mode1"].stop()
+        self.advance_time_and_run()
+        self.machine.modes["mode1"].start()
+        self.advance_time_and_run()
+
+        self.mock_event('mode1_combo_both')
+        self.hit_switch_and_run('switch2', .1)
+        self.assertEventNotCalled('mode1_combo_both')
+
+        # Re-pressing the pre-held switch inside the mode completes the combo.
+        self.release_switch_and_run('switch1', .1)
+        self.hit_switch_and_run('switch1', .1)
         self.assertEventCalled('mode1_combo_both')
 
     def test_built_in_combos(self):


### PR DESCRIPTION
## Problem

A mode-scoped `combo_switches` device fires **exactly once per MPF process** when its own event ends the mode that owns it.

`ComboSwitch` keeps three pieces of state: `_switches_1_active`, `_switches_2_active` and `_state`. `device_removed_from_mode` removes the switch handlers and kills the pending delays, but leaves all three untouched.

The switches are typically still held at that moment. That is the normal case for any combo whose own event ends the mode that owns it. Consider a "hold both buttons to cancel the game" combo defined in a game mode: `events_when_both` posts `end_game`, that stops the mode synchronously, and only afterwards does the player let go. With the handlers already removed the release is never seen, so the device stays latched at `both` with both groups marked active for the life of the process.

Every later attempt is then dropped twice over:

* `_switch_1_went_active` and `_switch_2_went_active` each guard on `if self._switches_N_active: return`, so neither group ever re-arms.
* `_switch_state` guards on `if state == self.state: return`, so even a re-armed group could not re-post `events_when_both`.

Reloading the mode does not clear it either. `add_switch_handler_obj` only back-fills switches that are already in the requested state for handlers registered with `ms > 0`, and `ComboSwitch` registers with `ms=0`, so re-registering the handlers on the next mode start does not re-arm anything.

## Reproduction

On a machine, hold LEFT FLIPPER + START to cancel a game, using a combo defined in a game mode. It works. Start another game, repeat the identical gesture, and nothing happens for the rest of the machine's uptime.

The same shape affects any combo whose event stops its own mode, including an attract-mode gesture that starts a game.

Observed on a live machine. The relevant ordering, measured from the moment both buttons went down:

```
+2.002s  end_game            (combo fires)
+2.003s  ball_will_end
+2.006s  mode_..._stopped    <- handlers removed, buttons STILL DOWN
+2.008s  buttons released    <- nobody is listening any more
```

## Fix

Reset the three attributes in `device_removed_from_mode`. An unloaded device observes nothing, so holding no state is the only accurate option, and a reload re-arms from the next real switch change.

## Test

`test_combo_switches_in_mode` already covers mode-scoped combos, but it releases the switches *before* stopping the mode, so it never reached this path. The new `test_combo_switches_in_mode_stopped_while_held` stops the mode with both switches still down, releases them, restarts the mode, and asserts the identical gesture works again.

| | `test_ComboSwitches.py` |
|---|---|
| without the fix | 1 failed, 10 passed |
| with the fix | 11 passed |

Full suite on this branch: **895 passed, 15 skipped, no failures.** (The 34 collection errors are pre-existing `fixture 'config_file' not found` artifacts from the helper functions in `MpfTestCase.py`, present with or without this change.)
